### PR TITLE
static link

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,10 @@ endif
 ldflags += $(LDFLAGS)
 ldflags := $(strip $(ldflags))
 
+ifeq (staticlink,$(findstring staticlink,$(COSMOS_BUILD_OPTIONS)))
+  ldflags += -linkmode external -extldflags '-static'
+endif
+
 BUILD_FLAGS := -tags "$(build_tags)" -ldflags '$(ldflags)'
 # check for nostrip option
 ifeq (,$(findstring nostrip,$(COSMOS_BUILD_OPTIONS)))


### PR DESCRIPTION
solving the problem using different versions of glibc

when building one version on ubuntu and running another version on the server, it can lead to problems due to different versions of the glibc library.
