### PR TITLE
Fix compile issue in start.go

### DIFF
--- a/server/start.go
+++ b/server/start.go
@@ -145,10 +145,6 @@ which accepts a path for the resulting pprof file.
 			}
 
 			serverCtx.Logger.Debug("received quit signal")
-			// TODO: why is this check here? Should not make sense since err is checked above
-			if err != nil {
-				serverCtx.Logger.Error(fmt.Sprintf("error on quit: %s", err.Error()))
-			}
 
 			return nil
 		},


### PR DESCRIPTION
## Summary
- remove undefined error check in `start.go`

## Testing
- `go fmt server/start.go`
- `go build ./server...` *(fails: proxyconnect tcp: no route to host)*