### PR TITLE
tests: add erc20 native coin test cases for ibc v2 middleware

### DIFF
--- a/tests/ibc/v2_ibc_middleware_test.go
+++ b/tests/ibc/v2_ibc_middleware_test.go
@@ -1,8 +1,13 @@
 package ibc
 
 import (
-	"cosmossdk.io/math"
 	"errors"
+	"math/big"
+	"testing"
+	"time"
+
+	testifysuite "github.com/stretchr/testify/suite"
+
 	"github.com/cosmos/evm/evmd"
 	evmibctesting "github.com/cosmos/evm/ibc/testing"
 	"github.com/cosmos/evm/testutil"
@@ -14,10 +19,8 @@ import (
 	channeltypesv2 "github.com/cosmos/ibc-go/v10/modules/core/04-channel/v2/types"
 	ibctesting "github.com/cosmos/ibc-go/v10/testing"
 	ibcmockv2 "github.com/cosmos/ibc-go/v10/testing/mock/v2"
-	testifysuite "github.com/stretchr/testify/suite"
-	"math/big"
-	"testing"
-	"time"
+
+	"cosmossdk.io/math"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
@@ -335,7 +338,6 @@ func (suite *MiddlewareV2TestSuite) TestOnRecvPacketNativeERC20() {
 				new(big.Int).Sub(nativeErc20.InitialBal, sendAmt.BigInt()).String(),
 				erc20BalAfterConvert.String(),
 			)
-			// 1-2: Check native erc20 token is unregistered on chainA.
 			balAfterConvert := evmApp.BankKeeper.GetBalance(evmCtx, sender, nativeErc20.Denom)
 			suite.Require().Equal(sendAmt.String(), balAfterConvert.Amount.String())
 
@@ -607,7 +609,6 @@ func (suite *MiddlewareV2TestSuite) TestOnAcknowledgementPacketNativeErc20() {
 				new(big.Int).Sub(nativeErc20.InitialBal, sendAmt.BigInt()).String(),
 				erc20BalAfterConvert.String(),
 			)
-			// 1-2: Check native erc20 token is unregistered on chainA.
 			balAfterConvert := evmApp.BankKeeper.GetBalance(evmCtx, sender, nativeErc20.Denom)
 			suite.Require().Equal(sendAmt.String(), balAfterConvert.Amount.String())
 
@@ -842,7 +843,6 @@ func (suite *MiddlewareV2TestSuite) TestOnTimeoutPacketNativeErc20() {
 				new(big.Int).Sub(nativeErc20.InitialBal, sendAmt.BigInt()).String(),
 				erc20BalAfterConvert.String(),
 			)
-			// 1-2: Check native erc20 token is unregistered on chainA.
 			balAfterConvert := evmApp.BankKeeper.GetBalance(evmCtx, sender, nativeErc20.Denom)
 			suite.Require().Equal(sendAmt.String(), balAfterConvert.Amount.String())
 

--- a/tests/ibc/v2_ibc_middleware_test.go
+++ b/tests/ibc/v2_ibc_middleware_test.go
@@ -537,8 +537,8 @@ func (suite *MiddlewareV2TestSuite) TestOnAcknowledgementPacket() {
 // TestOnAcknowledgementPacketNativeErc20 tests ack logic when the packet involves a native ERC20.
 func (suite *MiddlewareV2TestSuite) TestOnAcknowledgementPacketNativeErc20() {
 	var (
-		packet channeltypes.Packet
-		ack    []byte
+		payload channeltypesv2.Payload
+		ack     []byte
 	)
 
 	testCases := []struct {
@@ -554,10 +554,9 @@ func (suite *MiddlewareV2TestSuite) TestOnAcknowledgementPacketNativeErc20() {
 			expRefund: false,
 		},
 		{
-			name: "pass: refund escrowed token",
+			name: "pass: refund escrowed token because ack err(UNIVERSAL_ERROR_ACKNOWLEDGEMENT)",
 			malleate: func() {
-				ackErr := channeltypes.NewErrorAcknowledgement(errors.New("error"))
-				ack = ackErr.Acknowledgement()
+				ack = channeltypesv2.ErrorAcknowledgement[:]
 			},
 			expError:  "",
 			expRefund: true,
@@ -565,9 +564,9 @@ func (suite *MiddlewareV2TestSuite) TestOnAcknowledgementPacketNativeErc20() {
 		{
 			name: "fail: malformed packet data",
 			malleate: func() {
-				packet.Data = []byte("malformed data")
+				payload.Value = []byte("malformed data")
 			},
-			expError:  "cannot unmarshal ICS-20 transfer packet data",
+			expError:  "cannot unmarshal ICS20-V1 transfer packet data",
 			expRefund: false,
 		},
 		{
@@ -642,7 +641,7 @@ func (suite *MiddlewareV2TestSuite) TestOnAcknowledgementPacketNativeErc20() {
 				sender.String(), chainBAcc.String(),
 				"",
 			)
-			payload := channeltypesv2.NewPayload(
+			payload = channeltypesv2.NewPayload(
 				transfertypes.PortID, transfertypes.PortID,
 				transfertypes.V1, transfertypes.EncodingJSON,
 				packetData.GetBytes(),


### PR DESCRIPTION
# Description

This PR adds test cases for handling native ERC20 coins in the IBC v2 middleware.
Previously, test cases were not written because native ERC20 coins had the prefix `erc20/`, which was incompatible with IBC v2 (see #61 for details).
Now that the prefix has been changed to `erc20:` through #92, this restriction no longer applies, and the relevant functionality can be tested properly.

Complements: #63 

---

## Author Checklist

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.

I have...

- [x] tackled an existing issue or discussed with a team member
- [ ] left instructions on how to review the changes
- [ ] targeted the `main` branch

## Reviewers Checklist

**All** items are required.
Please add a note if the item is not applicable
and please add your handle next to the items reviewed
if you only reviewed selected items.

I have...

- [ ] added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] confirmed all author checklist items have been addressed
- [x] confirmed that this PR does not change production code
- [x] reviewed content
- [ ] tested instructions (if applicable)
- [ ] confirmed all CI checks have passed
