### PR TITLE
Fix example app export

### DIFF
--- a/cmd/evmd/cmd/root.go
+++ b/cmd/evmd/cmd/root.go
@@ -325,7 +325,7 @@ func newApp(
 	}
 
 	// get the chain id
-	chainID, err := getChainIdFromOpts(appOpts)
+	chainID, err := getChainIDFromOpts(appOpts)
 	if err != nil {
 		panic(err)
 	}
@@ -403,7 +403,7 @@ func appExport(
 	appOpts = viperAppOpts
 
 	// get the chain id
-	chainID, err := getChainIdFromOpts(appOpts)
+	chainID, err := getChainIDFromOpts(appOpts)
 	if err != nil {
 		return servertypes.ExportedApp{}, err
 	}
@@ -421,10 +421,10 @@ func appExport(
 	return exampleApp.ExportAppStateAndValidators(forZeroHeight, jailAllowedAddrs, modulesToExport)
 }
 
-// getChainIdFromOpts returns the chain Id from app Opts
+// getChainIDFromOpts returns the chain Id from app Opts
 // It first tries to get from the chainId flag, if not available
 // it will load from home
-func getChainIdFromOpts(appOpts servertypes.AppOptions) (chainID string, err error) {
+func getChainIDFromOpts(appOpts servertypes.AppOptions) (chainID string, err error) {
 	// Get the chain Id from appOpts
 	chainID = cast.ToString(appOpts.Get(flags.FlagChainID))
 	if chainID == "" {

--- a/cmd/evmd/cmd/root.go
+++ b/cmd/evmd/cmd/root.go
@@ -324,13 +324,10 @@ func newApp(
 		panic(err)
 	}
 
-	homeDir := cast.ToString(appOpts.Get(flags.FlagHome))
-	chainID := cast.ToString(appOpts.Get(flags.FlagChainID))
-	if chainID == "" {
-		chainID, err = evmdconfig.GetChainIDFromHome(homeDir)
-		if err != nil {
-			panic(err)
-		}
+	// get the chain id
+	chainID, err := getChainIdFromOpts(appOpts)
+	if err != nil {
+		panic(err)
 	}
 
 	snapshotStore, err := sdkserver.GetSnapshotStore(appOpts)
@@ -405,15 +402,39 @@ func appExport(
 	viperAppOpts.Set(sdkserver.FlagInvCheckPeriod, 1)
 	appOpts = viperAppOpts
 
+	// get the chain id
+	chainID, err := getChainIdFromOpts(appOpts)
+	if err != nil {
+		return servertypes.ExportedApp{}, err
+	}
+
 	if height != -1 {
-		exampleApp = evmd.NewExampleApp(logger, db, traceStore, false, appOpts, evmd.EvmAppOptions)
+		exampleApp = evmd.NewExampleApp(logger, db, traceStore, false, appOpts, evmd.EvmAppOptions, baseapp.SetChainID(chainID))
 
 		if err := exampleApp.LoadHeight(height); err != nil {
 			return servertypes.ExportedApp{}, err
 		}
 	} else {
-		exampleApp = evmd.NewExampleApp(logger, db, traceStore, true, appOpts, evmd.EvmAppOptions)
+		exampleApp = evmd.NewExampleApp(logger, db, traceStore, true, appOpts, evmd.EvmAppOptions, baseapp.SetChainID(chainID))
 	}
 
 	return exampleApp.ExportAppStateAndValidators(forZeroHeight, jailAllowedAddrs, modulesToExport)
+}
+
+// getChainIdFromOpts returns the chain Id from app Opts
+// It first tries to get from the chainId flag, if not available
+// it will load from home
+func getChainIdFromOpts(appOpts servertypes.AppOptions) (chainID string, err error) {
+	// Get the chain Id from appOpts
+	chainID = cast.ToString(appOpts.Get(flags.FlagChainID))
+	if chainID == "" {
+		// If not available load from home
+		homeDir := cast.ToString(appOpts.Get(flags.FlagHome))
+		chainID, err = evmdconfig.GetChainIDFromHome(homeDir)
+		if err != nil {
+			return "", err
+		}
+	}
+
+	return
 }

--- a/evmd/config.go
+++ b/evmd/config.go
@@ -51,7 +51,6 @@ func EvmAppOptions(chainID string) error {
 	}
 
 	id := strings.Split(chainID, "-")[0]
-	fmt.Printf("ChainID: %v\n", chainID)
 	coinInfo, found := ChainsCoinInfo[id]
 	if !found {
 		return fmt.Errorf("unknown chain id: %s", id)


### PR DESCRIPTION
# Description

This fixes the export option on the example app:
- The chain ID was not being passed to the example app, thus making the command fail
- This refactors the viper chain ID handling to commands and allow the chain to be passed on the export app

---

## Author Checklist

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.

I have...

- [ ] tackled an existing issue or discussed with a team member
- [x] left instructions on how to review the changes
- [x] targeted the `main` branch