### PR TITLE
feat: add x/vm QOL commands

### DIFF
--- a/evmd/app.go
+++ b/evmd/app.go
@@ -457,7 +457,7 @@ func NewExampleApp(
 
 	app.GovKeeper = *govKeeper.SetHooks(
 		govtypes.NewMultiGovHooks(
-			// register the governance hooks
+		// register the governance hooks
 		),
 	)
 
@@ -626,7 +626,7 @@ func NewExampleApp(
 		ibctm.NewAppModule(tmLightClientModule),
 		transferModule,
 		// Cosmos EVM modules
-		vm.NewAppModule(app.EVMKeeper, app.AccountKeeper),
+		vm.NewAppModule(app.EVMKeeper, app.AccountKeeper, app.AccountKeeper.AddressCodec()),
 		feemarket.NewAppModule(app.FeeMarketKeeper),
 		erc20.NewAppModule(app.Erc20Keeper, app.AccountKeeper),
 		precisebank.NewAppModule(app.PreciseBankKeeper, app.BankKeeper, app.AccountKeeper),

--- a/evmd/app.go
+++ b/evmd/app.go
@@ -457,7 +457,7 @@ func NewExampleApp(
 
 	app.GovKeeper = *govKeeper.SetHooks(
 		govtypes.NewMultiGovHooks(
-		// register the governance hooks
+			// register the governance hooks
 		),
 	)
 
@@ -1091,7 +1091,7 @@ func BlockedAddresses() map[string]bool {
 	}
 
 	for _, precompile := range blockedPrecompilesHex {
-		blockedAddrs[cosmosevmutils.EthHexToCosmosAddr(precompile).String()] = true
+		blockedAddrs[cosmosevmutils.Bech32StringFromHexAddress(precompile)] = true
 	}
 
 	return blockedAddrs

--- a/precompiles/common/types.go
+++ b/precompiles/common/types.go
@@ -98,6 +98,10 @@ func HexAddressFromBech32String(addr string) (res common.Address, err error) {
 	return common.BytesToAddress(accAddr), nil
 }
 
+func Bech32FromHexAddress(addr string) string {
+	return sdk.AccAddress(common.HexToAddress(addr).Bytes()).String()
+}
+
 // SafeAdd adds two integers and returns a boolean if an overflow occurs to avoid panic.
 // TODO: Upstream this to the SDK math package.
 func SafeAdd(a, b math.Int) (res *big.Int, overflow bool) {

--- a/precompiles/common/types.go
+++ b/precompiles/common/types.go
@@ -1,14 +1,10 @@
 package common
 
 import (
+	"cosmossdk.io/math"
 	"fmt"
 	"math/big"
 	"reflect"
-	"strings"
-
-	"github.com/ethereum/go-ethereum/common"
-
-	"cosmossdk.io/math"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
@@ -78,28 +74,6 @@ func NewDecCoinsResponse(amount sdk.DecCoins) []DecCoin {
 		}
 	}
 	return outputs
-}
-
-// HexAddressFromBech32String converts a hex address to a bech32 encoded address.
-func HexAddressFromBech32String(addr string) (res common.Address, err error) {
-	if strings.Contains(addr, sdk.PrefixValidator) {
-		valAddr, err := sdk.ValAddressFromBech32(addr)
-		if err != nil {
-			return res, err
-		}
-		return common.BytesToAddress(valAddr.Bytes()), nil
-	}
-
-	accAddr, err := sdk.AccAddressFromBech32(addr)
-	if err != nil {
-		return res, err
-	}
-
-	return common.BytesToAddress(accAddr), nil
-}
-
-func Bech32FromHexAddress(addr string) string {
-	return sdk.AccAddress(common.HexToAddress(addr).Bytes()).String()
 }
 
 // SafeAdd adds two integers and returns a boolean if an overflow occurs to avoid panic.

--- a/precompiles/distribution/types.go
+++ b/precompiles/distribution/types.go
@@ -2,6 +2,7 @@ package distribution
 
 import (
 	"fmt"
+	"github.com/cosmos/evm/utils"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
@@ -138,7 +139,7 @@ func NewMsgWithdrawValidatorCommission(args []interface{}) (*distributiontypes.M
 		ValidatorAddress: validatorAddress,
 	}
 
-	validatorHexAddr, err := cmn.HexAddressFromBech32String(msg.ValidatorAddress)
+	validatorHexAddr, err := utils.HexAddressFromBech32String(msg.ValidatorAddress)
 	if err != nil {
 		return nil, common.Address{}, err
 	}

--- a/precompiles/gov/types.go
+++ b/precompiles/gov/types.go
@@ -355,7 +355,7 @@ func ParseVotesArgs(method *abi.Method, args []interface{}) (*govv1.QueryVotesRe
 func (vo *VotesOutput) FromResponse(res *govv1.QueryVotesResponse) *VotesOutput {
 	vo.Votes = make([]WeightedVote, len(res.Votes))
 	for i, v := range res.Votes {
-		hexAddr, err := utils.Bech32ToHexAddr(v.Voter)
+		hexAddr, err := utils.HexAddressFromBech32String(v.Voter)
 		if err != nil {
 			return nil
 		}
@@ -406,7 +406,7 @@ func ParseVoteArgs(args []interface{}) (*govv1.QueryVoteRequest, error) {
 }
 
 func (vo *VoteOutput) FromResponse(res *govv1.QueryVoteResponse) *VoteOutput {
-	hexVoter, err := utils.Bech32ToHexAddr(res.Vote.Voter)
+	hexVoter, err := utils.HexAddressFromBech32String(res.Vote.Voter)
 	if err != nil {
 		return nil
 	}
@@ -482,7 +482,7 @@ func ParseTallyResultArgs(args []interface{}) (*govv1.QueryTallyResultRequest, e
 }
 
 func (do *DepositOutput) FromResponse(res *govv1.QueryDepositResponse) *DepositOutput {
-	hexDepositor, err := utils.Bech32ToHexAddr(res.Deposit.Depositor)
+	hexDepositor, err := utils.HexAddressFromBech32String(res.Deposit.Depositor)
 	if err != nil {
 		return nil
 	}
@@ -504,7 +504,7 @@ func (do *DepositOutput) FromResponse(res *govv1.QueryDepositResponse) *DepositO
 func (do *DepositsOutput) FromResponse(res *govv1.QueryDepositsResponse) *DepositsOutput {
 	do.Deposits = make([]DepositData, len(res.Deposits))
 	for i, d := range res.Deposits {
-		hexDepositor, err := utils.Bech32ToHexAddr(d.Depositor)
+		hexDepositor, err := utils.HexAddressFromBech32String(d.Depositor)
 		if err != nil {
 			return nil
 		}
@@ -635,7 +635,7 @@ func (po *ProposalOutput) FromResponse(res *govv1.QueryProposalResponse) *Propos
 		}
 	}
 
-	proposer, err := utils.Bech32ToHexAddr(res.Proposal.Proposer)
+	proposer, err := utils.HexAddressFromBech32String(res.Proposal.Proposer)
 	if err != nil {
 		return nil
 	}
@@ -684,7 +684,7 @@ func (po *ProposalsOutput) FromResponse(res *govv1.QueryProposalsResponse) *Prop
 			}
 		}
 
-		proposer, err := utils.Bech32ToHexAddr(p.Proposer)
+		proposer, err := utils.HexAddressFromBech32String(p.Proposer)
 		if err != nil {
 			return nil
 		}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -22,15 +22,10 @@ import (
 	errortypes "github.com/cosmos/cosmos-sdk/types/errors"
 )
 
-// EthHexToCosmosAddr takes a given Hex string and derives a Cosmos SDK account address
+// Bech32StringFromHexAddress takes a given Hex string and derives a Cosmos SDK account address
 // from it.
-func EthHexToCosmosAddr(hexAddr string) sdk.AccAddress {
-	return EthToCosmosAddr(common.HexToAddress(hexAddr))
-}
-
-// EthToCosmosAddr converts a given Ethereum style address to an SDK address.
-func EthToCosmosAddr(addr common.Address) sdk.AccAddress {
-	return sdk.AccAddress(addr.Bytes())
+func Bech32StringFromHexAddress(hexAddr string) string {
+	return sdk.AccAddress(common.HexToAddress(hexAddr).Bytes()).String()
 }
 
 // HexAddressFromBech32String converts a hex address to a bech32 encoded address.
@@ -49,12 +44,6 @@ func HexAddressFromBech32String(addr string) (res common.Address, err error) {
 	}
 
 	return common.BytesToAddress(accAddr), nil
-}
-
-// CosmosToEthAddr converts a given SDK account address to
-// an Ethereum address.
-func CosmosToEthAddr(accAddr sdk.AccAddress) common.Address {
-	return common.BytesToAddress(accAddr.Bytes())
 }
 
 // IsSupportedKey returns true if the pubkey type is supported by the chain

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -33,15 +33,22 @@ func EthToCosmosAddr(addr common.Address) sdk.AccAddress {
 	return sdk.AccAddress(addr.Bytes())
 }
 
-// Bech32ToHexAddr converts a given Bech32 address string and converts it to
-// an Ethereum address.
-func Bech32ToHexAddr(bech32Addr string) (common.Address, error) {
-	accAddr, err := sdk.AccAddressFromBech32(bech32Addr)
-	if err != nil {
-		return common.Address{}, errorsmod.Wrapf(err, "failed to convert bech32 string to address")
+// HexAddressFromBech32String converts a hex address to a bech32 encoded address.
+func HexAddressFromBech32String(addr string) (res common.Address, err error) {
+	if strings.Contains(addr, sdk.PrefixValidator) {
+		valAddr, err := sdk.ValAddressFromBech32(addr)
+		if err != nil {
+			return res, err
+		}
+		return common.BytesToAddress(valAddr.Bytes()), nil
 	}
 
-	return CosmosToEthAddr(accAddr), nil
+	accAddr, err := sdk.AccAddressFromBech32(addr)
+	if err != nil {
+		return res, err
+	}
+
+	return common.BytesToAddress(accAddr), nil
 }
 
 // CosmosToEthAddr converts a given SDK account address to

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 
 	"github.com/cosmos/evm/crypto/ethsecp256k1"
@@ -240,13 +239,7 @@ func TestAddressConversion(t *testing.T) {
 	hex := "0x7cB61D4117AE31a12E393a1Cfa3BaC666481D02E"
 	bech32 := "cosmos10jmp6sgh4cc6zt3e8gw05wavvejgr5pwsjskvv"
 
-	hexAddr := common.HexToAddress(hex)
-	require.Equal(t, bech32, EthToCosmosAddr(hexAddr).String())
-	require.Equal(t, bech32, EthHexToCosmosAddr(hex).String())
-
-	accAddr := sdk.MustAccAddressFromBech32(bech32)
-	require.Equal(t, hex, CosmosToEthAddr(accAddr).Hex())
-
+	require.Equal(t, bech32, Bech32StringFromHexAddress(hex))
 	gotAddr, err := HexAddressFromBech32String(bech32)
 	require.NoError(t, err)
 	require.Equal(t, hex, gotAddr.Hex())

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -247,7 +247,7 @@ func TestAddressConversion(t *testing.T) {
 	accAddr := sdk.MustAccAddressFromBech32(bech32)
 	require.Equal(t, hex, CosmosToEthAddr(accAddr).Hex())
 
-	gotAddr, err := Bech32ToHexAddr(bech32)
+	gotAddr, err := HexAddressFromBech32String(bech32)
 	require.NoError(t, err)
 	require.Equal(t, hex, gotAddr.Hex())
 }

--- a/x/vm/client/cli/query.go
+++ b/x/vm/client/cli/query.go
@@ -1,6 +1,8 @@
 package cli
 
 import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	common "github.com/cosmos/evm/precompiles/common"
 	"github.com/spf13/cobra"
 
 	rpctypes "github.com/cosmos/evm/rpc/types"
@@ -26,6 +28,8 @@ func GetQueryCmd() *cobra.Command {
 		GetAccountCmd(),
 		GetParamsCmd(),
 		GetConfigCmd(),
+		HexToBech32Cmd(),
+		Bech32ToHexCmd(),
 	)
 	return cmd
 }
@@ -193,6 +197,47 @@ func GetConfigCmd() *cobra.Command {
 			}
 
 			return clientCtx.PrintProto(res)
+		},
+	}
+
+	flags.AddQueryFlagsToCmd(cmd)
+	return cmd
+}
+
+// GetConfigCmd queries the evm configuration
+func HexToBech32Cmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "0x-to-bech32",
+		Short:   "Get the evm 0x address for a given bech32 address",
+		Long:    "Get the evm 0x address for a given bech32 address.",
+		Example: "evmd query evm 0x-to-bech32 0x7cB61D4117AE31a12E393a1Cfa3BaC666481D02E",
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.Println(common.Bech32FromHexAddress(args[0]))
+			return nil
+		},
+	}
+
+	flags.AddQueryFlagsToCmd(cmd)
+	return cmd
+}
+
+// GetConfigCmd queries the evm configuration
+func Bech32ToHexCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "bech32-to-0x",
+		Short:   "Get the bech32 address for a given 0x address",
+		Long:    "Get the evm 0x address for a given bech 32 address.",
+		Example: "evmd query evm 0x-to-bech32 ",
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			addr, err := sdk.AccAddressFromBech32(args[0])
+			if err != nil {
+				return err
+			}
+			hex, err := common.HexAddressFromBech32String(addr.String())
+			cmd.Println(hex.String())
+			return nil
 		},
 	}
 

--- a/x/vm/client/cli/query.go
+++ b/x/vm/client/cli/query.go
@@ -2,7 +2,7 @@ package cli
 
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	common "github.com/cosmos/evm/precompiles/common"
+	"github.com/cosmos/evm/utils"
 	"github.com/spf13/cobra"
 
 	rpctypes "github.com/cosmos/evm/rpc/types"
@@ -213,7 +213,7 @@ func HexToBech32Cmd() *cobra.Command {
 		Example: "evmd query evm 0x-to-bech32 0x7cB61D4117AE31a12E393a1Cfa3BaC666481D02E",
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cmd.Println(common.Bech32FromHexAddress(args[0]))
+			cmd.Println(utils.EthHexToCosmosAddr(args[0]))
 			return nil
 		},
 	}
@@ -227,15 +227,15 @@ func Bech32ToHexCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "bech32-to-0x",
 		Short:   "Get the bech32 address for a given 0x address",
-		Long:    "Get the evm 0x address for a given bech 32 address.",
-		Example: "evmd query evm 0x-to-bech32 ",
+		Long:    "Get the bech32 address for a given 0x address.",
+		Example: "evmd query evm bech32-to-0x cosmos10jmp6sgh4cc6zt3e8gw05wavvejgr5pwsjskvv",
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			addr, err := sdk.AccAddressFromBech32(args[0])
 			if err != nil {
 				return err
 			}
-			hex, err := common.HexAddressFromBech32String(addr.String())
+			hex, err := utils.HexAddressFromBech32String(addr.String())
 			cmd.Println(hex.String())
 			return nil
 		},

--- a/x/vm/client/cli/query.go
+++ b/x/vm/client/cli/query.go
@@ -1,7 +1,6 @@
 package cli
 
 import (
-	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/evm/utils"
 	"github.com/spf13/cobra"
 
@@ -213,7 +212,7 @@ func HexToBech32Cmd() *cobra.Command {
 		Example: "evmd query evm 0x-to-bech32 0x7cB61D4117AE31a12E393a1Cfa3BaC666481D02E",
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cmd.Println(utils.EthHexToCosmosAddr(args[0]))
+			cmd.Println(utils.Bech32StringFromHexAddress(args[0]))
 			return nil
 		},
 	}
@@ -231,11 +230,10 @@ func Bech32ToHexCmd() *cobra.Command {
 		Example: "evmd query evm bech32-to-0x cosmos10jmp6sgh4cc6zt3e8gw05wavvejgr5pwsjskvv",
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			addr, err := sdk.AccAddressFromBech32(args[0])
+			hex, err := utils.HexAddressFromBech32String(args[0])
 			if err != nil {
 				return err
 			}
-			hex, err := utils.HexAddressFromBech32String(addr.String())
 			cmd.Println(hex.String())
 			return nil
 		},

--- a/x/vm/client/cli/tx.go
+++ b/x/vm/client/cli/tx.go
@@ -132,7 +132,7 @@ When using '--dry-run' a key name cannot be used, only an 0x or bech32 address.
 		RunE: func(cmd *cobra.Command, args []string) error {
 			fromAddr := args[0]
 			if strings.HasPrefix(args[0], "0x") {
-				fromAddr = utils.Bech32StringFromHexAddress(args[1])
+				fromAddr = utils.Bech32StringFromHexAddress(args[0])
 			}
 
 			err := cmd.Flags().Set(flags.FlagFrom, fromAddr)

--- a/x/vm/client/cli/tx.go
+++ b/x/vm/client/cli/tx.go
@@ -2,8 +2,14 @@ package cli
 
 import (
 	"bufio"
+	"cosmossdk.io/core/address"
 	"fmt"
+	"github.com/cosmos/cosmos-sdk/client/tx"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	types2 "github.com/cosmos/cosmos-sdk/x/bank/types"
+	"github.com/cosmos/evm/utils"
 	"os"
+	"strings"
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/pkg/errors"
@@ -17,7 +23,7 @@ import (
 )
 
 // NewTxCmd returns a root CLI command handler for evm module transaction commands
-func NewTxCmd() *cobra.Command {
+func NewTxCmd(ac address.Codec) *cobra.Command {
 	txCmd := &cobra.Command{
 		Use:                        types.ModuleName,
 		Short:                      "evm subcommands",
@@ -28,6 +34,7 @@ func NewTxCmd() *cobra.Command {
 
 	txCmd.AddCommand(
 		NewRawTxCmd(),
+		NewSendTxCmd(ac),
 	)
 	return txCmd
 }
@@ -107,5 +114,57 @@ func NewRawTxCmd() *cobra.Command {
 	}
 
 	flags.AddTxFlagsToCmd(cmd)
+	return cmd
+}
+
+// NewSendTxCmd returns a CLI command handler for creating a MsgSend transaction.
+func NewSendTxCmd(ac address.Codec) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "send [from_key_or_address] [to_address] [amount]",
+		Short: "Send funds from one account to another.",
+		Long: `Send funds from one account to another. Both 0x and bech32 addresses
+may be used.
+Note, the '--from' flag is ignored as it is implied from [from_key_or_address].
+When using '--dry-run' a key name cannot be used, only an 0x or bech32 address.
+`,
+		Example: "evmd tx evm send 0x7cB61D4117AE31a12E393a1Cfa3BaC666481D02E 0xA2A8B87390F8F2D188242656BFb6852914073D06 10utoken",
+		Args:    cobra.ExactArgs(3),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			fromAddr := args[0]
+			if strings.HasPrefix(args[0], "0x") {
+				fromAddr = utils.Bech32StringFromHexAddress(args[1])
+			}
+
+			err := cmd.Flags().Set(flags.FlagFrom, fromAddr)
+			if err != nil {
+				return err
+			}
+			clientCtx, err := client.GetClientTxContext(cmd)
+			if err != nil {
+				return err
+			}
+
+			toAddr, err := ac.StringToBytes(utils.Bech32StringFromHexAddress(args[1]))
+			if err != nil {
+				return err
+			}
+
+			coins, err := sdk.ParseCoinsNormalized(args[2])
+			if err != nil {
+				return err
+			}
+
+			if len(coins) == 0 {
+				return fmt.Errorf("invalid coins")
+			}
+
+			msg := types2.NewMsgSend(clientCtx.GetFromAddress(), toAddr, coins)
+
+			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+		},
+	}
+
+	flags.AddTxFlagsToCmd(cmd)
+
 	return cmd
 }

--- a/x/vm/keeper/keeper_test.go
+++ b/x/vm/keeper/keeper_test.go
@@ -80,7 +80,7 @@ func (suite *KeeperTestSuite) TestGetAccountStorage() {
 					return false
 				}
 
-				address, err := utils.Bech32ToHexAddr(acc.Address)
+				address, err := utils.HexAddressFromBech32String(acc.Address)
 				if err != nil {
 					// NOTE: we panic in the test to see any potential problems
 					// instead of skipping to the next account

--- a/x/vm/module.go
+++ b/x/vm/module.go
@@ -111,7 +111,7 @@ type AppModule struct {
 // NewAppModule creates a new AppModule object
 func NewAppModule(k *keeper.Keeper, ak types.AccountKeeper, ac address.Codec) AppModule {
 	return AppModule{
-		AppModuleBasic: AppModuleBasic{},
+		AppModuleBasic: AppModuleBasic{ac: ac},
 		keeper:         k,
 		ak:             ak,
 	}

--- a/x/vm/module.go
+++ b/x/vm/module.go
@@ -2,6 +2,7 @@ package vm
 
 import (
 	"context"
+	"cosmossdk.io/core/address"
 	"encoding/json"
 	"fmt"
 
@@ -37,7 +38,9 @@ var (
 )
 
 // AppModuleBasic defines the basic application module used by the evm module.
-type AppModuleBasic struct{}
+type AppModuleBasic struct {
+	ac address.Codec
+}
 
 // Name returns the evm module's name.
 func (AppModuleBasic) Name() string {
@@ -87,8 +90,8 @@ func (AppModuleBasic) RegisterInterfaces(registry codectypes.InterfaceRegistry) 
 }
 
 // GetTxCmd returns the root tx command for the erc20 module.
-func (AppModuleBasic) GetTxCmd() *cobra.Command {
-	return cli.NewTxCmd()
+func (b AppModuleBasic) GetTxCmd() *cobra.Command {
+	return cli.NewTxCmd(b.ac)
 }
 
 // GetQueryCmd returns the root query command for the erc20 module.
@@ -106,7 +109,7 @@ type AppModule struct {
 }
 
 // NewAppModule creates a new AppModule object
-func NewAppModule(k *keeper.Keeper, ak types.AccountKeeper) AppModule {
+func NewAppModule(k *keeper.Keeper, ak types.AccountKeeper, ac address.Codec) AppModule {
 	return AppModule{
 		AppModuleBasic: AppModuleBasic{},
 		keeper:         k,


### PR DESCRIPTION
closes: #193

- Adds 0x to bech32 conversion
- Adds bech32 to 0x conversion
- Adds bank sends to and from 0x addresses
- Adds bank balance queries for 0x addresses
- Adds ERC20 balance queries for 0x addresses

Could add ERC20 sends in the ERC20 module in this PR or a future one if needed.