### PR TITLE
fix(precompiles): return data for revert

### DIFF
--- a/precompiles/common/revert.go
+++ b/precompiles/common/revert.go
@@ -1,0 +1,26 @@
+package common
+
+import (
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+var (
+	revertSelector = crypto.Keccak256([]byte("Error(string)"))[:4]
+)
+
+// RevertReasonBytes converts a message to ABI-encoded revert bytes.
+func RevertReasonBytes(reason string) ([]byte, error) {
+	typ, err := abi.NewType("string", "", nil)
+	if err != nil {
+		return nil, err
+	}
+	packed, err := (abi.Arguments{{Type: typ}}).Pack(reason)
+	if err != nil {
+		return nil, err
+	}
+	bz := make([]byte, 0, len(revertSelector)+len(packed))
+	bz = append(bz, revertSelector...)
+	bz = append(bz, packed...)
+	return bz, nil
+}

--- a/precompiles/distribution/distribution.go
+++ b/precompiles/distribution/distribution.go
@@ -131,7 +131,14 @@ func (p Precompile) Run(evm *vm.EVM, contract *vm.Contract, readOnly bool) (bz [
 	}
 
 	if err != nil {
-		return nil, err
+		bz, encErr := cmn.RevertReasonBytes(err.Error())
+		if encErr != nil {
+			return nil, encErr
+		}
+
+		evm.Interpreter().SetReturnData(bz)
+
+		return bz, vm.ErrExecutionReverted
 	}
 
 	cost := ctx.GasMeter().GasConsumed() - initialGas

--- a/testutil/integration/evm/factory/factory.go
+++ b/testutil/integration/evm/factory/factory.go
@@ -211,7 +211,8 @@ func (tf *IntegrationTxFactory) checkEthTxResponse(res *abcitypes.ExecTxResult) 
 	}
 
 	if evmRes.Failed() {
-		return fmt.Errorf("tx failed with VmError: %v, Logs: %s", evmRes.VmError, res.GetLog())
+		reason := evmtypes.NewExecErrorWithReason(evmRes.Ret)
+		return fmt.Errorf("tx failed with VmError: %v, Reason: %s", evmRes.VmError, reason)
 	}
 	return nil
 }

--- a/x/vm/keeper/state_transition.go
+++ b/x/vm/keeper/state_transition.go
@@ -444,6 +444,11 @@ func (k *Keeper) ApplyMessageWithConfig(
 	// reset leftoverGas, to be used by the tracer
 	leftoverGas = msg.GasLimit - gasUsed
 
+	// if the execution reverted, we return the revert reason as the return data
+	if vmError == vm.ErrExecutionReverted.Error() {
+		ret = evm.Interpreter().ReturnData()
+	}
+
 	return &types.MsgEthereumTxResponse{
 		GasUsed: gasUsed,
 		VmError: vmError,

--- a/x/vm/types/errors.go
+++ b/x/vm/types/errors.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/common/hexutil"
 
 	errorsmod "cosmossdk.io/errors"
 )
@@ -99,7 +98,7 @@ func NewExecErrorWithReason(revertReason []byte) *RevertError {
 	}
 	return &RevertError{
 		error:  err,
-		reason: hexutil.Encode(result),
+		reason: reason,
 	}
 }
 


### PR DESCRIPTION
# Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

<!-- Please keep your PR as draft until it's ready for review -->

<!-- Pull requests that sit inactive for longer than 30 days will be closed.  -->

## Problem

- When the caller contract calls the precompile, the error message isn’t propagated back to it.
- Unlike the geth opcode opRevert, which returns the error message in its return data and ErrExecutionReverted as the error, the Cosmos/EVM precompile currently returns nil as return data and a custom error type as the error.
- We need to make precompile errors behave like opRevert: return the error message in the return data and use ErrExecutionReverted as the error.

## Solution

1. Modify return values on precompile error
    - Always return `ErrExecutionReverted` as the error.
    - Encode the original error message with the Revert selector (`"Error(string)"`) as the return data.
    - Use `evm.Interpreter.SetReturnData()` to set that encoded data into `EVMInterpreter.returnData`.
2. Modify return values in `ApplyMessageWithConfig`
    - If err is `ErrExecutionReverted`, set res.Ret to `evm.Interpreter.ReturnData()`.
3.  Update the test util function
    - Previously, on error the code logged the revert reason via emitted events (which never occur when an error is thrown).
    - Now, pull the `EthereumTxResponse.Ret` returned in step 2, decode it with `abi.UnpackRevert`, and print that as the reason.

## Result

### As-Is

<img width="906" alt="err_msg_empty" src="https://github.com/user-attachments/assets/6c7ff77e-4627-400b-987a-554ac0c18d4f" />
In the original code, errors thrown by the precompile were not propagated to the caller contract.

### To-Be

![revert_with_reason](https://github.com/user-attachments/assets/dccc23f8-82d1-496f-9573-6e47285a9568)
Now, errors returned by the precompile are returned in the caller contract’s return data, and the test utilities have been updated so that the test code can verify them.

Closes: #223 

---

## Author Checklist

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.

I have...

- [ ] tackled an existing issue or discussed with a team member
- [ ] left instructions on how to review the changes
- [ ] targeted the `main` branch

## Reviewers Checklist

**All** items are required.
Please add a note if the item is not applicable
and please add your handle next to the items reviewed
if you only reviewed selected items.

I have...

- [ ] added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] confirmed all author checklist items have been addressed
- [ ] confirmed that this PR does not change production code
- [ ] reviewed content
- [ ] tested instructions (if applicable)
- [ ] confirmed all CI checks have passed
