### PR TITLE
Fixes typo in gov precompile IGov.sol

### DIFF
--- a/precompiles/gov/IGov.sol
+++ b/precompiles/gov/IGov.sol
@@ -21,8 +21,8 @@ enum VoteOption {
     Abstain,
     // No defines a no vote option.
     No,
-    // NoWithWeto defines a no with veto vote option.
-    NoWithWeto
+    // NoWithVeto defines a no with veto vote option.
+    NoWithVeto
 }
 /// @dev WeightedVote represents a vote on a governance proposal
 struct WeightedVote {


### PR DESCRIPTION
# Description

Lines 24/25 `NoWithWeto` >> `NoWithVeto`

[L24/25](https://github.com/cosmos/evm/blob/a4337cedc3eae5ad122db549055644549734b95a/precompiles/gov/IGov.sol#L25C7-L25C15)

Closes: #212 

---

## Author Checklist

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.

I have...

- [x] tackled an existing issue or discussed with a team member
- [ ] left instructions on how to review the changes
- [x] targeted the `main` branch

## Reviewers Checklist

**All** items are required.
Please add a note if the item is not applicable
and please add your handle next to the items reviewed
if you only reviewed selected items.

I have...

- [ ] added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] confirmed all author checklist items have been addressed
- [ ] confirmed that this PR does not change production code
- [ ] reviewed content
- [ ] tested instructions (if applicable)
- [ ] confirmed all CI checks have passed
