### PR TITLE
fix(rpc): don't return negative rewards from eth_feeHistory

### DIFF
--- a/rpc/backend/utils.go
+++ b/rpc/backend/utils.go
@@ -179,7 +179,7 @@ func (b *Backend) processBlock(
 			}
 			tx := ethMsg.AsTransaction()
 			reward := tx.EffectiveGasTipValue(blockBaseFee)
-			if reward == nil {
+			if reward == nil || reward.Sign() < 0 {
 				reward = big.NewInt(0)
 			}
 			sorter = append(sorter, txGasAndReward{gasUsed: txGasUsed, reward: reward})


### PR DESCRIPTION
# Description

Hi, I have a corner case where I'm doing something funny with gas meters during the execution of ethereum transactions, this leads to the `eth_feeHistory` RPC to return negative rewards in the first ~100 blocks after genesis.

Here is an example of what `eth_feeHistory` RPC returns when this happen:
```
{
  "jsonrpc": "2.0",
  "id": 1,
  "result": {
    "oldestBlock": "0x24",
    "reward": [
      [
        "-0x7caf0c"
      ],
      [
        "-0x6d192a"
      ],
      [
        "-0x5f7605"
      ],
      [
        "-0x538744"
      ],
      [
        "-0x49165c"
      ],
      [
        "-0x3ff390"
      ],
      [
        "-0x37f51e"
      ],
      [
        "-0x30f67a"
      ],
      [
        "-0x2ad7ab"
      ],
      [
        "-0x257cb6"
      ]
    ],
    "baseFeePerGas": [
      "0x7caf0c",
      "0x6d192a",
      "0x5f7605",
      "0x538744",
      "0x49165c",
      "0x3ff390",
      "0x37f51e",
      "0x30f67a",
      "0x2ad7ab",
      "0x257cb6",
      "0x257cb6"
    ],
    "gasUsedRatio": [
      0.000023283064370807974,
      0.000023283064370807974,
      0.000023283064370807974,
      0.000023283064370807974,
      0.000023283064370807974,
      0.000023283064370807974,
      0.000023283064370807974,
      0.000023283064370807974,
      0.000023283064370807974,
      0.000023283064370807974
    ]
  }
}
```

_Numbers_ like `-0x7caf0c` make most parser/eth clients cry 😅 This PR clips the reward to zero.

Honestly, I'm not 100% sure this is the right thing to do, but it fixes my issues with those clients (e.g. `forge`) that try to estimate EIP1552 fees using this RPC call (it's possible that they don't even use these rewards number, but at least they can now parse the response). 

As I said initially, this issue goes away after a few blocks, as rewards tend to return to 0 over time and baseFee decreases. Still, it's a bit annoying when developing and restarting the chain often.