### PR TITLE
Fix: Correct JSON path for consensus max_gas setting

### DIFF
--- a/local_node.sh
+++ b/local_node.sh
@@ -139,7 +139,7 @@ if [[ $overwrite == "y" || $overwrite == "Y" ]]; then
 	jq '.app_state.erc20.token_pairs=[{contract_owner:1,erc20_address:"0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",denom:"utest",enabled:true}]' "$GENESIS" >"$TMP_GENESIS" && mv "$TMP_GENESIS" "$GENESIS"
 
 	# Set gas limit in genesis
-	jq '.consensus_params["block"]["max_gas"]="10000000"' "$GENESIS" >"$TMP_GENESIS" && mv "$TMP_GENESIS" "$GENESIS"
+	jq '.consensus.params.block.max_gas="10000000"' "$GENESIS" >"$TMP_GENESIS" && mv "$TMP_GENESIS" "$GENESIS"
 
 	if [[ $1 == "pending" ]]; then
 		if [[ "$OSTYPE" == "darwin"* ]]; then


### PR DESCRIPTION
# Fix: Correct JSON path for consensus max_gas setting

## Issue
The current implementation in `local_node.sh` uses an incorrect JSON path to set the maximum gas limit for blocks in the genesis file. This results in the `max_gas` parameter remaining at the default value `-1` (unlimited) instead of being set to the intended value of `10000000`.

## Root Cause
The script is using the path `.consensus_params["block"]["max_gas"]` which doesn't match the actual structure in the genesis.json file. The correct path should be `.consensus.params.block.max_gas`.

## Changes
- Updated the jq command in `local_node.sh` to use the correct JSON path structure
- Changed from:
  ```bash
  jq '.consensus_params["block"]["max_gas"]="10000000"' "$GENESIS" >"$TMP_GENESIS" && mv "$TMP_GENESIS" "$GENESIS"
  ```
- To:
  ```bash
  jq '.consensus.params.block.max_gas="10000000"' "$GENESIS" >"$TMP_GENESIS" && mv "$TMP_GENESIS" "$GENESIS"
  ```

## Testing
I've tested this change by:
1. Running the updated script
2. Verifying the genesis.json file has the correct value set:
   ```json
   "consensus": {
     "params": {
       "block": {
         "max_bytes": "22020096",
         "max_gas": "10000000"
       },
   ```
3. Confirming the chain starts with the intended gas limit

This fix ensures that nodes are properly configured with the specified block gas limit rather than using unlimited gas, which could lead to block processing issues.
