### PR TITLE
fix(precompiles/slashing): decode bech32 consensus address before converting to bytes

### DIFF
--- a/precompiles/slashing/query.go
+++ b/precompiles/slashing/query.go
@@ -17,7 +17,10 @@ const (
 	GetParamsMethod = "getParams"
 )
 
-// GetSigningInfo implements the query to get a validator's signing info.
+// GetSigningInfo handles the `getSigningInfo` precompile call.
+// It expects a single argument: the validator’s consensus address in hex format.
+// That address comes from the validator’s Tendermint ed25519 public key,
+// typically found in `$HOME/.evmd/config/priv_validator_key.json`.
 func (p *Precompile) GetSigningInfo(
 	ctx sdk.Context,
 	method *abi.Method,
@@ -34,7 +37,10 @@ func (p *Precompile) GetSigningInfo(
 		return nil, err
 	}
 
-	out := new(SigningInfoOutput).FromResponse(res)
+	out, err := new(SigningInfoOutput).FromResponse(res)
+	if err != nil {
+		return nil, err
+	}
 	return method.Outputs.Pack(out.SigningInfo)
 }
 
@@ -55,7 +61,10 @@ func (p *Precompile) GetSigningInfos(
 		return nil, err
 	}
 
-	out := new(SigningInfosOutput).FromResponse(res)
+	out, err := new(SigningInfosOutput).FromResponse(res)
+	if err != nil {
+		return nil, err
+	}
 	return method.Outputs.Pack(out.SigningInfos, out.PageResponse)
 }
 

--- a/precompiles/slashing/types.go
+++ b/precompiles/slashing/types.go
@@ -73,23 +73,32 @@ func ParseSigningInfosArgs(method *abi.Method, args []interface{}) (*slashingtyp
 	}, nil
 }
 
-func (sio *SigningInfoOutput) FromResponse(res *slashingtypes.QuerySigningInfoResponse) *SigningInfoOutput {
+func (sio *SigningInfoOutput) FromResponse(res *slashingtypes.QuerySigningInfoResponse) (*SigningInfoOutput, error) {
+	consAddr, err := types.ConsAddressFromBech32(res.ValSigningInfo.Address)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing consensus address: %w", err)
+	}
+
 	sio.SigningInfo = SigningInfo{
-		ValidatorAddress:    common.BytesToAddress([]byte(res.ValSigningInfo.Address)),
+		ValidatorAddress:    common.BytesToAddress(consAddr.Bytes()),
 		StartHeight:         res.ValSigningInfo.StartHeight,
 		IndexOffset:         res.ValSigningInfo.IndexOffset,
 		JailedUntil:         res.ValSigningInfo.JailedUntil.Unix(),
 		Tombstoned:          res.ValSigningInfo.Tombstoned,
 		MissedBlocksCounter: res.ValSigningInfo.MissedBlocksCounter,
 	}
-	return sio
+	return sio, nil
 }
 
-func (sio *SigningInfosOutput) FromResponse(res *slashingtypes.QuerySigningInfosResponse) *SigningInfosOutput {
+func (sio *SigningInfosOutput) FromResponse(res *slashingtypes.QuerySigningInfosResponse) (*SigningInfosOutput, error) {
 	sio.SigningInfos = make([]SigningInfo, len(res.Info))
 	for i, info := range res.Info {
+		consAddr, err := types.ConsAddressFromBech32(info.Address)
+		if err != nil {
+			return nil, fmt.Errorf("error parsing consensus address: %w", err)
+		}
 		sio.SigningInfos[i] = SigningInfo{
-			ValidatorAddress:    common.BytesToAddress([]byte(info.Address)),
+			ValidatorAddress:    common.BytesToAddress(consAddr.Bytes()),
 			StartHeight:         info.StartHeight,
 			IndexOffset:         info.IndexOffset,
 			JailedUntil:         info.JailedUntil.Unix(),
@@ -103,7 +112,7 @@ func (sio *SigningInfosOutput) FromResponse(res *slashingtypes.QuerySigningInfos
 			Total:   res.Pagination.Total,
 		}
 	}
-	return sio
+	return sio, nil
 }
 
 // ValidatorUnjailed defines the data structure for the ValidatorUnjailed event.

--- a/tests/integration/precompiles/slashing/test_query.go
+++ b/tests/integration/precompiles/slashing/test_query.go
@@ -17,6 +17,10 @@ import (
 func (s *PrecompileTestSuite) TestGetSigningInfo() {
 	method := s.precompile.Methods[slashing.GetSigningInfoMethod]
 
+	valSigners := s.network.GetValidators()
+	val0ConsAddr, _ := valSigners[0].GetConsAddr()
+
+	consAddr := types.ConsAddress(val0ConsAddr)
 	testCases := []struct {
 		name        string
 		malleate    func() []interface{}
@@ -52,8 +56,9 @@ func (s *PrecompileTestSuite) TestGetSigningInfo() {
 			func() []interface{} {
 				err := s.network.App.GetSlashingKeeper().SetValidatorSigningInfo(
 					s.network.GetContext(),
-					types.ConsAddress(s.keyring.GetAddr(0).Bytes()),
+					consAddr,
 					slashingtypes.ValidatorSigningInfo{
+						Address:             consAddr.String(),
 						StartHeight:         1,
 						IndexOffset:         2,
 						MissedBlocksCounter: 1,
@@ -62,10 +67,11 @@ func (s *PrecompileTestSuite) TestGetSigningInfo() {
 				)
 				s.Require().NoError(err)
 				return []interface{}{
-					s.keyring.GetAddr(0),
+					common.BytesToAddress(consAddr.Bytes()),
 				}
 			},
 			func(signingInfo *slashing.SigningInfo) {
+				s.Require().Equal(consAddr.Bytes(), signingInfo.ValidatorAddress.Bytes())
 				s.Require().Equal(int64(1), signingInfo.StartHeight)
 				s.Require().Equal(int64(2), signingInfo.IndexOffset)
 				s.Require().Equal(int64(1), signingInfo.MissedBlocksCounter)
@@ -134,19 +140,26 @@ func (s *PrecompileTestSuite) TestGetSigningInfos() {
 				s.Require().Len(signingInfos, 3)
 				s.Require().Equal(uint64(3), pageResponse.Total)
 
+				valSigners := s.network.GetValidators()
+				val0ConsAddr, _ := valSigners[0].GetConsAddr()
+				val1ConsAddr, _ := valSigners[1].GetConsAddr()
+				val2ConsAddr, _ := valSigners[2].GetConsAddr()
 				// Check first validator's signing info
+				s.Require().Equal(val0ConsAddr, signingInfos[0].ValidatorAddress.Bytes())
 				s.Require().Equal(int64(0), signingInfos[0].StartHeight)
 				s.Require().Equal(int64(1), signingInfos[0].IndexOffset)
 				s.Require().Equal(int64(0), signingInfos[0].JailedUntil)
 				s.Require().False(signingInfos[0].Tombstoned)
 
 				// Check second validator's signing info
+				s.Require().Equal(val1ConsAddr, signingInfos[1].ValidatorAddress.Bytes())
 				s.Require().Equal(int64(0), signingInfos[1].StartHeight)
 				s.Require().Equal(int64(1), signingInfos[1].IndexOffset)
 				s.Require().Equal(int64(0), signingInfos[1].JailedUntil)
 				s.Require().False(signingInfos[1].Tombstoned)
 
 				// Check third validator's signing info
+				s.Require().Equal(val2ConsAddr, signingInfos[2].ValidatorAddress.Bytes())
 				s.Require().Equal(int64(0), signingInfos[2].StartHeight)
 				s.Require().Equal(int64(1), signingInfos[2].IndexOffset)
 				s.Require().Equal(int64(0), signingInfos[2].JailedUntil)
@@ -172,6 +185,9 @@ func (s *PrecompileTestSuite) TestGetSigningInfos() {
 				s.Require().NotNil(pageResponse.NextKey)
 
 				// Check first validator's signing info
+				valSigners := s.network.GetValidators()
+				val0ConsAddr, _ := valSigners[0].GetConsAddr()
+				s.Require().Equal(val0ConsAddr, signingInfos[0].ValidatorAddress.Bytes())
 				s.Require().Equal(int64(0), signingInfos[0].StartHeight)
 				s.Require().Equal(int64(1), signingInfos[0].IndexOffset)
 				s.Require().Equal(int64(0), signingInfos[0].JailedUntil)


### PR DESCRIPTION
# Description

This PR fixes a bug where consensus addresses returned from `GetSigningInfo` and `GetSigningInfos` were incorrectly used in their bech32-encoded form.

Previously, the bech32 string (typically 52 characters long) was treated as if it were a raw 20-byte address, leading to invalid conversions and silent data loss. 

With this change, consensus addresses are now properly decoded from bech32 to their original 20-byte binary representation before any further processing.


Closes: #XXXX

---

## Author Checklist

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.

I have...

- [ ] tackled an existing issue or discussed with a team member
- [ ] left instructions on how to review the changes
- [x] targeted the `main` branch

## Reviewers Checklist

**All** items are required.
Please add a note if the item is not applicable
and please add your handle next to the items reviewed
if you only reviewed selected items.

I have...

- [ ] added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] confirmed all author checklist items have been addressed
- [ ] confirmed that this PR does not change production code
- [ ] reviewed content
- [ ] tested instructions (if applicable)
- [ ] confirmed all CI checks have passed
