### PR TITLE
fix: cast send --legacy support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### BUG FIXES
 
 - Fixed example chain's cmd by adding NoOpEVMOptions to tmpApp in root.go
+- Added RPC support for `--legacy` transactions (Non EIP-1559)
 
 ### IMPROVEMENTS
 

--- a/rpc/backend/tx_info.go
+++ b/rpc/backend/tx_info.go
@@ -238,6 +238,9 @@ func (b *Backend) GetTransactionReceipt(hash common.Hash) (map[string]interface{
 		"blockNumber":      hexutil.Uint64(res.Height),     //nolint:gosec // G115 // won't exceed uint64
 		"transactionIndex": hexutil.Uint64(res.EthTxIndex), //nolint:gosec // G115 // no int overflow expected here
 
+		// https://github.com/foundry-rs/foundry/issues/7640
+		"effectiveGasPrice": (*hexutil.Big)(txData.GetGasPrice()),
+
 		// sender and receiver (contract or EOA) addreses
 		"from": from,
 		"to":   txData.GetTo(),


### PR DESCRIPTION
## Summary

title. adds non EIP1559 txs support so `cast` works as expected.

originally https://github.com/cosmos/evm/pull/1 but the changes in base branch broke this