### PR TITLE
fix(precompiles): sdk-incompatible types of slashing precompile

### DIFF
--- a/contracts/solidity/precompiles/slashing/ISlashing.sol
+++ b/contracts/solidity/precompiles/slashing/ISlashing.sol
@@ -15,25 +15,25 @@ struct SigningInfo {
     /// @dev Address of the validator
     address validatorAddress;
     /// @dev Height at which validator was first a candidate OR was unjailed
-    uint64 startHeight;
+    int64 startHeight;
     /// @dev Index offset into signed block bit array
-    uint64 indexOffset;
+    int64 indexOffset;
     /// @dev Timestamp until which validator is jailed due to liveness downtime
-    uint64 jailedUntil;
+    int64 jailedUntil;
     /// @dev Whether or not a validator has been tombstoned (killed out of validator set)
     bool tombstoned;
     /// @dev Missed blocks counter (to avoid scanning the array every time)
-    uint64 missedBlocksCounter;
+    int64 missedBlocksCounter;
 }
 
 /// @dev Params defines the parameters for the slashing module.
 struct Params {
     /// @dev SignedBlocksWindow defines how many blocks the validator should have signed
-    uint64 signedBlocksWindow;
+    int64 signedBlocksWindow;
     /// @dev MinSignedPerWindow defines the minimum blocks signed per window to avoid slashing
     Dec minSignedPerWindow;
     /// @dev DowntimeJailDuration defines how long the validator will be jailed for downtime
-    uint64 downtimeJailDuration;
+    int64 downtimeJailDuration;
     /// @dev SlashFractionDoubleSign defines the percentage of slash for double sign
     Dec slashFractionDoubleSign;
     /// @dev SlashFractionDowntime defines the percentage of slash for downtime

--- a/contracts/solidity/precompiles/slashing/ISlashing.sol
+++ b/contracts/solidity/precompiles/slashing/ISlashing.sol
@@ -31,13 +31,13 @@ struct Params {
     /// @dev SignedBlocksWindow defines how many blocks the validator should have signed
     uint64 signedBlocksWindow;
     /// @dev MinSignedPerWindow defines the minimum blocks signed per window to avoid slashing
-    string minSignedPerWindow;
+    Dec minSignedPerWindow;
     /// @dev DowntimeJailDuration defines how long the validator will be jailed for downtime
     uint64 downtimeJailDuration;
     /// @dev SlashFractionDoubleSign defines the percentage of slash for double sign
-    string slashFractionDoubleSign;
+    Dec slashFractionDoubleSign;
     /// @dev SlashFractionDowntime defines the percentage of slash for downtime
-    string slashFractionDowntime;
+    Dec slashFractionDowntime;
 }
 
 /// @author Evmos Team

--- a/precompiles/slashing/ISlashing.sol
+++ b/precompiles/slashing/ISlashing.sol
@@ -15,25 +15,25 @@ struct SigningInfo {
     /// @dev Address of the validator
     address validatorAddress;
     /// @dev Height at which validator was first a candidate OR was unjailed
-    uint64 startHeight;
+    int64 startHeight;
     /// @dev Index offset into signed block bit array
-    uint64 indexOffset;
+    int64 indexOffset;
     /// @dev Timestamp until which validator is jailed due to liveness downtime
-    uint64 jailedUntil;
+    int64 jailedUntil;
     /// @dev Whether or not a validator has been tombstoned (killed out of validator set)
     bool tombstoned;
     /// @dev Missed blocks counter (to avoid scanning the array every time)
-    uint64 missedBlocksCounter;
+    int64 missedBlocksCounter;
 }
 
 /// @dev Params defines the parameters for the slashing module.
 struct Params {
     /// @dev SignedBlocksWindow defines how many blocks the validator should have signed
-    uint64 signedBlocksWindow;
+    int64 signedBlocksWindow;
     /// @dev MinSignedPerWindow defines the minimum blocks signed per window to avoid slashing
     Dec minSignedPerWindow;
     /// @dev DowntimeJailDuration defines how long the validator will be jailed for downtime
-    uint64 downtimeJailDuration;
+    int64 downtimeJailDuration;
     /// @dev SlashFractionDoubleSign defines the percentage of slash for double sign
     Dec slashFractionDoubleSign;
     /// @dev SlashFractionDowntime defines the percentage of slash for downtime

--- a/precompiles/slashing/ISlashing.sol
+++ b/precompiles/slashing/ISlashing.sol
@@ -31,13 +31,13 @@ struct Params {
     /// @dev SignedBlocksWindow defines how many blocks the validator should have signed
     uint64 signedBlocksWindow;
     /// @dev MinSignedPerWindow defines the minimum blocks signed per window to avoid slashing
-    string minSignedPerWindow;
+    Dec minSignedPerWindow;
     /// @dev DowntimeJailDuration defines how long the validator will be jailed for downtime
     uint64 downtimeJailDuration;
     /// @dev SlashFractionDoubleSign defines the percentage of slash for double sign
-    string slashFractionDoubleSign;
+    Dec slashFractionDoubleSign;
     /// @dev SlashFractionDowntime defines the percentage of slash for downtime
-    string slashFractionDowntime;
+    Dec slashFractionDowntime;
 }
 
 /// @author Evmos Team

--- a/precompiles/slashing/abi.json
+++ b/precompiles/slashing/abi.json
@@ -23,9 +23,9 @@
         {
           "components": [
             {
-              "internalType": "uint64",
+              "internalType": "int64",
               "name": "signedBlocksWindow",
-              "type": "uint64"
+              "type": "int64"
             },
             {
               "components": [
@@ -45,9 +45,9 @@
               "type": "tuple"
             },
             {
-              "internalType": "uint64",
+              "internalType": "int64",
               "name": "downtimeJailDuration",
-              "type": "uint64"
+              "type": "int64"
             },
             {
               "components": [
@@ -110,19 +110,19 @@
               "type": "address"
             },
             {
-              "internalType": "uint64",
+              "internalType": "int64",
               "name": "startHeight",
-              "type": "uint64"
+              "type": "int64"
             },
             {
-              "internalType": "uint64",
+              "internalType": "int64",
               "name": "indexOffset",
-              "type": "uint64"
+              "type": "int64"
             },
             {
-              "internalType": "uint64",
+              "internalType": "int64",
               "name": "jailedUntil",
-              "type": "uint64"
+              "type": "int64"
             },
             {
               "internalType": "bool",
@@ -130,9 +130,9 @@
               "type": "bool"
             },
             {
-              "internalType": "uint64",
+              "internalType": "int64",
               "name": "missedBlocksCounter",
-              "type": "uint64"
+              "type": "int64"
             }
           ],
           "internalType": "struct SigningInfo",
@@ -188,19 +188,19 @@
               "type": "address"
             },
             {
-              "internalType": "uint64",
+              "internalType": "int64",
               "name": "startHeight",
-              "type": "uint64"
+              "type": "int64"
             },
             {
-              "internalType": "uint64",
+              "internalType": "int64",
               "name": "indexOffset",
-              "type": "uint64"
+              "type": "int64"
             },
             {
-              "internalType": "uint64",
+              "internalType": "int64",
               "name": "jailedUntil",
-              "type": "uint64"
+              "type": "int64"
             },
             {
               "internalType": "bool",
@@ -208,9 +208,9 @@
               "type": "bool"
             },
             {
-              "internalType": "uint64",
+              "internalType": "int64",
               "name": "missedBlocksCounter",
-              "type": "uint64"
+              "type": "int64"
             }
           ],
           "internalType": "struct SigningInfo[]",

--- a/precompiles/slashing/abi.json
+++ b/precompiles/slashing/abi.json
@@ -28,9 +28,21 @@
               "type": "uint64"
             },
             {
-              "internalType": "string",
+              "components": [
+                {
+                  "internalType": "uint256",
+                  "name": "value",
+                  "type": "uint256"
+                },
+                {
+                  "internalType": "uint8",
+                  "name": "precision",
+                  "type": "uint8"
+                }
+              ],
+              "internalType": "struct Dec",
               "name": "minSignedPerWindow",
-              "type": "string"
+              "type": "tuple"
             },
             {
               "internalType": "uint64",
@@ -38,14 +50,38 @@
               "type": "uint64"
             },
             {
-              "internalType": "string",
+              "components": [
+                {
+                  "internalType": "uint256",
+                  "name": "value",
+                  "type": "uint256"
+                },
+                {
+                  "internalType": "uint8",
+                  "name": "precision",
+                  "type": "uint8"
+                }
+              ],
+              "internalType": "struct Dec",
               "name": "slashFractionDoubleSign",
-              "type": "string"
+              "type": "tuple"
             },
             {
-              "internalType": "string",
+              "components": [
+                {
+                  "internalType": "uint256",
+                  "name": "value",
+                  "type": "uint256"
+                },
+                {
+                  "internalType": "uint8",
+                  "name": "precision",
+                  "type": "uint8"
+                }
+              ],
+              "internalType": "struct Dec",
               "name": "slashFractionDowntime",
-              "type": "string"
+              "type": "tuple"
             }
           ],
           "internalType": "struct Params",

--- a/precompiles/slashing/query_test.go
+++ b/precompiles/slashing/query_test.go
@@ -66,9 +66,9 @@ func (s *PrecompileTestSuite) TestGetSigningInfo() {
 				}
 			},
 			func(signingInfo *slashing.SigningInfo) {
-				s.Require().Equal(uint64(1), signingInfo.StartHeight)
-				s.Require().Equal(uint64(2), signingInfo.IndexOffset)
-				s.Require().Equal(uint64(1), signingInfo.MissedBlocksCounter)
+				s.Require().Equal(int64(1), signingInfo.StartHeight)
+				s.Require().Equal(int64(2), signingInfo.IndexOffset)
+				s.Require().Equal(int64(1), signingInfo.MissedBlocksCounter)
 				s.Require().False(signingInfo.Tombstoned)
 			},
 			200000,
@@ -135,21 +135,21 @@ func (s *PrecompileTestSuite) TestGetSigningInfos() {
 				s.Require().Equal(uint64(3), pageResponse.Total)
 
 				// Check first validator's signing info
-				s.Require().Equal(uint64(0), signingInfos[0].StartHeight)
-				s.Require().Equal(uint64(1), signingInfos[0].IndexOffset)
-				s.Require().Equal(uint64(18446744011573954816), signingInfos[0].JailedUntil)
+				s.Require().Equal(int64(0), signingInfos[0].StartHeight)
+				s.Require().Equal(int64(1), signingInfos[0].IndexOffset)
+				s.Require().Equal(int64(0), signingInfos[0].JailedUntil)
 				s.Require().False(signingInfos[0].Tombstoned)
 
 				// Check second validator's signing info
-				s.Require().Equal(uint64(0), signingInfos[1].StartHeight)
-				s.Require().Equal(uint64(1), signingInfos[1].IndexOffset)
-				s.Require().Equal(uint64(18446744011573954816), signingInfos[1].JailedUntil)
+				s.Require().Equal(int64(0), signingInfos[1].StartHeight)
+				s.Require().Equal(int64(1), signingInfos[1].IndexOffset)
+				s.Require().Equal(int64(0), signingInfos[1].JailedUntil)
 				s.Require().False(signingInfos[1].Tombstoned)
 
 				// Check third validator's signing info
-				s.Require().Equal(uint64(0), signingInfos[2].StartHeight)
-				s.Require().Equal(uint64(1), signingInfos[2].IndexOffset)
-				s.Require().Equal(uint64(18446744011573954816), signingInfos[2].JailedUntil)
+				s.Require().Equal(int64(0), signingInfos[2].StartHeight)
+				s.Require().Equal(int64(1), signingInfos[2].IndexOffset)
+				s.Require().Equal(int64(0), signingInfos[2].JailedUntil)
 				s.Require().False(signingInfos[2].Tombstoned)
 			},
 			200000,
@@ -172,9 +172,9 @@ func (s *PrecompileTestSuite) TestGetSigningInfos() {
 				s.Require().NotNil(pageResponse.NextKey)
 
 				// Check first validator's signing info
-				s.Require().Equal(uint64(0), signingInfos[0].StartHeight)
-				s.Require().Equal(uint64(1), signingInfos[0].IndexOffset)
-				s.Require().Equal(uint64(18446744011573954816), signingInfos[0].JailedUntil)
+				s.Require().Equal(int64(0), signingInfos[0].StartHeight)
+				s.Require().Equal(int64(1), signingInfos[0].IndexOffset)
+				s.Require().Equal(int64(0), signingInfos[0].JailedUntil)
 				s.Require().False(signingInfos[0].Tombstoned)
 			},
 			200000,
@@ -225,9 +225,9 @@ func (s *PrecompileTestSuite) TestGetParams() {
 				// Get the default params from the network
 				defaultParams, err := s.network.App.SlashingKeeper.GetParams(s.network.GetContext())
 				s.Require().NoError(err)
-				s.Require().Equal(uint64(defaultParams.SignedBlocksWindow), params.SignedBlocksWindow) //nolint:gosec // G115
+				s.Require().Equal(defaultParams.SignedBlocksWindow, params.SignedBlocksWindow)
 				s.Require().Equal(defaultParams.MinSignedPerWindow.BigInt(), params.MinSignedPerWindow.Value)
-				s.Require().Equal(uint64(defaultParams.DowntimeJailDuration.Seconds()), params.DowntimeJailDuration)
+				s.Require().Equal(int64(defaultParams.DowntimeJailDuration.Seconds()), params.DowntimeJailDuration)
 				s.Require().Equal(defaultParams.SlashFractionDoubleSign.BigInt(), params.SlashFractionDoubleSign.Value)
 				s.Require().Equal(defaultParams.SlashFractionDowntime.BigInt(), params.SlashFractionDowntime.Value)
 			},

--- a/precompiles/slashing/query_test.go
+++ b/precompiles/slashing/query_test.go
@@ -226,10 +226,10 @@ func (s *PrecompileTestSuite) TestGetParams() {
 				defaultParams, err := s.network.App.SlashingKeeper.GetParams(s.network.GetContext())
 				s.Require().NoError(err)
 				s.Require().Equal(uint64(defaultParams.SignedBlocksWindow), params.SignedBlocksWindow) //nolint:gosec // G115
-				s.Require().Equal(defaultParams.MinSignedPerWindow.String(), params.MinSignedPerWindow)
+				s.Require().Equal(defaultParams.MinSignedPerWindow.BigInt(), params.MinSignedPerWindow.Value)
 				s.Require().Equal(uint64(defaultParams.DowntimeJailDuration.Seconds()), params.DowntimeJailDuration)
-				s.Require().Equal(defaultParams.SlashFractionDoubleSign.String(), params.SlashFractionDoubleSign)
-				s.Require().Equal(defaultParams.SlashFractionDowntime.String(), params.SlashFractionDowntime)
+				s.Require().Equal(defaultParams.SlashFractionDoubleSign.BigInt(), params.SlashFractionDoubleSign.Value)
+				s.Require().Equal(defaultParams.SlashFractionDowntime.BigInt(), params.SlashFractionDowntime.Value)
 			},
 			200000,
 			false,

--- a/precompiles/slashing/types.go
+++ b/precompiles/slashing/types.go
@@ -3,6 +3,7 @@ package slashing
 import (
 	"fmt"
 
+	"cosmossdk.io/math"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
 
@@ -111,11 +112,11 @@ type ValidatorUnjailed struct {
 
 // Params defines the parameters for the slashing module
 type Params struct {
-	SignedBlocksWindow      uint64 `abi:"signedBlocksWindow"`
-	MinSignedPerWindow      string `abi:"minSignedPerWindow"`
-	DowntimeJailDuration    uint64 `abi:"downtimeJailDuration"`
-	SlashFractionDoubleSign string `abi:"slashFractionDoubleSign"`
-	SlashFractionDowntime   string `abi:"slashFractionDowntime"`
+	SignedBlocksWindow      uint64  `abi:"signedBlocksWindow"`
+	MinSignedPerWindow      cmn.Dec `abi:"minSignedPerWindow"`
+	DowntimeJailDuration    uint64  `abi:"downtimeJailDuration"`
+	SlashFractionDoubleSign cmn.Dec `abi:"slashFractionDoubleSign"`
+	SlashFractionDowntime   cmn.Dec `abi:"slashFractionDowntime"`
 }
 
 // ParamsOutput represents the output of the params query
@@ -125,11 +126,20 @@ type ParamsOutput struct {
 
 func (po *ParamsOutput) FromResponse(res *slashingtypes.QueryParamsResponse) *ParamsOutput {
 	po.Params = Params{
-		SignedBlocksWindow:      uint64(res.Params.SignedBlocksWindow), //nolint:gosec // G115
-		MinSignedPerWindow:      res.Params.MinSignedPerWindow.String(),
-		DowntimeJailDuration:    uint64(res.Params.DowntimeJailDuration.Seconds()),
-		SlashFractionDoubleSign: res.Params.SlashFractionDoubleSign.String(),
-		SlashFractionDowntime:   res.Params.SlashFractionDowntime.String(),
+		SignedBlocksWindow: uint64(res.Params.SignedBlocksWindow), //nolint:gosec // G115
+		MinSignedPerWindow: cmn.Dec{
+			Value:     res.Params.MinSignedPerWindow.BigInt(),
+			Precision: math.LegacyPrecision,
+		},
+		DowntimeJailDuration: uint64(res.Params.DowntimeJailDuration.Seconds()),
+		SlashFractionDoubleSign: cmn.Dec{
+			Value:     res.Params.SlashFractionDoubleSign.BigInt(),
+			Precision: math.LegacyPrecision,
+		},
+		SlashFractionDowntime: cmn.Dec{
+			Value:     res.Params.SlashFractionDowntime.BigInt(),
+			Precision: math.LegacyPrecision,
+		},
 	}
 	return po
 }

--- a/precompiles/slashing/types.go
+++ b/precompiles/slashing/types.go
@@ -17,11 +17,11 @@ import (
 // SigningInfo represents the signing info for a validator
 type SigningInfo struct {
 	ValidatorAddress    common.Address `abi:"validatorAddress"`
-	StartHeight         uint64         `abi:"startHeight"`
-	IndexOffset         uint64         `abi:"indexOffset"`
-	JailedUntil         uint64         `abi:"jailedUntil"`
+	StartHeight         int64          `abi:"startHeight"`
+	IndexOffset         int64          `abi:"indexOffset"`
+	JailedUntil         int64          `abi:"jailedUntil"`
 	Tombstoned          bool           `abi:"tombstoned"`
-	MissedBlocksCounter uint64         `abi:"missedBlocksCounter"`
+	MissedBlocksCounter int64          `abi:"missedBlocksCounter"`
 }
 
 // SigningInfoOutput represents the output of the signing info query
@@ -75,11 +75,11 @@ func ParseSigningInfosArgs(method *abi.Method, args []interface{}) (*slashingtyp
 func (sio *SigningInfoOutput) FromResponse(res *slashingtypes.QuerySigningInfoResponse) *SigningInfoOutput {
 	sio.SigningInfo = SigningInfo{
 		ValidatorAddress:    common.BytesToAddress([]byte(res.ValSigningInfo.Address)),
-		StartHeight:         uint64(res.ValSigningInfo.StartHeight),        //nolint:gosec // G115
-		IndexOffset:         uint64(res.ValSigningInfo.IndexOffset),        //nolint:gosec // G115
-		JailedUntil:         uint64(res.ValSigningInfo.JailedUntil.Unix()), //nolint:gosec // G115
+		StartHeight:         res.ValSigningInfo.StartHeight,
+		IndexOffset:         res.ValSigningInfo.IndexOffset,
+		JailedUntil:         res.ValSigningInfo.JailedUntil.Unix(),
 		Tombstoned:          res.ValSigningInfo.Tombstoned,
-		MissedBlocksCounter: uint64(res.ValSigningInfo.MissedBlocksCounter), //nolint:gosec // G115
+		MissedBlocksCounter: res.ValSigningInfo.MissedBlocksCounter,
 	}
 	return sio
 }
@@ -89,11 +89,11 @@ func (sio *SigningInfosOutput) FromResponse(res *slashingtypes.QuerySigningInfos
 	for i, info := range res.Info {
 		sio.SigningInfos[i] = SigningInfo{
 			ValidatorAddress:    common.BytesToAddress([]byte(info.Address)),
-			StartHeight:         uint64(info.StartHeight),        //nolint:gosec // G115
-			IndexOffset:         uint64(info.IndexOffset),        //nolint:gosec // G115
-			JailedUntil:         uint64(info.JailedUntil.Unix()), //nolint:gosec // G115
+			StartHeight:         info.StartHeight,
+			IndexOffset:         info.IndexOffset,
+			JailedUntil:         int64(info.JailedUntil.Unix()),
 			Tombstoned:          info.Tombstoned,
-			MissedBlocksCounter: uint64(info.MissedBlocksCounter), //nolint:gosec // G115
+			MissedBlocksCounter: info.MissedBlocksCounter,
 		}
 	}
 	if res.Pagination != nil {
@@ -112,9 +112,9 @@ type ValidatorUnjailed struct {
 
 // Params defines the parameters for the slashing module
 type Params struct {
-	SignedBlocksWindow      uint64  `abi:"signedBlocksWindow"`
+	SignedBlocksWindow      int64   `abi:"signedBlocksWindow"`
 	MinSignedPerWindow      cmn.Dec `abi:"minSignedPerWindow"`
-	DowntimeJailDuration    uint64  `abi:"downtimeJailDuration"`
+	DowntimeJailDuration    int64   `abi:"downtimeJailDuration"`
 	SlashFractionDoubleSign cmn.Dec `abi:"slashFractionDoubleSign"`
 	SlashFractionDowntime   cmn.Dec `abi:"slashFractionDowntime"`
 }
@@ -126,12 +126,12 @@ type ParamsOutput struct {
 
 func (po *ParamsOutput) FromResponse(res *slashingtypes.QueryParamsResponse) *ParamsOutput {
 	po.Params = Params{
-		SignedBlocksWindow: uint64(res.Params.SignedBlocksWindow), //nolint:gosec // G115
+		SignedBlocksWindow: res.Params.SignedBlocksWindow,
 		MinSignedPerWindow: cmn.Dec{
 			Value:     res.Params.MinSignedPerWindow.BigInt(),
 			Precision: math.LegacyPrecision,
 		},
-		DowntimeJailDuration: uint64(res.Params.DowntimeJailDuration.Seconds()),
+		DowntimeJailDuration: int64(res.Params.DowntimeJailDuration.Seconds()),
 		SlashFractionDoubleSign: cmn.Dec{
 			Value:     res.Params.SlashFractionDoubleSign.BigInt(),
 			Precision: math.LegacyPrecision,

--- a/precompiles/slashing/types.go
+++ b/precompiles/slashing/types.go
@@ -3,11 +3,12 @@ package slashing
 import (
 	"fmt"
 
-	"cosmossdk.io/math"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
 
 	cmn "github.com/cosmos/evm/precompiles/common"
+
+	"cosmossdk.io/math"
 
 	"github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/query"
@@ -91,7 +92,7 @@ func (sio *SigningInfosOutput) FromResponse(res *slashingtypes.QuerySigningInfos
 			ValidatorAddress:    common.BytesToAddress([]byte(info.Address)),
 			StartHeight:         info.StartHeight,
 			IndexOffset:         info.IndexOffset,
-			JailedUntil:         int64(info.JailedUntil.Unix()),
+			JailedUntil:         info.JailedUntil.Unix(),
 			Tombstoned:          info.Tombstoned,
 			MissedBlocksCounter: info.MissedBlocksCounter,
 		}

--- a/testutil/integration/os/network/setup.go
+++ b/testutil/integration/os/network/setup.go
@@ -283,7 +283,8 @@ func getValidatorsSlashingGen(validators []stakingtypes.Validator, sk slashingty
 		signInfo[i] = slashingtypes.SigningInfo{
 			Address: consAddr,
 			ValidatorSigningInfo: slashingtypes.ValidatorSigningInfo{
-				Address: consAddr,
+				Address:     consAddr,
+				JailedUntil: time.Unix(0, 0),
 			},
 		}
 		missedBlocks[i] = slashingtypes.ValidatorMissedBlocks{


### PR DESCRIPTION
# Description

Modify types of SigningInfo and Params to sync with cosmos-sdk types

### `string` -> precompiles/common/`Dec`

- Params.`MinSignedPerWindow`
- Params.`SlashFractionDoubleSign`
- Params.`SlashFractionDowntime`

### `uint64` -> `int64`

- SigningInfo.`StartHeight`
- SigningInfo.`indexOffset`
- SigningInfo.`jailedUntil`
- SigningInfo.`missedBlocksCounter`
- Params.`SignedBlocksWindow`
- Params.`DowntimeJailDuration`

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

<!-- Please keep your PR as draft until it's ready for review -->

<!-- Pull requests that sit inactive for longer than 30 days will be closed.  -->

Closes: #133 

---

## Author Checklist

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.

I have...

- [ ] tackled an existing issue or discussed with a team member
- [ ] left instructions on how to review the changes
- [ ] targeted the `main` branch

## Reviewers Checklist

**All** items are required.
Please add a note if the item is not applicable
and please add your handle next to the items reviewed
if you only reviewed selected items.

I have...

- [ ] added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] confirmed all author checklist items have been addressed
- [ ] confirmed that this PR does not change production code
- [ ] reviewed content
- [ ] tested instructions (if applicable)
- [ ] confirmed all CI checks have passed
