### PR TITLE
chore: Remove valid account check in vm init genesis

### DIFF
--- a/x/vm/genesis.go
+++ b/x/vm/genesis.go
@@ -33,14 +33,6 @@ func InitGenesis(
 
 	for _, account := range data.Accounts {
 		address := common.HexToAddress(account.Address)
-		accAddress := sdk.AccAddress(address.Bytes())
-
-		// check that the account is actually found in the account keeper
-		acc := accountKeeper.GetAccount(ctx, accAddress)
-		if acc == nil {
-			panic(fmt.Errorf("account not found for address %s", account.Address))
-		}
-
 		code := common.Hex2Bytes(account.Code)
 		codeHash := crypto.Keccak256Hash(code).Bytes()
 

--- a/x/vm/genesis_test.go
+++ b/x/vm/genesis_test.go
@@ -89,19 +89,6 @@ func TestInitGenesis(t *testing.T) {
 			expPanic: false,
 		},
 		{
-			name:     "account not found",
-			malleate: func(_ *testnetwork.UnitTestNetwork) {},
-			genState: &types.GenesisState{
-				Params: types.DefaultParams(),
-				Accounts: []types.GenesisAccount{
-					{
-						Address: address.String(),
-					},
-				},
-			},
-			expPanic: true,
-		},
-		{
 			name: "ignore empty account code checking",
 			malleate: func(network *testnetwork.UnitTestNetwork) {
 				acc := network.App.AccountKeeper.NewAccountWithAddress(ctx, address.Bytes())


### PR DESCRIPTION
# Description

It's not clear to me why this check needs to be here. When deploying new chains using a custom genesis to create preinstall contracts, there will be no account stored in the account keeper for these, and that seems like a valid use case.

Closes: #XXXX

---

## Author Checklist

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.

I have...

- [ ] tackled an existing issue or discussed with a team member
- [ ] left instructions on how to review the changes
- [ ] targeted the `main` branch

## Reviewers Checklist

**All** items are required.
Please add a note if the item is not applicable
and please add your handle next to the items reviewed
if you only reviewed selected items.

I have...

- [ ] added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] confirmed all author checklist items have been addressed
- [ ] confirmed that this PR does not change production code
- [ ] reviewed content
- [ ] tested instructions (if applicable)
- [ ] confirmed all CI checks have passed
