### PR TITLE
tests: exclude generated and irrelevant files from coverage report

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -131,6 +131,8 @@ test-unit-cover: run-tests
 	@cd evmd && go test -tags=test $(COMMON_COVER_ARGS) -coverpkg=$(COVERPKG_ALL) -coverprofile=coverage_evmd.txt ./...
 	@echo "🔀 Merging evmd coverage into root coverage..."
 	@tail -n +2 evmd/coverage_evmd.txt >> coverage.txt && rm evmd/coverage_evmd.txt
+	@echo "🧹 Filtering ignored files from coverage.txt..."
+	@grep -v -E '/cmd/|/client/|/proto/|/testutil/|/mocks/|/test_.*\.go:|\.pb\.go:|\.pb\.gw\.go:|/x/[^/]+/module\.go:|/scripts/|/ibc/testing/|/version/|\.md:|\.pulsar\.go:' coverage.txt > tmp_coverage.txt && mv tmp_coverage.txt coverage.txt
 	@echo "📊 Coverage summary:"
 	@go tool cover -func=coverage.txt
 


### PR DESCRIPTION
## Summary

This PR updates the `test-unit-cover` Makefile target to exclude generated files and non-essential directories from the final coverage report. This ensures the coverage percentage more accurately reflects the test coverage of core logic.

### Changes

- Filters out the following from `coverage.txt`:
  - Generated files: `*.pb.go`, `*.pb.gw.go`, `*.pulsar.go`
  - Test helpers and mocks: `/testutil/`, `/test_*.go`, `/mocks/`
  - SDK integration or non-core modules: `/proto/`, `/cmd/`, `/client/`, `/x/*/module.go`, `/ibc/testing/`, `/scripts/`, `/version/`
  - Documentation and Markdown: `*.md`

### Motivation

Including these files in the coverage report artificially deflates the coverage percentage and creates noise when tracking test effectiveness. By excluding them, we can focus coverage metrics on files that contain actual business logic.

---

## Author Checklist

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.

I have...

- [ ] tackled an existing issue or discussed with a team member
- [ ] left instructions on how to review the changes
- [ ] targeted the `main` branch

## Reviewers Checklist

**All** items are required.
Please add a note if the item is not applicable
and please add your handle next to the items reviewed
if you only reviewed selected items.

I have...

- [ ] added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] confirmed all author checklist items have been addressed
- [ ] confirmed that this PR does not change production code
- [ ] reviewed content
- [ ] tested instructions (if applicable)
- [ ] confirmed all CI checks have passed
