### PR TITLE
refactor: Remove old params object from x/feemarket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Refactored evmos/os into cosmos/evm
 - Renamed x/evm to x/vm
 - Renamed protobuf files from evmos to cosmos org
+- [\#83](https://github.com/cosmos/evm/pull/83) Remove base fee v1 from x/feemarket
 
 ### API-Breaking
 

--- a/x/feemarket/keeper/keeper.go
+++ b/x/feemarket/keeper/keeper.go
@@ -1,8 +1,6 @@
 package keeper
 
 import (
-	"math/big"
-
 	"github.com/cosmos/evm/x/feemarket/types"
 
 	"cosmossdk.io/log"
@@ -12,9 +10,6 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	paramstypes "github.com/cosmos/cosmos-sdk/x/params/types"
 )
-
-// KeyPrefixBaseFeeV1 TODO: Temporary will be removed with params refactor PR
-var KeyPrefixBaseFeeV1 = []byte{2}
 
 // Keeper grants access to the Fee Market module state.
 type Keeper struct {
@@ -89,16 +84,4 @@ func (k Keeper) AddTransientGasWanted(ctx sdk.Context, gasWanted uint64) (uint64
 	result := k.GetTransientGasWanted(ctx) + gasWanted
 	k.SetTransientBlockGasWanted(ctx, result)
 	return result, nil
-}
-
-// GetBaseFeeV1 get the base fee from v1 version of states.
-// return nil if base fee is not enabled
-// TODO: Figure out if this will be deleted ?
-func (k Keeper) GetBaseFeeV1(ctx sdk.Context) *big.Int {
-	store := ctx.KVStore(k.storeKey)
-	bz := store.Get(KeyPrefixBaseFeeV1)
-	if len(bz) == 0 {
-		return nil
-	}
-	return new(big.Int).SetBytes(bz)
 }

--- a/x/feemarket/keeper/params.go
+++ b/x/feemarket/keeper/params.go
@@ -60,17 +60,7 @@ func (k Keeper) GetBaseFee(ctx sdk.Context) math.LegacyDec {
 	if params.NoBaseFee {
 		return math.LegacyDec{}
 	}
-
-	baseFee := params.BaseFee
-	if baseFee.IsNil() || baseFee.IsZero() {
-		bfV1 := k.GetBaseFeeV1(ctx)
-		if bfV1 == nil {
-			return math.LegacyDec{}
-		}
-		// try v1 format
-		return math.LegacyNewDecFromBigInt(bfV1)
-	}
-	return baseFee
+	return params.BaseFee
 }
 
 // SetBaseFee set's the base fee in the store


### PR DESCRIPTION
# Description

Removes the v1 params base fee from the x/feemarket module. 

This seems to be a legacy parameter which is no longer needed since the `Params` object holds this data now. Any chains still using this v1 base fee data would need to execute a migration via an upgrade handler to migrate to the supported path. I don't think we should include any upgrade code here since I'm not aware of anyone actually using this and it's pretty trivial to write on the case by case basis if someone realizes they are affected by this.

---

## Author Checklist

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.

I have...

- [X] tackled an existing issue or discussed with a team member
- [X] left instructions on how to review the changes
- [X] targeted the `main` branch

## Reviewers Checklist

**All** items are required.
Please add a note if the item is not applicable
and please add your handle next to the items reviewed
if you only reviewed selected items.

I have...

- [ ] added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] confirmed all author checklist items have been addressed
- [ ] confirmed that this PR does not change production code
- [ ] reviewed content
- [ ] tested instructions (if applicable)
- [ ] confirmed all CI checks have passed
