### PR TITLE
(chore): move feemarket update BaseFee to EndBlock

### DIFF
--- a/testutil/integration/common/factory/helper.go
+++ b/testutil/integration/common/factory/helper.go
@@ -87,7 +87,7 @@ func (tf *baseTxFactory) calculateFees(gasPrice *sdkmath.Int, gasLimit uint64) (
 			return sdktypes.Coins{}, errorsmod.Wrap(err, "failed to get base fee")
 		}
 		price := resp.BaseFee
-		fees = sdktypes.Coins{{Denom: denom, Amount: price.MulInt64(int64(gasLimit)).TruncateInt()}} //#nosec G115
+		fees = sdktypes.Coins{{Denom: denom, Amount: price.MulInt64(int64(gasLimit)).Ceil().RoundInt()}} //#nosec G115
 	}
 	return fees, nil
 }

--- a/x/feemarket/keeper/abci.go
+++ b/x/feemarket/keeper/abci.go
@@ -12,41 +12,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
-// BeginBlock updates base fee
-func (k *Keeper) BeginBlock(ctx sdk.Context) error {
-	baseFee := k.CalculateBaseFee(ctx)
-
-	// return immediately if base fee is nil
-	if baseFee.IsNil() {
-		return nil
-	}
-
-	k.SetBaseFee(ctx, baseFee)
-
-	defer func() {
-		floatBaseFee, err := baseFee.Float64()
-		if err != nil {
-			ctx.Logger().Error("error converting base fee to float64", "error", err.Error())
-			return
-		}
-		// there'll be no panic if fails to convert to float32. Will only loose precision
-		telemetry.SetGauge(float32(floatBaseFee), "feemarket", "base_fee")
-	}()
-
-	// Store current base fee in event
-	ctx.EventManager().EmitEvents(sdk.Events{
-		sdk.NewEvent(
-			types.EventTypeFeeMarket,
-			sdk.NewAttribute(types.AttributeKeyBaseFee, baseFee.String()),
-		),
-	})
-
-	return nil
-}
-
-// EndBlock update block gas wanted.
-// The EVM end block logic doesn't update the validator set, thus it returns
-// an empty slice.
+// EndBlock now handles both gas tracking and base fee calculation for the next block
 func (k *Keeper) EndBlock(ctx sdk.Context) error {
 	if ctx.BlockGasMeter() == nil {
 		err := errors.New("block gas meter is nil when setting block gas wanted")
@@ -78,8 +44,34 @@ func (k *Keeper) EndBlock(ctx sdk.Context) error {
 	updatedGasWanted := math.LegacyMaxDec(limitedGasWanted, math.LegacyNewDec(gasUsed.Int64())).TruncateInt().Uint64()
 	k.SetBlockGasWanted(ctx, updatedGasWanted)
 
+	// Calculate the next block's base fee using current block's gas data
+	nextBaseFee := k.CalculateBaseFee(ctx)
+
+	// Set the calculated base fee for the next block
+	if !nextBaseFee.IsNil() {
+		k.SetBaseFee(ctx, nextBaseFee)
+
+		// Emit event for the newly calculated base fee
+		ctx.EventManager().EmitEvents(sdk.Events{
+			sdk.NewEvent(
+				types.EventTypeFeeMarket,
+				sdk.NewAttribute(types.AttributeKeyBaseFee, nextBaseFee.String()),
+				sdk.NewAttribute("calculated_at_block", fmt.Sprintf("%d", ctx.BlockHeight())),
+			),
+		})
+	}
+
 	defer func() {
 		telemetry.SetGauge(float32(updatedGasWanted), "feemarket", "block_gas")
+
+		if !nextBaseFee.IsNil() {
+			floatBaseFee, err := nextBaseFee.Float64()
+			if err != nil {
+				ctx.Logger().Error("error converting next base fee to float64", "error", err.Error())
+				return
+			}
+			telemetry.SetGauge(float32(floatBaseFee), "feemarket", "next_base_fee")
+		}
 	}()
 
 	ctx.EventManager().EmitEvent(sdk.NewEvent(

--- a/x/feemarket/keeper/integration_test.go
+++ b/x/feemarket/keeper/integration_test.go
@@ -397,16 +397,21 @@ var _ = Describe("Feemarket", func() {
 						bz, err := s.factory.EncodeTx(tx)
 						Expect(err).To(BeNil())
 
+						err = s.network.NextBlock()
+						Expect(err).To(BeNil())
+
 						res, err := s.network.CheckTx(bz)
 						Expect(err).To(BeNil())
 						Expect(res.IsOK()).To(BeFalse())
 						Expect(res.Log).To(ContainSubstring("insufficient fee"))
 					},
 					Entry("legacy tx", func() txParams {
-						return txParams{big.NewInt(baseFee - 2_000_000_000), nil, nil, nil}
+						currBaseFee := s.network.App.FeeMarketKeeper.GetBaseFee(s.network.GetContext())
+						return txParams{big.NewInt(currBaseFee.Sub(currBaseFee.Sub(math.LegacyNewDec(minGasPrices)).QuoInt64(2)).RoundInt64()), nil, nil, nil}
 					}),
 					Entry("dynamic tx", func() txParams {
-						return txParams{nil, big.NewInt(baseFee - 2_000_000_000), big.NewInt(0), &ethtypes.AccessList{}}
+						currBaseFee := s.network.App.FeeMarketKeeper.GetBaseFee(s.network.GetContext())
+						return txParams{nil, big.NewInt(currBaseFee.Sub(currBaseFee.Sub(math.LegacyNewDec(minGasPrices)).QuoInt64(2)).RoundInt64()), big.NewInt(0), &ethtypes.AccessList{}}
 					}),
 				)
 

--- a/x/feemarket/module.go
+++ b/x/feemarket/module.go
@@ -32,9 +32,8 @@ var (
 	_ module.AppModule      = AppModule{}
 	_ module.AppModuleBasic = AppModuleBasic{}
 
-	_ appmodule.HasEndBlocker   = AppModule{}
-	_ appmodule.HasBeginBlocker = AppModule{}
-	_ module.HasABCIGenesis     = AppModule{}
+	_ appmodule.HasEndBlocker = AppModule{}
+	_ module.HasABCIGenesis   = AppModule{}
 )
 
 // AppModuleBasic defines the basic application module used by the fee market module.
@@ -118,12 +117,6 @@ func (AppModule) Name() string {
 func (am AppModule) RegisterServices(cfg module.Configurator) {
 	types.RegisterQueryServer(cfg.QueryServer(), am.keeper)
 	types.RegisterMsgServer(cfg.MsgServer(), &am.keeper)
-}
-
-// BeginBlock returns the begin block for the fee market module.
-func (am AppModule) BeginBlock(ctx context.Context) error {
-	c := sdk.UnwrapSDKContext(ctx)
-	return am.keeper.BeginBlock(c)
 }
 
 // EndBlock returns the end blocker for the fee market module. It returns no validator


### PR DESCRIPTION
Moves the feemarket base fee updates to the end of the block for easier gas fee estimation.

Closes: #123 