### PR TITLE
fix: pad ECDSA signature fields to 32 bytes in signMsg to prevent intermittent P256 precompile test failures

### DIFF
--- a/tests/integration/precompiles/p256/test_integration.go
+++ b/tests/integration/precompiles/p256/test_integration.go
@@ -104,13 +104,16 @@ func TestPrecompileIntegrationTestSuite(t *testing.T, create network.CreateEvmAp
 
 						rInt, sInt, err := ecdsa.Sign(rand.Reader, s.p256Priv, hash)
 						Expect(err).To(BeNil())
+						pub := privB.PublicKey
 
 						input = make([]byte, p256.VerifyInputLength)
 						copy(input[0:32], hash)
-						copy(input[32:64], rInt.Bytes())
-						copy(input[64:96], sInt.Bytes())
-						copy(input[96:128], privB.PublicKey.X.Bytes())
-						copy(input[128:160], privB.PublicKey.Y.Bytes())
+
+						// ALWAYS left-pad to 32 bytes:
+						copy(input[32:64], common.LeftPadBytes(rInt.Bytes(), 32))
+						copy(input[64:96], common.LeftPadBytes(sInt.Bytes(), 32))
+						copy(input[96:128], common.LeftPadBytes(pub.X.Bytes(), 32))
+						copy(input[128:160], common.LeftPadBytes(pub.Y.Bytes(), 32))
 						return input, nil, ""
 					},
 				),


### PR DESCRIPTION
### Background
The P256 precompile integration tests are intermittently failing with:
<img width="1141" alt="image" src="https://github.com/user-attachments/assets/65ef231c-71fe-45de-94de-fbd9141faf42" />

This happened because our `signMsg` helper was doing a plain `copy(input[32:64], r.Bytes())`, which only writes as many bytes as `r.Bytes()` returns (its minimal big-endian encoding). Whenever `r` or `s` happened to have a leading zero byte (i.e. length < 32), the remaining bytes in that 32-byte slot stayed zero, so the precompile saw a shifted value and verification failed.

Since `k` is random, roughly 50% of signatures produce an `r` or `s` shorter than 32 bytes, making the test flake about 75% of the time.

### Changes
- Replace all `copy(..., someInt.Bytes())` calls in `signMsg` with `common.LeftPadBytes(..., 32)` (or an equivalent manual left-zero-pad).
- Ensure each of the five 32-byte fields (hash, r, s, pub.X, pub.Y) is right-aligned within its slot.

Closes: #273

---

## Author Checklist

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.

I have...

- [ ] tackled an existing issue or discussed with a team member
- [ ] left instructions on how to review the changes
- [ ] targeted the `main` branch

## Reviewers Checklist

**All** items are required.
Please add a note if the item is not applicable
and please add your handle next to the items reviewed
if you only reviewed selected items.

I have...

- [ ] added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] confirmed all author checklist items have been addressed
- [ ] confirmed that this PR does not change production code
- [ ] reviewed content
- [ ] tested instructions (if applicable)
- [ ] confirmed all CI checks have passed
