### PR TITLE
fix: use address codecs in precompiles

### DIFF
--- a/evmd/precompiles.go
+++ b/evmd/precompiles.go
@@ -35,7 +35,7 @@ import (
 )
 
 // Optionals define some optional params that can be applied to _some_ precompiles.
-// Extend this struct, add a sane default to DefaultOptionals, and an Option function to provide users with a non-breaking
+// Extend this struct, add a sane default to defaultOptionals, and an Option function to provide users with a non-breaking
 // way to provide custom args to certain precompiles.
 type Optionals struct {
 	AddressCodec       address.Codec // used by gov/staking
@@ -43,7 +43,7 @@ type Optionals struct {
 	ConsensusAddrCodec address.Codec // used by slashing
 }
 
-func DefaultOptionals() Optionals {
+func defaultOptionals() Optionals {
 	return Optionals{
 		AddressCodec:       addresscodec.NewBech32Codec(sdk.GetConfig().GetBech32AccountAddrPrefix()),
 		ValidatorAddrCodec: addresscodec.NewBech32Codec(sdk.GetConfig().GetBech32ValidatorAddrPrefix()),
@@ -90,7 +90,7 @@ func NewAvailableStaticPrecompiles(
 	codec codec.Codec,
 	opts ...Option,
 ) map[common.Address]vm.PrecompiledContract {
-	options := DefaultOptionals()
+	options := defaultOptionals()
 	for _, opt := range opts {
 		opt(&options)
 	}

--- a/evmd/precompiles.go
+++ b/evmd/precompiles.go
@@ -34,10 +34,13 @@ import (
 	stakingkeeper "github.com/cosmos/cosmos-sdk/x/staking/keeper"
 )
 
+// Optionals define some optional params that can be applied to _some_ precompiles.
+// Extend this struct, add a sane default to DefaultOptionals, and an Option function to provide users with a non-breaking
+// way to provide custom args to certain precompiles.
 type Optionals struct {
-	AddressCodec       address.Codec
-	ValidatorAddrCodec address.Codec
-	ConsensusAddrCodec address.Codec
+	AddressCodec       address.Codec // used by gov/staking
+	ValidatorAddrCodec address.Codec // used by slashing
+	ConsensusAddrCodec address.Codec // used by slashing
 }
 
 func DefaultOptionals() Optionals {

--- a/evmd/precompiles.go
+++ b/evmd/precompiles.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"maps"
 
+	addresscodec "github.com/cosmos/cosmos-sdk/codec/address"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/vm"
 
@@ -22,6 +24,7 @@ import (
 	evmkeeper "github.com/cosmos/evm/x/vm/keeper"
 	channelkeeper "github.com/cosmos/ibc-go/v10/modules/core/04-channel/keeper"
 
+	"cosmossdk.io/core/address"
 	evidencekeeper "cosmossdk.io/x/evidence/keeper"
 
 	"github.com/cosmos/cosmos-sdk/codec"
@@ -30,6 +33,40 @@ import (
 	slashingkeeper "github.com/cosmos/cosmos-sdk/x/slashing/keeper"
 	stakingkeeper "github.com/cosmos/cosmos-sdk/x/staking/keeper"
 )
+
+type Optionals struct {
+	AddressCodec       address.Codec
+	ValidatorAddrCodec address.Codec
+	ConsensusAddrCodec address.Codec
+}
+
+func DefaultOptionals() Optionals {
+	return Optionals{
+		AddressCodec:       addresscodec.NewBech32Codec(sdk.GetConfig().GetBech32AccountAddrPrefix()),
+		ValidatorAddrCodec: addresscodec.NewBech32Codec(sdk.GetConfig().GetBech32ValidatorAddrPrefix()),
+		ConsensusAddrCodec: addresscodec.NewBech32Codec(sdk.GetConfig().GetBech32ConsensusAddrPrefix()),
+	}
+}
+
+type Option func(opts *Optionals)
+
+func WithAddressCodec(codec address.Codec) Option {
+	return func(opts *Optionals) {
+		opts.AddressCodec = codec
+	}
+}
+
+func WithValidatorAddrCodec(codec address.Codec) Option {
+	return func(opts *Optionals) {
+		opts.ValidatorAddrCodec = codec
+	}
+}
+
+func WithConsensusAddrCodec(codec address.Codec) Option {
+	return func(opts *Optionals) {
+		opts.ConsensusAddrCodec = codec
+	}
+}
 
 const bech32PrecompileBaseGas = 6_000
 
@@ -48,7 +85,12 @@ func NewAvailableStaticPrecompiles(
 	slashingKeeper slashingkeeper.Keeper,
 	evidenceKeeper evidencekeeper.Keeper,
 	codec codec.Codec,
+	opts ...Option,
 ) map[common.Address]vm.PrecompiledContract {
+	options := DefaultOptionals()
+	for _, opt := range opts {
+		opt(&options)
+	}
 	// Clone the mapping from the latest EVM fork.
 	precompiles := maps.Clone(vm.PrecompiledContractsBerlin)
 
@@ -60,7 +102,7 @@ func NewAvailableStaticPrecompiles(
 		panic(fmt.Errorf("failed to instantiate bech32 precompile: %w", err))
 	}
 
-	stakingPrecompile, err := stakingprecompile.NewPrecompile(stakingKeeper)
+	stakingPrecompile, err := stakingprecompile.NewPrecompile(stakingKeeper, options.AddressCodec)
 	if err != nil {
 		panic(fmt.Errorf("failed to instantiate staking precompile: %w", err))
 	}
@@ -69,6 +111,7 @@ func NewAvailableStaticPrecompiles(
 		distributionKeeper,
 		stakingKeeper,
 		evmKeeper,
+		options.AddressCodec,
 	)
 	if err != nil {
 		panic(fmt.Errorf("failed to instantiate distribution precompile: %w", err))
@@ -90,12 +133,12 @@ func NewAvailableStaticPrecompiles(
 		panic(fmt.Errorf("failed to instantiate bank precompile: %w", err))
 	}
 
-	govPrecompile, err := govprecompile.NewPrecompile(govKeeper, codec)
+	govPrecompile, err := govprecompile.NewPrecompile(govKeeper, codec, options.AddressCodec)
 	if err != nil {
 		panic(fmt.Errorf("failed to instantiate gov precompile: %w", err))
 	}
 
-	slashingPrecompile, err := slashingprecompile.NewPrecompile(slashingKeeper)
+	slashingPrecompile, err := slashingprecompile.NewPrecompile(slashingKeeper, options.ValidatorAddrCodec, options.ConsensusAddrCodec)
 	if err != nil {
 		panic(fmt.Errorf("failed to instantiate slashing precompile: %w", err))
 	}

--- a/precompiles/distribution/distribution.go
+++ b/precompiles/distribution/distribution.go
@@ -16,8 +16,6 @@ import (
 	"cosmossdk.io/core/address"
 	storetypes "cosmossdk.io/store/types"
 
-	addresscodec "github.com/cosmos/cosmos-sdk/codec/address"
-	sdk "github.com/cosmos/cosmos-sdk/types"
 	distributionkeeper "github.com/cosmos/cosmos-sdk/x/distribution/keeper"
 	stakingkeeper "github.com/cosmos/cosmos-sdk/x/staking/keeper"
 )
@@ -44,6 +42,7 @@ func NewPrecompile(
 	distributionKeeper distributionkeeper.Keeper,
 	stakingKeeper stakingkeeper.Keeper,
 	evmKeeper *evmkeeper.Keeper,
+	addrCdc address.Codec,
 ) (*Precompile, error) {
 	newAbi, err := cmn.LoadABI(f, "abi.json")
 	if err != nil {
@@ -59,7 +58,7 @@ func NewPrecompile(
 		stakingKeeper:      stakingKeeper,
 		distributionKeeper: distributionKeeper,
 		evmKeeper:          evmKeeper,
-		addrCdc:            addresscodec.NewBech32Codec(sdk.GetConfig().GetBech32AccountAddrPrefix()),
+		addrCdc:            addrCdc,
 	}
 
 	// SetAddress defines the address of the distribution compile contract.

--- a/precompiles/distribution/distribution.go
+++ b/precompiles/distribution/distribution.go
@@ -4,6 +4,8 @@ import (
 	"embed"
 	"fmt"
 
+	addresscodec "github.com/cosmos/cosmos-sdk/codec/address"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/tracing"
@@ -13,6 +15,7 @@ import (
 	evmkeeper "github.com/cosmos/evm/x/vm/keeper"
 	evmtypes "github.com/cosmos/evm/x/vm/types"
 
+	"cosmossdk.io/core/address"
 	storetypes "cosmossdk.io/store/types"
 
 	distributionkeeper "github.com/cosmos/cosmos-sdk/x/distribution/keeper"
@@ -32,6 +35,7 @@ type Precompile struct {
 	distributionKeeper distributionkeeper.Keeper
 	stakingKeeper      stakingkeeper.Keeper
 	evmKeeper          *evmkeeper.Keeper
+	addrCdc            address.Codec
 }
 
 // NewPrecompile creates a new distribution Precompile instance as a
@@ -55,6 +59,7 @@ func NewPrecompile(
 		stakingKeeper:      stakingKeeper,
 		distributionKeeper: distributionKeeper,
 		evmKeeper:          evmKeeper,
+		addrCdc:            addresscodec.NewBech32Codec(sdk.GetConfig().GetBech32AccountAddrPrefix()),
 	}
 
 	// SetAddress defines the address of the distribution compile contract.

--- a/precompiles/distribution/distribution.go
+++ b/precompiles/distribution/distribution.go
@@ -4,8 +4,6 @@ import (
 	"embed"
 	"fmt"
 
-	addresscodec "github.com/cosmos/cosmos-sdk/codec/address"
-	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/tracing"
@@ -18,6 +16,8 @@ import (
 	"cosmossdk.io/core/address"
 	storetypes "cosmossdk.io/store/types"
 
+	addresscodec "github.com/cosmos/cosmos-sdk/codec/address"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	distributionkeeper "github.com/cosmos/cosmos-sdk/x/distribution/keeper"
 	stakingkeeper "github.com/cosmos/cosmos-sdk/x/staking/keeper"
 )

--- a/precompiles/distribution/query.go
+++ b/precompiles/distribution/query.go
@@ -139,7 +139,7 @@ func (p Precompile) DelegationRewards(
 	method *abi.Method,
 	args []interface{},
 ) ([]byte, error) {
-	req, err := NewDelegationRewardsRequest(args)
+	req, err := NewDelegationRewardsRequest(args, p.addrCdc)
 	if err != nil {
 		return nil, err
 	}
@@ -160,7 +160,7 @@ func (p Precompile) DelegationTotalRewards(
 	method *abi.Method,
 	args []interface{},
 ) ([]byte, error) {
-	req, err := NewDelegationTotalRewardsRequest(args)
+	req, err := NewDelegationTotalRewardsRequest(args, p.addrCdc)
 	if err != nil {
 		return nil, err
 	}
@@ -184,7 +184,7 @@ func (p Precompile) DelegatorValidators(
 	method *abi.Method,
 	args []interface{},
 ) ([]byte, error) {
-	req, err := NewDelegatorValidatorsRequest(args)
+	req, err := NewDelegatorValidatorsRequest(args, p.addrCdc)
 	if err != nil {
 		return nil, err
 	}
@@ -206,7 +206,7 @@ func (p Precompile) DelegatorWithdrawAddress(
 	method *abi.Method,
 	args []interface{},
 ) ([]byte, error) {
-	req, err := NewDelegatorWithdrawAddressRequest(args)
+	req, err := NewDelegatorWithdrawAddressRequest(args, p.addrCdc)
 	if err != nil {
 		return nil, err
 	}

--- a/precompiles/distribution/tx.go
+++ b/precompiles/distribution/tx.go
@@ -93,7 +93,7 @@ func (p Precompile) SetWithdrawAddress(
 	method *abi.Method,
 	args []interface{},
 ) ([]byte, error) {
-	msg, delegatorHexAddr, err := NewMsgSetWithdrawAddress(args)
+	msg, delegatorHexAddr, err := NewMsgSetWithdrawAddress(args, p.addrCdc)
 	if err != nil {
 		return nil, err
 	}
@@ -123,7 +123,7 @@ func (p *Precompile) WithdrawDelegatorReward(
 	method *abi.Method,
 	args []interface{},
 ) ([]byte, error) {
-	msg, delegatorHexAddr, err := NewMsgWithdrawDelegatorReward(args)
+	msg, delegatorHexAddr, err := NewMsgWithdrawDelegatorReward(args, p.addrCdc)
 	if err != nil {
 		return nil, err
 	}
@@ -185,7 +185,7 @@ func (p *Precompile) FundCommunityPool(
 	method *abi.Method,
 	args []interface{},
 ) ([]byte, error) {
-	msg, depositorHexAddr, err := NewMsgFundCommunityPool(args)
+	msg, depositorHexAddr, err := NewMsgFundCommunityPool(args, p.addrCdc)
 	if err != nil {
 		return nil, err
 	}
@@ -217,7 +217,7 @@ func (p *Precompile) DepositValidatorRewardsPool(
 	method *abi.Method,
 	args []interface{},
 ) ([]byte, error) {
-	msg, depositorHexAddr, err := NewMsgDepositValidatorRewardsPool(args)
+	msg, depositorHexAddr, err := NewMsgDepositValidatorRewardsPool(args, p.addrCdc)
 	if err != nil {
 		return nil, err
 	}

--- a/precompiles/distribution/types.go
+++ b/precompiles/distribution/types.go
@@ -101,7 +101,7 @@ func NewMsgSetWithdrawAddress(args []interface{}, addrCdc address.Codec) (*distr
 
 	delAddr, err := addrCdc.BytesToString(delegatorAddress.Bytes())
 	if err != nil {
-		return nil, [20]byte{}, fmt.Errorf("failed to decode delegator address: %w", err)
+		return nil, common.Address{}, fmt.Errorf("failed to decode delegator address: %w", err)
 	}
 	msg := &distributiontypes.MsgSetWithdrawAddress{
 		DelegatorAddress: delAddr,
@@ -126,7 +126,7 @@ func NewMsgWithdrawDelegatorReward(args []interface{}, addrCdc address.Codec) (*
 
 	delAddr, err := addrCdc.BytesToString(delegatorAddress.Bytes())
 	if err != nil {
-		return nil, [20]byte{}, fmt.Errorf("failed to decode delegator address: %w", err)
+		return nil, common.Address{}, fmt.Errorf("failed to decode delegator address: %w", err)
 	}
 	msg := &distributiontypes.MsgWithdrawDelegatorReward{
 		DelegatorAddress: delAddr,
@@ -180,7 +180,7 @@ func NewMsgFundCommunityPool(args []interface{}, addrCdc address.Codec) (*distri
 
 	depAddr, err := addrCdc.BytesToString(depositorAddress.Bytes())
 	if err != nil {
-		return nil, [20]byte{}, fmt.Errorf("failed to decode depositor address: %w", err)
+		return nil, common.Address{}, fmt.Errorf("failed to decode depositor address: %w", err)
 	}
 	msg := &distributiontypes.MsgFundCommunityPool{
 		Depositor: depAddr,

--- a/precompiles/distribution/types.go
+++ b/precompiles/distribution/types.go
@@ -10,6 +10,7 @@ import (
 	cmn "github.com/cosmos/evm/precompiles/common"
 	"github.com/cosmos/evm/utils"
 
+	"cosmossdk.io/core/address"
 	"cosmossdk.io/math"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -77,7 +78,7 @@ func parseClaimRewardsArgs(args []interface{}) (common.Address, uint32, error) {
 }
 
 // NewMsgSetWithdrawAddress creates a new MsgSetWithdrawAddress instance.
-func NewMsgSetWithdrawAddress(args []interface{}) (*distributiontypes.MsgSetWithdrawAddress, common.Address, error) {
+func NewMsgSetWithdrawAddress(args []interface{}, addrCdc address.Codec) (*distributiontypes.MsgSetWithdrawAddress, common.Address, error) {
 	if len(args) != 2 {
 		return nil, common.Address{}, fmt.Errorf(cmn.ErrInvalidNumberOfArgs, 2, len(args))
 	}
@@ -98,8 +99,12 @@ func NewMsgSetWithdrawAddress(args []interface{}) (*distributiontypes.MsgSetWith
 		}
 	}
 
+	delAddr, err := addrCdc.BytesToString(delegatorAddress.Bytes())
+	if err != nil {
+		return nil, [20]byte{}, fmt.Errorf("failed to decode delegator address: %w", err)
+	}
 	msg := &distributiontypes.MsgSetWithdrawAddress{
-		DelegatorAddress: sdk.AccAddress(delegatorAddress.Bytes()).String(),
+		DelegatorAddress: delAddr,
 		WithdrawAddress:  withdrawerAddress,
 	}
 
@@ -107,7 +112,7 @@ func NewMsgSetWithdrawAddress(args []interface{}) (*distributiontypes.MsgSetWith
 }
 
 // NewMsgWithdrawDelegatorReward creates a new MsgWithdrawDelegatorReward instance.
-func NewMsgWithdrawDelegatorReward(args []interface{}) (*distributiontypes.MsgWithdrawDelegatorReward, common.Address, error) {
+func NewMsgWithdrawDelegatorReward(args []interface{}, addrCdc address.Codec) (*distributiontypes.MsgWithdrawDelegatorReward, common.Address, error) {
 	if len(args) != 2 {
 		return nil, common.Address{}, fmt.Errorf(cmn.ErrInvalidNumberOfArgs, 2, len(args))
 	}
@@ -119,8 +124,12 @@ func NewMsgWithdrawDelegatorReward(args []interface{}) (*distributiontypes.MsgWi
 
 	validatorAddress, _ := args[1].(string)
 
+	delAddr, err := addrCdc.BytesToString(delegatorAddress.Bytes())
+	if err != nil {
+		return nil, [20]byte{}, fmt.Errorf("failed to decode delegator address: %w", err)
+	}
 	msg := &distributiontypes.MsgWithdrawDelegatorReward{
-		DelegatorAddress: sdk.AccAddress(delegatorAddress.Bytes()).String(),
+		DelegatorAddress: delAddr,
 		ValidatorAddress: validatorAddress,
 	}
 
@@ -148,7 +157,7 @@ func NewMsgWithdrawValidatorCommission(args []interface{}) (*distributiontypes.M
 }
 
 // NewMsgFundCommunityPool creates a new NewMsgFundCommunityPool message.
-func NewMsgFundCommunityPool(args []interface{}) (*distributiontypes.MsgFundCommunityPool, common.Address, error) {
+func NewMsgFundCommunityPool(args []interface{}, addrCdc address.Codec) (*distributiontypes.MsgFundCommunityPool, common.Address, error) {
 	emptyAddr := common.Address{}
 	if len(args) != 2 {
 		return nil, emptyAddr, fmt.Errorf(cmn.ErrInvalidNumberOfArgs, 2, len(args))
@@ -169,8 +178,12 @@ func NewMsgFundCommunityPool(args []interface{}) (*distributiontypes.MsgFundComm
 		return nil, emptyAddr, fmt.Errorf(ErrInvalidAmount, "amount arg")
 	}
 
+	depAddr, err := addrCdc.BytesToString(depositorAddress.Bytes())
+	if err != nil {
+		return nil, [20]byte{}, fmt.Errorf("failed to decode depositor address: %w", err)
+	}
 	msg := &distributiontypes.MsgFundCommunityPool{
-		Depositor: sdk.AccAddress(depositorAddress.Bytes()).String(),
+		Depositor: depAddr,
 		Amount:    amt,
 	}
 
@@ -178,7 +191,7 @@ func NewMsgFundCommunityPool(args []interface{}) (*distributiontypes.MsgFundComm
 }
 
 // NewMsgDepositValidatorRewardsPool creates a new MsgDepositValidatorRewardsPool message.
-func NewMsgDepositValidatorRewardsPool(args []interface{}) (*distributiontypes.MsgDepositValidatorRewardsPool, common.Address, error) {
+func NewMsgDepositValidatorRewardsPool(args []interface{}, addrCdc address.Codec) (*distributiontypes.MsgDepositValidatorRewardsPool, common.Address, error) {
 	if len(args) != 3 {
 		return nil, common.Address{}, fmt.Errorf(cmn.ErrInvalidNumberOfArgs, 3, len(args))
 	}
@@ -200,8 +213,13 @@ func NewMsgDepositValidatorRewardsPool(args []interface{}) (*distributiontypes.M
 		return nil, common.Address{}, fmt.Errorf(cmn.ErrInvalidAmount, err.Error())
 	}
 
+	depAddr, err := addrCdc.BytesToString(depositorAddress.Bytes())
+	if err != nil {
+		return nil, common.Address{}, fmt.Errorf("failed to decode depositor address: %w", err)
+	}
+
 	msg := &distributiontypes.MsgDepositValidatorRewardsPool{
-		Depositor:        sdk.AccAddress(depositorAddress.Bytes()).String(),
+		Depositor:        depAddr,
 		ValidatorAddress: validatorAddress,
 		Amount:           amount,
 	}
@@ -280,7 +298,7 @@ func NewValidatorSlashesRequest(method *abi.Method, args []interface{}) (*distri
 
 // NewDelegationRewardsRequest creates a new QueryDelegationRewardsRequest  instance and does sanity
 // checks on the provided arguments.
-func NewDelegationRewardsRequest(args []interface{}) (*distributiontypes.QueryDelegationRewardsRequest, error) {
+func NewDelegationRewardsRequest(args []interface{}, addrCdc address.Codec) (*distributiontypes.QueryDelegationRewardsRequest, error) {
 	if len(args) != 2 {
 		return nil, fmt.Errorf(cmn.ErrInvalidNumberOfArgs, 2, len(args))
 	}
@@ -292,15 +310,19 @@ func NewDelegationRewardsRequest(args []interface{}) (*distributiontypes.QueryDe
 
 	validatorAddress, _ := args[1].(string)
 
+	delAddr, err := addrCdc.BytesToString(delegatorAddress.Bytes())
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode delegator address: %w", err)
+	}
 	return &distributiontypes.QueryDelegationRewardsRequest{
-		DelegatorAddress: sdk.AccAddress(delegatorAddress.Bytes()).String(),
+		DelegatorAddress: delAddr,
 		ValidatorAddress: validatorAddress,
 	}, nil
 }
 
 // NewDelegationTotalRewardsRequest creates a new QueryDelegationTotalRewardsRequest  instance and does sanity
 // checks on the provided arguments.
-func NewDelegationTotalRewardsRequest(args []interface{}) (*distributiontypes.QueryDelegationTotalRewardsRequest, error) {
+func NewDelegationTotalRewardsRequest(args []interface{}, addrCdc address.Codec) (*distributiontypes.QueryDelegationTotalRewardsRequest, error) {
 	if len(args) != 1 {
 		return nil, fmt.Errorf(cmn.ErrInvalidNumberOfArgs, 1, len(args))
 	}
@@ -310,14 +332,18 @@ func NewDelegationTotalRewardsRequest(args []interface{}) (*distributiontypes.Qu
 		return nil, fmt.Errorf(cmn.ErrInvalidDelegator, args[0])
 	}
 
+	delAddr, err := addrCdc.BytesToString(delegatorAddress.Bytes())
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode delegator address: %w", err)
+	}
 	return &distributiontypes.QueryDelegationTotalRewardsRequest{
-		DelegatorAddress: sdk.AccAddress(delegatorAddress.Bytes()).String(),
+		DelegatorAddress: delAddr,
 	}, nil
 }
 
 // NewDelegatorValidatorsRequest creates a new QueryDelegatorValidatorsRequest  instance and does sanity
 // checks on the provided arguments.
-func NewDelegatorValidatorsRequest(args []interface{}) (*distributiontypes.QueryDelegatorValidatorsRequest, error) {
+func NewDelegatorValidatorsRequest(args []interface{}, addrCdc address.Codec) (*distributiontypes.QueryDelegatorValidatorsRequest, error) {
 	if len(args) != 1 {
 		return nil, fmt.Errorf(cmn.ErrInvalidNumberOfArgs, 1, len(args))
 	}
@@ -327,14 +353,18 @@ func NewDelegatorValidatorsRequest(args []interface{}) (*distributiontypes.Query
 		return nil, fmt.Errorf(cmn.ErrInvalidDelegator, args[0])
 	}
 
+	delAddr, err := addrCdc.BytesToString(delegatorAddress.Bytes())
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode delegator address: %w", err)
+	}
 	return &distributiontypes.QueryDelegatorValidatorsRequest{
-		DelegatorAddress: sdk.AccAddress(delegatorAddress.Bytes()).String(),
+		DelegatorAddress: delAddr,
 	}, nil
 }
 
 // NewDelegatorWithdrawAddressRequest creates a new QueryDelegatorWithdrawAddressRequest  instance and does sanity
 // checks on the provided arguments.
-func NewDelegatorWithdrawAddressRequest(args []interface{}) (*distributiontypes.QueryDelegatorWithdrawAddressRequest, error) {
+func NewDelegatorWithdrawAddressRequest(args []interface{}, addrCdc address.Codec) (*distributiontypes.QueryDelegatorWithdrawAddressRequest, error) {
 	if len(args) != 1 {
 		return nil, fmt.Errorf(cmn.ErrInvalidNumberOfArgs, 1, len(args))
 	}
@@ -344,8 +374,12 @@ func NewDelegatorWithdrawAddressRequest(args []interface{}) (*distributiontypes.
 		return nil, fmt.Errorf(cmn.ErrInvalidDelegator, args[0])
 	}
 
+	delAddr, err := addrCdc.BytesToString(delegatorAddress.Bytes())
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode delegator address: %w", err)
+	}
 	return &distributiontypes.QueryDelegatorWithdrawAddressRequest{
-		DelegatorAddress: sdk.AccAddress(delegatorAddress.Bytes()).String(),
+		DelegatorAddress: delAddr,
 	}, nil
 }
 

--- a/precompiles/distribution/types_test.go
+++ b/precompiles/distribution/types_test.go
@@ -5,12 +5,16 @@ import (
 	"math/big"
 	"testing"
 
-	sdk "github.com/cosmos/cosmos-sdk/types"
-	authcodec "github.com/cosmos/cosmos-sdk/x/auth/codec"
-	cmn "github.com/cosmos/evm/precompiles/common"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
+
+	cmn "github.com/cosmos/evm/precompiles/common"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	authcodec "github.com/cosmos/cosmos-sdk/x/auth/codec"
 )
+
+const validatorAddr = "cosmosvaloper1qypqxpq9qcrsszg2pvxq6rs0zqg3yyc5a3kaax"
 
 func TestNewMsgSetWithdrawAddress(t *testing.T) {
 	addrCodec := authcodec.NewBech32Codec(sdk.GetConfig().GetBech32AccountAddrPrefix())
@@ -99,7 +103,6 @@ func TestNewMsgWithdrawDelegatorReward(t *testing.T) {
 	addrCodec := authcodec.NewBech32Codec(sdk.GetConfig().GetBech32AccountAddrPrefix())
 
 	delegatorAddr := common.HexToAddress("0x1234567890123456789012345678901234567890")
-	validatorAddr := "cosmosvaloper1qypqxpq9qcrsszg2pvxq6rs0zqg3yyc5a3kaax"
 
 	expectedDelegatorAddr, err := addrCodec.BytesToString(delegatorAddr.Bytes())
 	require.NoError(t, err)
@@ -229,7 +232,6 @@ func TestNewMsgDepositValidatorRewardsPool(t *testing.T) {
 	addrCodec := authcodec.NewBech32Codec(sdk.GetConfig().GetBech32AccountAddrPrefix())
 
 	depositorAddr := common.HexToAddress("0x1234567890123456789012345678901234567890")
-	validatorAddr := "cosmosvaloper1qypqxpq9qcrsszg2pvxq6rs0zqg3yyc5a3kaax"
 	validCoins := []cmn.Coin{{Denom: "stake", Amount: big.NewInt(1000)}}
 
 	expectedDepositorAddr, err := addrCodec.BytesToString(depositorAddr.Bytes())
@@ -300,7 +302,6 @@ func TestNewDelegationRewardsRequest(t *testing.T) {
 	addrCodec := authcodec.NewBech32Codec(sdk.GetConfig().GetBech32AccountAddrPrefix())
 
 	delegatorAddr := common.HexToAddress("0x1234567890123456789012345678901234567890")
-	validatorAddr := "cosmosvaloper1qypqxpq9qcrsszg2pvxq6rs0zqg3yyc5a3kaax"
 
 	expectedDelegatorAddr, err := addrCodec.BytesToString(delegatorAddr.Bytes())
 	require.NoError(t, err)

--- a/precompiles/distribution/types_test.go
+++ b/precompiles/distribution/types_test.go
@@ -1,0 +1,533 @@
+package distribution
+
+import (
+	"fmt"
+	"math/big"
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	authcodec "github.com/cosmos/cosmos-sdk/x/auth/codec"
+	cmn "github.com/cosmos/evm/precompiles/common"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewMsgSetWithdrawAddress(t *testing.T) {
+	addrCodec := authcodec.NewBech32Codec(sdk.GetConfig().GetBech32AccountAddrPrefix())
+
+	delegatorAddr := common.HexToAddress("0x1234567890123456789012345678901234567890")
+	withdrawerBech32 := "cosmos1qypqxpq9qcrsszg2pvxq6rs0zqg3yyc5lzv7xu"
+	withdrawerHex := "0xABCDEF1234567890123456789012345678901234"
+
+	expectedDelegatorAddr, err := addrCodec.BytesToString(delegatorAddr.Bytes())
+	require.NoError(t, err)
+
+	expectedWithdrawerFromHex, err := sdk.Bech32ifyAddressBytes(
+		sdk.GetConfig().GetBech32AccountAddrPrefix(),
+		common.HexToAddress(withdrawerHex).Bytes(),
+	)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name           string
+		args           []interface{}
+		wantErr        bool
+		errMsg         string
+		wantDelegator  string
+		wantWithdrawer string
+	}{
+		{
+			name:           "valid with bech32 withdrawer",
+			args:           []interface{}{delegatorAddr, withdrawerBech32},
+			wantErr:        false,
+			wantDelegator:  expectedDelegatorAddr,
+			wantWithdrawer: withdrawerBech32,
+		},
+		{
+			name:           "valid with hex withdrawer",
+			args:           []interface{}{delegatorAddr, withdrawerHex},
+			wantErr:        false,
+			wantDelegator:  expectedDelegatorAddr,
+			wantWithdrawer: expectedWithdrawerFromHex,
+		},
+		{
+			name:    "no arguments",
+			args:    []interface{}{},
+			wantErr: true,
+			errMsg:  fmt.Sprintf(cmn.ErrInvalidNumberOfArgs, 2, 0),
+		},
+		{
+			name:    "too many arguments",
+			args:    []interface{}{delegatorAddr, withdrawerBech32, "extra"},
+			wantErr: true,
+			errMsg:  fmt.Sprintf(cmn.ErrInvalidNumberOfArgs, 2, 3),
+		},
+		{
+			name:    "invalid delegator type",
+			args:    []interface{}{"not-an-address", withdrawerBech32},
+			wantErr: true,
+			errMsg:  fmt.Sprintf(cmn.ErrInvalidDelegator, "not-an-address"),
+		},
+		{
+			name:    "empty delegator address",
+			args:    []interface{}{common.Address{}, withdrawerBech32},
+			wantErr: true,
+			errMsg:  fmt.Sprintf(cmn.ErrInvalidDelegator, common.Address{}),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg, returnAddr, err := NewMsgSetWithdrawAddress(tt.args, addrCodec)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.errMsg)
+				require.Nil(t, msg)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, msg)
+				require.Equal(t, delegatorAddr, returnAddr)
+				require.Equal(t, tt.wantDelegator, msg.DelegatorAddress)
+				require.Equal(t, tt.wantWithdrawer, msg.WithdrawAddress)
+			}
+		})
+	}
+}
+
+func TestNewMsgWithdrawDelegatorReward(t *testing.T) {
+	addrCodec := authcodec.NewBech32Codec(sdk.GetConfig().GetBech32AccountAddrPrefix())
+
+	delegatorAddr := common.HexToAddress("0x1234567890123456789012345678901234567890")
+	validatorAddr := "cosmosvaloper1qypqxpq9qcrsszg2pvxq6rs0zqg3yyc5a3kaax"
+
+	expectedDelegatorAddr, err := addrCodec.BytesToString(delegatorAddr.Bytes())
+	require.NoError(t, err)
+
+	tests := []struct {
+		name          string
+		args          []interface{}
+		wantErr       bool
+		errMsg        string
+		wantDelegator string
+		wantValidator string
+	}{
+		{
+			name:          "valid",
+			args:          []interface{}{delegatorAddr, validatorAddr},
+			wantErr:       false,
+			wantDelegator: expectedDelegatorAddr,
+			wantValidator: validatorAddr,
+		},
+		{
+			name:    "no arguments",
+			args:    []interface{}{},
+			wantErr: true,
+			errMsg:  fmt.Sprintf(cmn.ErrInvalidNumberOfArgs, 2, 0),
+		},
+		{
+			name:    "invalid delegator type",
+			args:    []interface{}{"not-an-address", validatorAddr},
+			wantErr: true,
+			errMsg:  fmt.Sprintf(cmn.ErrInvalidDelegator, "not-an-address"),
+		},
+		{
+			name:    "empty delegator address",
+			args:    []interface{}{common.Address{}, validatorAddr},
+			wantErr: true,
+			errMsg:  fmt.Sprintf(cmn.ErrInvalidDelegator, common.Address{}),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg, returnAddr, err := NewMsgWithdrawDelegatorReward(tt.args, addrCodec)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.errMsg)
+				require.Nil(t, msg)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, msg)
+				require.Equal(t, delegatorAddr, returnAddr)
+				require.Equal(t, tt.wantDelegator, msg.DelegatorAddress)
+				require.Equal(t, tt.wantValidator, msg.ValidatorAddress)
+			}
+		})
+	}
+}
+
+func TestNewMsgFundCommunityPool(t *testing.T) {
+	addrCodec := authcodec.NewBech32Codec(sdk.GetConfig().GetBech32AccountAddrPrefix())
+
+	depositorAddr := common.HexToAddress("0x1234567890123456789012345678901234567890")
+	validCoins := []cmn.Coin{{Denom: "stake", Amount: big.NewInt(1000)}}
+
+	expectedDepositorAddr, err := addrCodec.BytesToString(depositorAddr.Bytes())
+	require.NoError(t, err)
+
+	tests := []struct {
+		name          string
+		args          []interface{}
+		wantErr       bool
+		errMsg        string
+		wantDepositor string
+	}{
+		{
+			name:          "valid",
+			args:          []interface{}{depositorAddr, validCoins},
+			wantErr:       false,
+			wantDepositor: expectedDepositorAddr,
+		},
+		{
+			name:    "no arguments",
+			args:    []interface{}{},
+			wantErr: true,
+			errMsg:  fmt.Sprintf(cmn.ErrInvalidNumberOfArgs, 2, 0),
+		},
+		{
+			name:    "invalid depositor type",
+			args:    []interface{}{"not-an-address", validCoins},
+			wantErr: true,
+			errMsg:  fmt.Sprintf(cmn.ErrInvalidHexAddress, "not-an-address"),
+		},
+		{
+			name:    "empty depositor address",
+			args:    []interface{}{common.Address{}, validCoins},
+			wantErr: true,
+			errMsg:  fmt.Sprintf(cmn.ErrInvalidHexAddress, common.Address{}),
+		},
+		{
+			name:    "invalid coins",
+			args:    []interface{}{depositorAddr, "invalid-coins"},
+			wantErr: true,
+			errMsg:  fmt.Sprintf(ErrInvalidAmount, "amount arg"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg, returnAddr, err := NewMsgFundCommunityPool(tt.args, addrCodec)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.errMsg)
+				require.Nil(t, msg)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, msg)
+				require.Equal(t, depositorAddr, returnAddr)
+				require.Equal(t, tt.wantDepositor, msg.Depositor)
+				require.NotEmpty(t, msg.Amount)
+			}
+		})
+	}
+}
+
+func TestNewMsgDepositValidatorRewardsPool(t *testing.T) {
+	addrCodec := authcodec.NewBech32Codec(sdk.GetConfig().GetBech32AccountAddrPrefix())
+
+	depositorAddr := common.HexToAddress("0x1234567890123456789012345678901234567890")
+	validatorAddr := "cosmosvaloper1qypqxpq9qcrsszg2pvxq6rs0zqg3yyc5a3kaax"
+	validCoins := []cmn.Coin{{Denom: "stake", Amount: big.NewInt(1000)}}
+
+	expectedDepositorAddr, err := addrCodec.BytesToString(depositorAddr.Bytes())
+	require.NoError(t, err)
+
+	tests := []struct {
+		name          string
+		args          []interface{}
+		wantErr       bool
+		errMsg        string
+		wantDepositor string
+		wantValidator string
+	}{
+		{
+			name:          "valid",
+			args:          []interface{}{depositorAddr, validatorAddr, validCoins},
+			wantErr:       false,
+			wantDepositor: expectedDepositorAddr,
+			wantValidator: validatorAddr,
+		},
+		{
+			name:    "no arguments",
+			args:    []interface{}{},
+			wantErr: true,
+			errMsg:  fmt.Sprintf(cmn.ErrInvalidNumberOfArgs, 3, 0),
+		},
+		{
+			name:    "invalid depositor type",
+			args:    []interface{}{"not-an-address", validatorAddr, validCoins},
+			wantErr: true,
+			errMsg:  fmt.Sprintf(cmn.ErrInvalidHexAddress, "not-an-address"),
+		},
+		{
+			name:    "empty depositor address",
+			args:    []interface{}{common.Address{}, validatorAddr, validCoins},
+			wantErr: true,
+			errMsg:  fmt.Sprintf(cmn.ErrInvalidHexAddress, common.Address{}),
+		},
+		{
+			name:    "invalid coins",
+			args:    []interface{}{depositorAddr, validatorAddr, "invalid-coins"},
+			wantErr: true,
+			errMsg:  fmt.Sprintf(cmn.ErrInvalidAmount, "invalid-coins"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg, returnAddr, err := NewMsgDepositValidatorRewardsPool(tt.args, addrCodec)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.errMsg)
+				require.Nil(t, msg)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, msg)
+				require.Equal(t, depositorAddr, returnAddr)
+				require.Equal(t, tt.wantDepositor, msg.Depositor)
+				require.Equal(t, tt.wantValidator, msg.ValidatorAddress)
+				require.NotEmpty(t, msg.Amount)
+			}
+		})
+	}
+}
+
+func TestNewDelegationRewardsRequest(t *testing.T) {
+	addrCodec := authcodec.NewBech32Codec(sdk.GetConfig().GetBech32AccountAddrPrefix())
+
+	delegatorAddr := common.HexToAddress("0x1234567890123456789012345678901234567890")
+	validatorAddr := "cosmosvaloper1qypqxpq9qcrsszg2pvxq6rs0zqg3yyc5a3kaax"
+
+	expectedDelegatorAddr, err := addrCodec.BytesToString(delegatorAddr.Bytes())
+	require.NoError(t, err)
+
+	tests := []struct {
+		name          string
+		args          []interface{}
+		wantErr       bool
+		errMsg        string
+		wantDelegator string
+		wantValidator string
+	}{
+		{
+			name:          "valid",
+			args:          []interface{}{delegatorAddr, validatorAddr},
+			wantErr:       false,
+			wantDelegator: expectedDelegatorAddr,
+			wantValidator: validatorAddr,
+		},
+		{
+			name:    "no arguments",
+			args:    []interface{}{},
+			wantErr: true,
+			errMsg:  fmt.Sprintf(cmn.ErrInvalidNumberOfArgs, 2, 0),
+		},
+		{
+			name:    "invalid delegator type",
+			args:    []interface{}{"not-an-address", validatorAddr},
+			wantErr: true,
+			errMsg:  fmt.Sprintf(cmn.ErrInvalidDelegator, "not-an-address"),
+		},
+		{
+			name:    "empty delegator address",
+			args:    []interface{}{common.Address{}, validatorAddr},
+			wantErr: true,
+			errMsg:  fmt.Sprintf(cmn.ErrInvalidDelegator, common.Address{}),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, err := NewDelegationRewardsRequest(tt.args, addrCodec)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.errMsg)
+				require.Nil(t, req)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, req)
+				require.Equal(t, tt.wantDelegator, req.DelegatorAddress)
+				require.Equal(t, tt.wantValidator, req.ValidatorAddress)
+			}
+		})
+	}
+}
+
+func TestNewDelegationTotalRewardsRequest(t *testing.T) {
+	addrCodec := authcodec.NewBech32Codec(sdk.GetConfig().GetBech32AccountAddrPrefix())
+
+	delegatorAddr := common.HexToAddress("0x1234567890123456789012345678901234567890")
+
+	expectedDelegatorAddr, err := addrCodec.BytesToString(delegatorAddr.Bytes())
+	require.NoError(t, err)
+
+	tests := []struct {
+		name          string
+		args          []interface{}
+		wantErr       bool
+		errMsg        string
+		wantDelegator string
+	}{
+		{
+			name:          "valid",
+			args:          []interface{}{delegatorAddr},
+			wantErr:       false,
+			wantDelegator: expectedDelegatorAddr,
+		},
+		{
+			name:    "no arguments",
+			args:    []interface{}{},
+			wantErr: true,
+			errMsg:  fmt.Sprintf(cmn.ErrInvalidNumberOfArgs, 1, 0),
+		},
+		{
+			name:    "invalid delegator type",
+			args:    []interface{}{"not-an-address"},
+			wantErr: true,
+			errMsg:  fmt.Sprintf(cmn.ErrInvalidDelegator, "not-an-address"),
+		},
+		{
+			name:    "empty delegator address",
+			args:    []interface{}{common.Address{}},
+			wantErr: true,
+			errMsg:  fmt.Sprintf(cmn.ErrInvalidDelegator, common.Address{}),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, err := NewDelegationTotalRewardsRequest(tt.args, addrCodec)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.errMsg)
+				require.Nil(t, req)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, req)
+				require.Equal(t, tt.wantDelegator, req.DelegatorAddress)
+			}
+		})
+	}
+}
+
+func TestNewDelegatorValidatorsRequest(t *testing.T) {
+	addrCodec := authcodec.NewBech32Codec(sdk.GetConfig().GetBech32AccountAddrPrefix())
+
+	delegatorAddr := common.HexToAddress("0x1234567890123456789012345678901234567890")
+
+	expectedDelegatorAddr, err := addrCodec.BytesToString(delegatorAddr.Bytes())
+	require.NoError(t, err)
+
+	tests := []struct {
+		name          string
+		args          []interface{}
+		wantErr       bool
+		errMsg        string
+		wantDelegator string
+	}{
+		{
+			name:          "valid",
+			args:          []interface{}{delegatorAddr},
+			wantErr:       false,
+			wantDelegator: expectedDelegatorAddr,
+		},
+		{
+			name:    "no arguments",
+			args:    []interface{}{},
+			wantErr: true,
+			errMsg:  fmt.Sprintf(cmn.ErrInvalidNumberOfArgs, 1, 0),
+		},
+		{
+			name:    "invalid delegator type",
+			args:    []interface{}{"not-an-address"},
+			wantErr: true,
+			errMsg:  fmt.Sprintf(cmn.ErrInvalidDelegator, "not-an-address"),
+		},
+		{
+			name:    "empty delegator address",
+			args:    []interface{}{common.Address{}},
+			wantErr: true,
+			errMsg:  fmt.Sprintf(cmn.ErrInvalidDelegator, common.Address{}),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, err := NewDelegatorValidatorsRequest(tt.args, addrCodec)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.errMsg)
+				require.Nil(t, req)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, req)
+				require.Equal(t, tt.wantDelegator, req.DelegatorAddress)
+			}
+		})
+	}
+}
+
+func TestNewDelegatorWithdrawAddressRequest(t *testing.T) {
+	addrCodec := authcodec.NewBech32Codec(sdk.GetConfig().GetBech32AccountAddrPrefix())
+
+	delegatorAddr := common.HexToAddress("0x1234567890123456789012345678901234567890")
+
+	expectedDelegatorAddr, err := addrCodec.BytesToString(delegatorAddr.Bytes())
+	require.NoError(t, err)
+
+	tests := []struct {
+		name          string
+		args          []interface{}
+		wantErr       bool
+		errMsg        string
+		wantDelegator string
+	}{
+		{
+			name:          "valid",
+			args:          []interface{}{delegatorAddr},
+			wantErr:       false,
+			wantDelegator: expectedDelegatorAddr,
+		},
+		{
+			name:    "no arguments",
+			args:    []interface{}{},
+			wantErr: true,
+			errMsg:  fmt.Sprintf(cmn.ErrInvalidNumberOfArgs, 1, 0),
+		},
+		{
+			name:    "invalid delegator type",
+			args:    []interface{}{"not-an-address"},
+			wantErr: true,
+			errMsg:  fmt.Sprintf(cmn.ErrInvalidDelegator, "not-an-address"),
+		},
+		{
+			name:    "empty delegator address",
+			args:    []interface{}{common.Address{}},
+			wantErr: true,
+			errMsg:  fmt.Sprintf(cmn.ErrInvalidDelegator, common.Address{}),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, err := NewDelegatorWithdrawAddressRequest(tt.args, addrCodec)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.errMsg)
+				require.Nil(t, req)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, req)
+				require.Equal(t, tt.wantDelegator, req.DelegatorAddress)
+			}
+		})
+	}
+}

--- a/precompiles/gov/gov.go
+++ b/precompiles/gov/gov.go
@@ -4,7 +4,6 @@ import (
 	"embed"
 	"fmt"
 
-	addresscodec "github.com/cosmos/cosmos-sdk/codec/address"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/tracing"
@@ -18,6 +17,7 @@ import (
 	storetypes "cosmossdk.io/store/types"
 
 	"github.com/cosmos/cosmos-sdk/codec"
+	addresscodec "github.com/cosmos/cosmos-sdk/codec/address"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	govkeeper "github.com/cosmos/cosmos-sdk/x/gov/keeper"
 )

--- a/precompiles/gov/gov.go
+++ b/precompiles/gov/gov.go
@@ -17,7 +17,6 @@ import (
 	storetypes "cosmossdk.io/store/types"
 
 	"github.com/cosmos/cosmos-sdk/codec"
-	addresscodec "github.com/cosmos/cosmos-sdk/codec/address"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	govkeeper "github.com/cosmos/cosmos-sdk/x/gov/keeper"
 )
@@ -48,6 +47,7 @@ func LoadABI() (abi.ABI, error) {
 func NewPrecompile(
 	govKeeper govkeeper.Keeper,
 	codec codec.Codec,
+	addrCdc address.Codec,
 ) (*Precompile, error) {
 	abi, err := LoadABI()
 	if err != nil {
@@ -62,7 +62,7 @@ func NewPrecompile(
 		},
 		govKeeper: govKeeper,
 		codec:     codec,
-		addrCdc:   addresscodec.NewBech32Codec(sdk.GetConfig().GetBech32AccountAddrPrefix()),
+		addrCdc:   addrCdc,
 	}
 
 	// SetAddress defines the address of the gov precompiled contract.

--- a/precompiles/gov/gov.go
+++ b/precompiles/gov/gov.go
@@ -4,6 +4,7 @@ import (
 	"embed"
 	"fmt"
 
+	addresscodec "github.com/cosmos/cosmos-sdk/codec/address"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/tracing"
@@ -12,6 +13,7 @@ import (
 	cmn "github.com/cosmos/evm/precompiles/common"
 	evmtypes "github.com/cosmos/evm/x/vm/types"
 
+	"cosmossdk.io/core/address"
 	"cosmossdk.io/log"
 	storetypes "cosmossdk.io/store/types"
 
@@ -32,6 +34,7 @@ type Precompile struct {
 	cmn.Precompile
 	govKeeper govkeeper.Keeper
 	codec     codec.Codec
+	addrCdc   address.Codec
 }
 
 // LoadABI loads the gov ABI from the embedded abi.json file
@@ -59,6 +62,7 @@ func NewPrecompile(
 		},
 		govKeeper: govKeeper,
 		codec:     codec,
+		addrCdc:   addresscodec.NewBech32Codec(sdk.GetConfig().GetBech32AccountAddrPrefix()),
 	}
 
 	// SetAddress defines the address of the gov precompiled contract.

--- a/precompiles/gov/query.go
+++ b/precompiles/gov/query.go
@@ -58,7 +58,7 @@ func (p *Precompile) GetVote(
 	_ *vm.Contract,
 	args []interface{},
 ) ([]byte, error) {
-	queryVotesReq, err := ParseVoteArgs(args)
+	queryVotesReq, err := ParseVoteArgs(args, p.addrCdc)
 	if err != nil {
 		return nil, err
 	}
@@ -81,7 +81,7 @@ func (p *Precompile) GetDeposit(
 	_ *vm.Contract,
 	args []interface{},
 ) ([]byte, error) {
-	queryDepositReq, err := ParseDepositArgs(args)
+	queryDepositReq, err := ParseDepositArgs(args, p.addrCdc)
 	if err != nil {
 		return nil, err
 	}
@@ -169,7 +169,7 @@ func (p *Precompile) GetProposals(
 	_ *vm.Contract,
 	args []interface{},
 ) ([]byte, error) {
-	queryProposalsReq, err := ParseProposalsArgs(method, args)
+	queryProposalsReq, err := ParseProposalsArgs(method, args, p.addrCdc)
 	if err != nil {
 		return nil, err
 	}

--- a/precompiles/gov/tx.go
+++ b/precompiles/gov/tx.go
@@ -33,7 +33,7 @@ func (p *Precompile) SubmitProposal(
 	method *abi.Method,
 	args []interface{},
 ) ([]byte, error) {
-	msg, proposerHexAddr, err := NewMsgSubmitProposal(args, p.codec)
+	msg, proposerHexAddr, err := NewMsgSubmitProposal(args, p.codec, p.addrCdc)
 	if err != nil {
 		return nil, err
 	}
@@ -63,7 +63,7 @@ func (p *Precompile) Deposit(
 	method *abi.Method,
 	args []interface{},
 ) ([]byte, error) {
-	msg, depositorHexAddr, err := NewMsgDeposit(args)
+	msg, depositorHexAddr, err := NewMsgDeposit(args, p.addrCdc)
 	if err != nil {
 		return nil, err
 	}
@@ -92,7 +92,7 @@ func (p *Precompile) CancelProposal(
 	method *abi.Method,
 	args []interface{},
 ) ([]byte, error) {
-	msg, proposerHexAddr, err := NewMsgCancelProposal(args)
+	msg, proposerHexAddr, err := NewMsgCancelProposal(args, p.addrCdc)
 	if err != nil {
 		return nil, err
 	}
@@ -121,7 +121,7 @@ func (p Precompile) Vote(
 	method *abi.Method,
 	args []interface{},
 ) ([]byte, error) {
-	msg, voterHexAddr, err := NewMsgVote(args)
+	msg, voterHexAddr, err := NewMsgVote(args, p.addrCdc)
 	if err != nil {
 		return nil, err
 	}
@@ -151,7 +151,7 @@ func (p Precompile) VoteWeighted(
 	method *abi.Method,
 	args []interface{},
 ) ([]byte, error) {
-	msg, voterHexAddr, options, err := NewMsgVoteWeighted(method, args)
+	msg, voterHexAddr, options, err := NewMsgVoteWeighted(method, args, p.addrCdc)
 	if err != nil {
 		return nil, err
 	}

--- a/precompiles/gov/types.go
+++ b/precompiles/gov/types.go
@@ -10,6 +10,7 @@ import (
 	cmn "github.com/cosmos/evm/precompiles/common"
 	"github.com/cosmos/evm/utils"
 
+	"cosmossdk.io/core/address"
 	sdkerrors "cosmossdk.io/errors"
 
 	"github.com/cosmos/cosmos-sdk/codec"
@@ -112,7 +113,7 @@ type TallyResultData struct {
 
 // NewMsgSubmitProposal constructs a MsgSubmitProposal.
 // args: [proposerAddress, jsonBlob, []cmn.CoinInput deposit]
-func NewMsgSubmitProposal(args []interface{}, cdc codec.Codec) (*govv1.MsgSubmitProposal, common.Address, error) {
+func NewMsgSubmitProposal(args []interface{}, cdc codec.Codec, addrCdc address.Codec) (*govv1.MsgSubmitProposal, common.Address, error) {
 	emptyAddr := common.Address{}
 	// -------------------------------------------------------------------------
 	// 1. Argument sanity
@@ -179,10 +180,14 @@ func NewMsgSubmitProposal(args []interface{}, cdc codec.Codec) (*govv1.MsgSubmit
 	}
 
 	// 4. Build & dispatch MsgSubmitProposal
+	proposerAddr, err := addrCdc.BytesToString(proposer.Bytes())
+	if err != nil {
+		return nil, common.Address{}, fmt.Errorf("failed to decode proposer address: %w", err)
+	}
 	smsg := &govv1.MsgSubmitProposal{
 		Messages:       anys,
 		InitialDeposit: amt,
-		Proposer:       sdk.AccAddress(proposer.Bytes()).String(),
+		Proposer:       proposerAddr,
 		Metadata:       prop.Metadata,
 		Title:          prop.Title,
 		Summary:        prop.Summary,
@@ -194,7 +199,7 @@ func NewMsgSubmitProposal(args []interface{}, cdc codec.Codec) (*govv1.MsgSubmit
 
 // NewMsgDeposit constructs a MsgDeposit.
 // args: [depositorAddress, proposalID, []cmn.CoinInput deposit]
-func NewMsgDeposit(args []interface{}) (*govv1.MsgDeposit, common.Address, error) {
+func NewMsgDeposit(args []interface{}, addrCdc address.Codec) (*govv1.MsgDeposit, common.Address, error) {
 	emptyAddr := common.Address{}
 	if len(args) != 3 {
 		return nil, emptyAddr, fmt.Errorf(cmn.ErrInvalidNumberOfArgs, 3, len(args))
@@ -220,10 +225,14 @@ func NewMsgDeposit(args []interface{}) (*govv1.MsgDeposit, common.Address, error
 		return nil, emptyAddr, fmt.Errorf(ErrInvalidDeposits, "deposit arg")
 	}
 
+	depositorAddr, err := addrCdc.BytesToString(depositor.Bytes())
+	if err != nil {
+		return nil, common.Address{}, fmt.Errorf("failed to decode depositor address: %w", err)
+	}
 	msg := &govv1.MsgDeposit{
 		ProposalId: proposalID,
 		Amount:     amt,
-		Depositor:  sdk.AccAddress(depositor.Bytes()).String(),
+		Depositor:  depositorAddr,
 	}
 
 	return msg, depositor, nil
@@ -231,7 +240,7 @@ func NewMsgDeposit(args []interface{}) (*govv1.MsgDeposit, common.Address, error
 
 // NewMsgCancelProposal constructs a MsgCancelProposal.
 // args: [proposerAddress, proposalID]
-func NewMsgCancelProposal(args []interface{}) (*govv1.MsgCancelProposal, common.Address, error) {
+func NewMsgCancelProposal(args []interface{}, addrCdc address.Codec) (*govv1.MsgCancelProposal, common.Address, error) {
 	emptyAddr := common.Address{}
 	if len(args) != 2 {
 		return nil, emptyAddr, fmt.Errorf(cmn.ErrInvalidNumberOfArgs, 1, len(args))
@@ -247,14 +256,18 @@ func NewMsgCancelProposal(args []interface{}) (*govv1.MsgCancelProposal, common.
 		return nil, emptyAddr, fmt.Errorf(ErrInvalidProposalID, args[1])
 	}
 
+	proposerAddr, err := addrCdc.BytesToString(proposer.Bytes())
+	if err != nil {
+		return nil, common.Address{}, fmt.Errorf("failed to decode proposer address: %w", err)
+	}
 	return govv1.NewMsgCancelProposal(
 		proposalID,
-		sdk.AccAddress(proposer.Bytes()).String(),
+		proposerAddr,
 	), proposer, nil
 }
 
 // NewMsgVote creates a new MsgVote instance.
-func NewMsgVote(args []interface{}) (*govv1.MsgVote, common.Address, error) {
+func NewMsgVote(args []interface{}, addrCdc address.Codec) (*govv1.MsgVote, common.Address, error) {
 	if len(args) != 4 {
 		return nil, common.Address{}, fmt.Errorf(cmn.ErrInvalidNumberOfArgs, 4, len(args))
 	}
@@ -279,9 +292,13 @@ func NewMsgVote(args []interface{}) (*govv1.MsgVote, common.Address, error) {
 		return nil, common.Address{}, fmt.Errorf(ErrInvalidMetadata, args[3])
 	}
 
+	voterAddr, err := addrCdc.BytesToString(voterAddress.Bytes())
+	if err != nil {
+		return nil, common.Address{}, fmt.Errorf("failed to decode voter address: %w", err)
+	}
 	msg := &govv1.MsgVote{
 		ProposalId: proposalID,
-		Voter:      sdk.AccAddress(voterAddress.Bytes()).String(),
+		Voter:      voterAddr,
 		Option:     govv1.VoteOption(option),
 		Metadata:   metadata,
 	}
@@ -290,7 +307,7 @@ func NewMsgVote(args []interface{}) (*govv1.MsgVote, common.Address, error) {
 }
 
 // NewMsgVoteWeighted creates a new MsgVoteWeighted instance.
-func NewMsgVoteWeighted(method *abi.Method, args []interface{}) (*govv1.MsgVoteWeighted, common.Address, WeightedVoteOptions, error) {
+func NewMsgVoteWeighted(method *abi.Method, args []interface{}, addrCdc address.Codec) (*govv1.MsgVoteWeighted, common.Address, WeightedVoteOptions, error) {
 	if len(args) != 4 {
 		return nil, common.Address{}, WeightedVoteOptions{}, fmt.Errorf(cmn.ErrInvalidNumberOfArgs, 4, len(args))
 	}
@@ -325,9 +342,13 @@ func NewMsgVoteWeighted(method *abi.Method, args []interface{}) (*govv1.MsgVoteW
 		return nil, common.Address{}, WeightedVoteOptions{}, fmt.Errorf(ErrInvalidMetadata, args[3])
 	}
 
+	voterAddr, err := addrCdc.BytesToString(voterAddress.Bytes())
+	if err != nil {
+		return nil, common.Address{}, WeightedVoteOptions{}, fmt.Errorf("failed to decode voter address: %w", err)
+	}
 	msg := &govv1.MsgVoteWeighted{
 		ProposalId: proposalID,
-		Voter:      sdk.AccAddress(voterAddress.Bytes()).String(),
+		Voter:      voterAddr,
 		Options:    weightedOptions,
 		Metadata:   metadata,
 	}
@@ -383,7 +404,7 @@ func (vo *VotesOutput) FromResponse(res *govv1.QueryVotesResponse) *VotesOutput 
 }
 
 // ParseVoteArgs parses the arguments for the Votes query.
-func ParseVoteArgs(args []interface{}) (*govv1.QueryVoteRequest, error) {
+func ParseVoteArgs(args []interface{}, addrCdc address.Codec) (*govv1.QueryVoteRequest, error) {
 	if len(args) != 2 {
 		return nil, fmt.Errorf(cmn.ErrInvalidNumberOfArgs, 2, len(args))
 	}
@@ -398,10 +419,13 @@ func ParseVoteArgs(args []interface{}) (*govv1.QueryVoteRequest, error) {
 		return nil, fmt.Errorf(ErrInvalidVoter, args[1])
 	}
 
-	voterAccAddr := sdk.AccAddress(voter.Bytes())
+	voterAddr, err := addrCdc.BytesToString(voter.Bytes())
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode voter address: %w", err)
+	}
 	return &govv1.QueryVoteRequest{
 		ProposalId: proposalID,
-		Voter:      voterAccAddr.String(),
+		Voter:      voterAddr,
 	}, nil
 }
 
@@ -426,7 +450,7 @@ func (vo *VoteOutput) FromResponse(res *govv1.QueryVoteResponse) *VoteOutput {
 }
 
 // ParseDepositArgs parses the arguments for the Deposit query.
-func ParseDepositArgs(args []interface{}) (*govv1.QueryDepositRequest, error) {
+func ParseDepositArgs(args []interface{}, addrCdc address.Codec) (*govv1.QueryDepositRequest, error) {
 	if len(args) != 2 {
 		return nil, fmt.Errorf(cmn.ErrInvalidNumberOfArgs, 2, len(args))
 	}
@@ -441,10 +465,13 @@ func ParseDepositArgs(args []interface{}) (*govv1.QueryDepositRequest, error) {
 		return nil, fmt.Errorf(ErrInvalidDepositor, args[1])
 	}
 
-	depositorAccAddr := sdk.AccAddress(depositor.Bytes())
+	depositorAddr, err := addrCdc.BytesToString(depositor.Bytes())
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode depositor address: %w", err)
+	}
 	return &govv1.QueryDepositRequest{
 		ProposalId: proposalID,
-		Depositor:  depositorAccAddr.String(),
+		Depositor:  depositorAddr,
 	}, nil
 }
 
@@ -593,7 +620,7 @@ func ParseProposalArgs(args []interface{}) (*govv1.QueryProposalRequest, error) 
 }
 
 // ParseProposalsArgs parses the arguments for the Proposals query
-func ParseProposalsArgs(method *abi.Method, args []interface{}) (*govv1.QueryProposalsRequest, error) {
+func ParseProposalsArgs(method *abi.Method, args []interface{}, addrCdc address.Codec) (*govv1.QueryProposalsRequest, error) {
 	if len(args) != 4 {
 		return nil, fmt.Errorf(cmn.ErrInvalidNumberOfArgs, 4, len(args))
 	}
@@ -605,12 +632,20 @@ func ParseProposalsArgs(method *abi.Method, args []interface{}) (*govv1.QueryPro
 
 	voter := ""
 	if input.Voter != (common.Address{}) {
-		voter = sdk.AccAddress(input.Voter.Bytes()).String()
+		var err error
+		voter, err = addrCdc.BytesToString(input.Voter.Bytes())
+		if err != nil {
+			return nil, fmt.Errorf("failed to decode voter address: %w", err)
+		}
 	}
 
 	depositor := ""
 	if input.Depositor != (common.Address{}) {
-		depositor = sdk.AccAddress(input.Depositor.Bytes()).String()
+		var err error
+		depositor, err = addrCdc.BytesToString(input.Depositor.Bytes())
+		if err != nil {
+			return nil, fmt.Errorf("failed to decode depositor address: %w", err)
+		}
 	}
 
 	return &govv1.QueryProposalsRequest{

--- a/precompiles/gov/types.go
+++ b/precompiles/gov/types.go
@@ -205,8 +205,8 @@ func NewMsgDeposit(args []interface{}, addrCdc address.Codec) (*govv1.MsgDeposit
 		return nil, emptyAddr, fmt.Errorf(cmn.ErrInvalidNumberOfArgs, 3, len(args))
 	}
 
-	depositor := args[0].(common.Address)
-	if depositor == emptyAddr {
+	depositor, ok := args[0].(common.Address)
+	if !ok || depositor == emptyAddr {
 		return nil, emptyAddr, fmt.Errorf(ErrInvalidDepositor, args[0])
 	}
 

--- a/precompiles/gov/types_test.go
+++ b/precompiles/gov/types_test.go
@@ -5,11 +5,13 @@ import (
 	"math/big"
 	"testing"
 
-	sdk "github.com/cosmos/cosmos-sdk/types"
-	authcodec "github.com/cosmos/cosmos-sdk/x/auth/codec"
-	cmn "github.com/cosmos/evm/precompiles/common"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
+
+	cmn "github.com/cosmos/evm/precompiles/common"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	authcodec "github.com/cosmos/cosmos-sdk/x/auth/codec"
 )
 
 func TestNewMsgDeposit(t *testing.T) {
@@ -23,18 +25,18 @@ func TestNewMsgDeposit(t *testing.T) {
 	require.NoError(t, err)
 
 	tests := []struct {
-		name          string
-		args          []interface{}
-		wantErr       bool
-		errMsg        string
-		wantDepositor string
+		name           string
+		args           []interface{}
+		wantErr        bool
+		errMsg         string
+		wantDepositor  string
 		wantProposalID uint64
 	}{
 		{
-			name:          "valid",
-			args:          []interface{}{depositorAddr, proposalID, validCoins},
-			wantErr:       false,
-			wantDepositor: expectedDepositorAddr,
+			name:           "valid",
+			args:           []interface{}{depositorAddr, proposalID, validCoins},
+			wantErr:        false,
+			wantDepositor:  expectedDepositorAddr,
 			wantProposalID: proposalID,
 		},
 		{
@@ -258,7 +260,7 @@ func TestNewMsgVote(t *testing.T) {
 				require.Equal(t, voterAddr, returnAddr)
 				require.Equal(t, tt.wantVoter, msg.Voter)
 				require.Equal(t, tt.wantProposalID, msg.ProposalId)
-				require.Equal(t, tt.wantOption, uint8(msg.Option))
+				require.Equal(t, tt.wantOption, uint8(msg.Option)) //nolint:gosec // doesn't matter here
 				require.Equal(t, tt.wantMetadata, msg.Metadata)
 			}
 		})

--- a/precompiles/gov/types_test.go
+++ b/precompiles/gov/types_test.go
@@ -1,0 +1,402 @@
+package gov
+
+import (
+	"fmt"
+	"math/big"
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	authcodec "github.com/cosmos/cosmos-sdk/x/auth/codec"
+	cmn "github.com/cosmos/evm/precompiles/common"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewMsgDeposit(t *testing.T) {
+	addrCodec := authcodec.NewBech32Codec(sdk.GetConfig().GetBech32AccountAddrPrefix())
+
+	depositorAddr := common.HexToAddress("0x1234567890123456789012345678901234567890")
+	validCoins := []cmn.Coin{{Denom: "stake", Amount: big.NewInt(1000)}}
+	proposalID := uint64(1)
+
+	expectedDepositorAddr, err := addrCodec.BytesToString(depositorAddr.Bytes())
+	require.NoError(t, err)
+
+	tests := []struct {
+		name          string
+		args          []interface{}
+		wantErr       bool
+		errMsg        string
+		wantDepositor string
+		wantProposalID uint64
+	}{
+		{
+			name:          "valid",
+			args:          []interface{}{depositorAddr, proposalID, validCoins},
+			wantErr:       false,
+			wantDepositor: expectedDepositorAddr,
+			wantProposalID: proposalID,
+		},
+		{
+			name:    "no arguments",
+			args:    []interface{}{},
+			wantErr: true,
+			errMsg:  fmt.Sprintf(cmn.ErrInvalidNumberOfArgs, 3, 0),
+		},
+		{
+			name:    "too many arguments",
+			args:    []interface{}{depositorAddr, proposalID, validCoins, "extra"},
+			wantErr: true,
+			errMsg:  fmt.Sprintf(cmn.ErrInvalidNumberOfArgs, 3, 4),
+		},
+		{
+			name:    "invalid depositor type",
+			args:    []interface{}{"not-an-address", proposalID, validCoins},
+			wantErr: true,
+			errMsg:  fmt.Sprintf(ErrInvalidDepositor, "not-an-address"),
+		},
+		{
+			name:    "empty depositor address",
+			args:    []interface{}{common.Address{}, proposalID, validCoins},
+			wantErr: true,
+			errMsg:  fmt.Sprintf(ErrInvalidDepositor, common.Address{}),
+		},
+		{
+			name:    "invalid proposal ID type",
+			args:    []interface{}{depositorAddr, "not-a-uint64", validCoins},
+			wantErr: true,
+			errMsg:  "invalid proposal id",
+		},
+		{
+			name:    "invalid coins",
+			args:    []interface{}{depositorAddr, proposalID, "invalid-coins"},
+			wantErr: true,
+			errMsg:  fmt.Sprintf(ErrInvalidDeposits, "deposit arg"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg, returnAddr, err := NewMsgDeposit(tt.args, addrCodec)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.errMsg)
+				require.Nil(t, msg)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, msg)
+				require.Equal(t, depositorAddr, returnAddr)
+				require.Equal(t, tt.wantDepositor, msg.Depositor)
+				require.Equal(t, tt.wantProposalID, msg.ProposalId)
+				require.NotEmpty(t, msg.Amount)
+			}
+		})
+	}
+}
+
+func TestNewMsgCancelProposal(t *testing.T) {
+	addrCodec := authcodec.NewBech32Codec(sdk.GetConfig().GetBech32AccountAddrPrefix())
+
+	proposerAddr := common.HexToAddress("0x1234567890123456789012345678901234567890")
+	proposalID := uint64(1)
+
+	expectedProposerAddr, err := addrCodec.BytesToString(proposerAddr.Bytes())
+	require.NoError(t, err)
+
+	tests := []struct {
+		name           string
+		args           []interface{}
+		wantErr        bool
+		errMsg         string
+		wantProposer   string
+		wantProposalID uint64
+	}{
+		{
+			name:           "valid",
+			args:           []interface{}{proposerAddr, proposalID},
+			wantErr:        false,
+			wantProposer:   expectedProposerAddr,
+			wantProposalID: proposalID,
+		},
+		{
+			name:    "no arguments",
+			args:    []interface{}{},
+			wantErr: true,
+			errMsg:  fmt.Sprintf(cmn.ErrInvalidNumberOfArgs, 1, 0),
+		},
+		{
+			name:    "too many arguments",
+			args:    []interface{}{proposerAddr, proposalID, "extra"},
+			wantErr: true,
+			errMsg:  fmt.Sprintf(cmn.ErrInvalidNumberOfArgs, 1, 3),
+		},
+		{
+			name:    "invalid proposer type",
+			args:    []interface{}{"not-an-address", proposalID},
+			wantErr: true,
+			errMsg:  fmt.Sprintf(ErrInvalidProposer, "not-an-address"),
+		},
+		{
+			name:    "empty proposer address",
+			args:    []interface{}{common.Address{}, proposalID},
+			wantErr: true,
+			errMsg:  fmt.Sprintf(ErrInvalidProposer, common.Address{}),
+		},
+		{
+			name:    "invalid proposal ID type",
+			args:    []interface{}{proposerAddr, "not-a-uint64"},
+			wantErr: true,
+			errMsg:  "invalid proposal id",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg, returnAddr, err := NewMsgCancelProposal(tt.args, addrCodec)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.errMsg)
+				require.Nil(t, msg)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, msg)
+				require.Equal(t, proposerAddr, returnAddr)
+				require.Equal(t, tt.wantProposer, msg.Proposer)
+				require.Equal(t, tt.wantProposalID, msg.ProposalId)
+			}
+		})
+	}
+}
+
+func TestNewMsgVote(t *testing.T) {
+	addrCodec := authcodec.NewBech32Codec(sdk.GetConfig().GetBech32AccountAddrPrefix())
+
+	voterAddr := common.HexToAddress("0x1234567890123456789012345678901234567890")
+	proposalID := uint64(1)
+	option := uint8(1)
+	metadata := "test-metadata"
+
+	expectedVoterAddr, err := addrCodec.BytesToString(voterAddr.Bytes())
+	require.NoError(t, err)
+
+	tests := []struct {
+		name           string
+		args           []interface{}
+		wantErr        bool
+		errMsg         string
+		wantVoter      string
+		wantProposalID uint64
+		wantOption     uint8
+		wantMetadata   string
+	}{
+		{
+			name:           "valid",
+			args:           []interface{}{voterAddr, proposalID, option, metadata},
+			wantErr:        false,
+			wantVoter:      expectedVoterAddr,
+			wantProposalID: proposalID,
+			wantOption:     option,
+			wantMetadata:   metadata,
+		},
+		{
+			name:    "no arguments",
+			args:    []interface{}{},
+			wantErr: true,
+			errMsg:  fmt.Sprintf(cmn.ErrInvalidNumberOfArgs, 4, 0),
+		},
+		{
+			name:    "too many arguments",
+			args:    []interface{}{voterAddr, proposalID, option, metadata, "extra"},
+			wantErr: true,
+			errMsg:  fmt.Sprintf(cmn.ErrInvalidNumberOfArgs, 4, 5),
+		},
+		{
+			name:    "invalid voter type",
+			args:    []interface{}{"not-an-address", proposalID, option, metadata},
+			wantErr: true,
+			errMsg:  fmt.Sprintf(ErrInvalidVoter, "not-an-address"),
+		},
+		{
+			name:    "empty voter address",
+			args:    []interface{}{common.Address{}, proposalID, option, metadata},
+			wantErr: true,
+			errMsg:  fmt.Sprintf(ErrInvalidVoter, common.Address{}),
+		},
+		{
+			name:    "invalid proposal ID type",
+			args:    []interface{}{voterAddr, "not-a-uint64", option, metadata},
+			wantErr: true,
+			errMsg:  "invalid proposal id",
+		},
+		{
+			name:    "invalid option type",
+			args:    []interface{}{voterAddr, proposalID, "not-a-uint8", metadata},
+			wantErr: true,
+			errMsg:  "invalid option",
+		},
+		{
+			name:    "invalid metadata type",
+			args:    []interface{}{voterAddr, proposalID, option, 123},
+			wantErr: true,
+			errMsg:  "invalid metadata",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg, returnAddr, err := NewMsgVote(tt.args, addrCodec)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.errMsg)
+				require.Nil(t, msg)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, msg)
+				require.Equal(t, voterAddr, returnAddr)
+				require.Equal(t, tt.wantVoter, msg.Voter)
+				require.Equal(t, tt.wantProposalID, msg.ProposalId)
+				require.Equal(t, tt.wantOption, uint8(msg.Option))
+				require.Equal(t, tt.wantMetadata, msg.Metadata)
+			}
+		})
+	}
+}
+
+func TestParseVoteArgs(t *testing.T) {
+	addrCodec := authcodec.NewBech32Codec(sdk.GetConfig().GetBech32AccountAddrPrefix())
+
+	voterAddr := common.HexToAddress("0x1234567890123456789012345678901234567890")
+	proposalID := uint64(1)
+
+	expectedVoterAddr, err := addrCodec.BytesToString(voterAddr.Bytes())
+	require.NoError(t, err)
+
+	tests := []struct {
+		name           string
+		args           []interface{}
+		wantErr        bool
+		errMsg         string
+		wantVoter      string
+		wantProposalID uint64
+	}{
+		{
+			name:           "valid",
+			args:           []interface{}{proposalID, voterAddr},
+			wantErr:        false,
+			wantVoter:      expectedVoterAddr,
+			wantProposalID: proposalID,
+		},
+		{
+			name:    "no arguments",
+			args:    []interface{}{},
+			wantErr: true,
+			errMsg:  fmt.Sprintf(cmn.ErrInvalidNumberOfArgs, 2, 0),
+		},
+		{
+			name:    "too many arguments",
+			args:    []interface{}{proposalID, voterAddr, "extra"},
+			wantErr: true,
+			errMsg:  fmt.Sprintf(cmn.ErrInvalidNumberOfArgs, 2, 3),
+		},
+		{
+			name:    "invalid proposal ID type",
+			args:    []interface{}{"not-a-uint64", voterAddr},
+			wantErr: true,
+			errMsg:  "invalid proposal id",
+		},
+		{
+			name:    "invalid voter type",
+			args:    []interface{}{proposalID, "not-an-address"},
+			wantErr: true,
+			errMsg:  fmt.Sprintf(ErrInvalidVoter, "not-an-address"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, err := ParseVoteArgs(tt.args, addrCodec)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.errMsg)
+				require.Nil(t, req)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, req)
+				require.Equal(t, tt.wantVoter, req.Voter)
+				require.Equal(t, tt.wantProposalID, req.ProposalId)
+			}
+		})
+	}
+}
+
+func TestParseDepositArgs(t *testing.T) {
+	addrCodec := authcodec.NewBech32Codec(sdk.GetConfig().GetBech32AccountAddrPrefix())
+
+	depositorAddr := common.HexToAddress("0x1234567890123456789012345678901234567890")
+	proposalID := uint64(1)
+
+	expectedDepositorAddr, err := addrCodec.BytesToString(depositorAddr.Bytes())
+	require.NoError(t, err)
+
+	tests := []struct {
+		name           string
+		args           []interface{}
+		wantErr        bool
+		errMsg         string
+		wantDepositor  string
+		wantProposalID uint64
+	}{
+		{
+			name:           "valid",
+			args:           []interface{}{proposalID, depositorAddr},
+			wantErr:        false,
+			wantDepositor:  expectedDepositorAddr,
+			wantProposalID: proposalID,
+		},
+		{
+			name:    "no arguments",
+			args:    []interface{}{},
+			wantErr: true,
+			errMsg:  fmt.Sprintf(cmn.ErrInvalidNumberOfArgs, 2, 0),
+		},
+		{
+			name:    "too many arguments",
+			args:    []interface{}{proposalID, depositorAddr, "extra"},
+			wantErr: true,
+			errMsg:  fmt.Sprintf(cmn.ErrInvalidNumberOfArgs, 2, 3),
+		},
+		{
+			name:    "invalid proposal ID type",
+			args:    []interface{}{"not-a-uint64", depositorAddr},
+			wantErr: true,
+			errMsg:  "invalid proposal id",
+		},
+		{
+			name:    "invalid depositor type",
+			args:    []interface{}{proposalID, "not-an-address"},
+			wantErr: true,
+			errMsg:  fmt.Sprintf(ErrInvalidDepositor, "not-an-address"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, err := ParseDepositArgs(tt.args, addrCodec)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.errMsg)
+				require.Nil(t, req)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, req)
+				require.Equal(t, tt.wantDepositor, req.Depositor)
+				require.Equal(t, tt.wantProposalID, req.ProposalId)
+			}
+		})
+	}
+}

--- a/precompiles/slashing/query.go
+++ b/precompiles/slashing/query.go
@@ -27,7 +27,7 @@ func (p *Precompile) GetSigningInfo(
 	_ *vm.Contract,
 	args []interface{},
 ) ([]byte, error) {
-	req, err := ParseSigningInfoArgs(args)
+	req, err := ParseSigningInfoArgs(args, p.consCodec)
 	if err != nil {
 		return nil, err
 	}

--- a/precompiles/slashing/slashing.go
+++ b/precompiles/slashing/slashing.go
@@ -4,8 +4,6 @@ import (
 	"embed"
 	"fmt"
 
-	"github.com/cosmos/cosmos-sdk/runtime"
-	authcodec "github.com/cosmos/cosmos-sdk/x/auth/codec"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/tracing"
@@ -17,7 +15,9 @@ import (
 	"cosmossdk.io/log"
 	storetypes "cosmossdk.io/store/types"
 
+	"github.com/cosmos/cosmos-sdk/runtime"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	authcodec "github.com/cosmos/cosmos-sdk/x/auth/codec"
 	slashingkeeper "github.com/cosmos/cosmos-sdk/x/slashing/keeper"
 )
 

--- a/precompiles/slashing/slashing.go
+++ b/precompiles/slashing/slashing.go
@@ -4,6 +4,8 @@ import (
 	"embed"
 	"fmt"
 
+	"github.com/cosmos/cosmos-sdk/runtime"
+	authcodec "github.com/cosmos/cosmos-sdk/x/auth/codec"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/tracing"
@@ -30,6 +32,8 @@ var f embed.FS
 type Precompile struct {
 	cmn.Precompile
 	slashingKeeper slashingkeeper.Keeper
+	consCodec      runtime.ConsensusAddressCodec
+	valCodec       runtime.ValidatorAddressCodec
 }
 
 // LoadABI loads the slashing ABI from the embedded abi.json file
@@ -55,6 +59,8 @@ func NewPrecompile(
 			TransientKVGasConfig: storetypes.TransientGasConfig(),
 		},
 		slashingKeeper: slashingKeeper,
+		valCodec:       authcodec.NewBech32Codec(sdk.GetConfig().GetBech32ValidatorAddrPrefix()),
+		consCodec:      authcodec.NewBech32Codec(sdk.GetConfig().GetBech32ConsensusAddrPrefix()),
 	}
 
 	// SetAddress defines the address of the slashing precompiled contract.

--- a/precompiles/slashing/slashing.go
+++ b/precompiles/slashing/slashing.go
@@ -12,12 +12,12 @@ import (
 	cmn "github.com/cosmos/evm/precompiles/common"
 	evmtypes "github.com/cosmos/evm/x/vm/types"
 
+	"cosmossdk.io/core/address"
 	"cosmossdk.io/log"
 	storetypes "cosmossdk.io/store/types"
 
 	"github.com/cosmos/cosmos-sdk/runtime"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	authcodec "github.com/cosmos/cosmos-sdk/x/auth/codec"
 	slashingkeeper "github.com/cosmos/cosmos-sdk/x/slashing/keeper"
 )
 
@@ -46,6 +46,7 @@ func LoadABI() (abi.ABI, error) {
 // PrecompiledContract interface.
 func NewPrecompile(
 	slashingKeeper slashingkeeper.Keeper,
+	valCdc, consCdc address.Codec,
 ) (*Precompile, error) {
 	abi, err := LoadABI()
 	if err != nil {
@@ -59,8 +60,8 @@ func NewPrecompile(
 			TransientKVGasConfig: storetypes.TransientGasConfig(),
 		},
 		slashingKeeper: slashingKeeper,
-		valCodec:       authcodec.NewBech32Codec(sdk.GetConfig().GetBech32ValidatorAddrPrefix()),
-		consCodec:      authcodec.NewBech32Codec(sdk.GetConfig().GetBech32ConsensusAddrPrefix()),
+		valCodec:       valCdc,
+		consCodec:      consCdc,
 	}
 
 	// SetAddress defines the address of the slashing precompiled contract.

--- a/precompiles/slashing/tx.go
+++ b/precompiles/slashing/tx.go
@@ -43,8 +43,13 @@ func (p Precompile) Unjail(
 		return nil, fmt.Errorf(cmn.ErrRequesterIsNotMsgSender, msgSender.String(), validatorAddress.String())
 	}
 
+	valAddr, err := p.valCodec.BytesToString(validatorAddress.Bytes())
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert validator address: %w", err)
+	}
+
 	msg := &types.MsgUnjail{
-		ValidatorAddr: sdk.ValAddress(validatorAddress.Bytes()).String(),
+		ValidatorAddr: valAddr,
 	}
 
 	msgSrv := slashingkeeper.NewMsgServerImpl(p.slashingKeeper)

--- a/precompiles/slashing/types.go
+++ b/precompiles/slashing/types.go
@@ -8,6 +8,7 @@ import (
 
 	cmn "github.com/cosmos/evm/precompiles/common"
 
+	"cosmossdk.io/core/address"
 	"cosmossdk.io/math"
 
 	"github.com/cosmos/cosmos-sdk/types"
@@ -42,7 +43,7 @@ type SigningInfosInput struct {
 }
 
 // ParseSigningInfoArgs parses the arguments for the signing info query
-func ParseSigningInfoArgs(args []interface{}) (*slashingtypes.QuerySigningInfoRequest, error) {
+func ParseSigningInfoArgs(args []interface{}, consCodec address.Codec) (*slashingtypes.QuerySigningInfoRequest, error) {
 	if len(args) != 1 {
 		return nil, fmt.Errorf(cmn.ErrInvalidNumberOfArgs, 1, len(args))
 	}
@@ -52,8 +53,13 @@ func ParseSigningInfoArgs(args []interface{}) (*slashingtypes.QuerySigningInfoRe
 		return nil, fmt.Errorf("invalid consensus address")
 	}
 
+	consAddr, err := consCodec.BytesToString(hexAddr.Bytes())
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert consensus address: %w", err)
+	}
+
 	return &slashingtypes.QuerySigningInfoRequest{
-		ConsAddress: types.ConsAddress(hexAddr.Bytes()).String(),
+		ConsAddress: consAddr,
 	}, nil
 }
 

--- a/precompiles/slashing/types_test.go
+++ b/precompiles/slashing/types_test.go
@@ -1,0 +1,86 @@
+package slashing
+
+import (
+	"fmt"
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	authcodec "github.com/cosmos/cosmos-sdk/x/auth/codec"
+	cmn "github.com/cosmos/evm/precompiles/common"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseSigningInfoArgs(t *testing.T) {
+	consCodec := authcodec.NewBech32Codec(sdk.GetConfig().GetBech32ConsensusAddrPrefix())
+	validAddr := common.HexToAddress("0x1234567890123456789012345678901234567890")
+	expectedConsAddr, err := consCodec.BytesToString(validAddr.Bytes())
+	require.NoError(t, err)
+
+	tests := []struct {
+		name            string
+		args            []any
+		wantErr         bool
+		errMsg          string
+		wantConsAddress string
+	}{
+		{
+			name:            "valid address",
+			args:            []any{validAddr},
+			wantErr:         false,
+			wantConsAddress: expectedConsAddr,
+		},
+		{
+			name:    "no arguments",
+			args:    []any{},
+			wantErr: true,
+			errMsg:  fmt.Sprintf(cmn.ErrInvalidNumberOfArgs, 1, 0),
+		},
+		{
+			name:    "too many arguments",
+			args:    []any{validAddr, "extra"},
+			wantErr: true,
+			errMsg:  fmt.Sprintf(cmn.ErrInvalidNumberOfArgs, 1, 2),
+		},
+		{
+			name:    "invalid type - string instead of address",
+			args:    []any{"not-an-address"},
+			wantErr: true,
+			errMsg:  "invalid consensus address",
+		},
+		{
+			name:    "invalid type - nil",
+			args:    []any{nil},
+			wantErr: true,
+			errMsg:  "invalid consensus address",
+		},
+		{
+			name:    "empty address",
+			args:    []any{common.Address{}},
+			wantErr: true,
+			errMsg:  "invalid consensus address",
+		},
+		{
+			name:    "invalid type - integer",
+			args:    []any{12345},
+			wantErr: true,
+			errMsg:  "invalid consensus address",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseSigningInfoArgs(tt.args, consCodec)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.errMsg)
+				require.Nil(t, got)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, got)
+				require.Equal(t, tt.wantConsAddress, got.ConsAddress)
+			}
+		})
+	}
+}

--- a/precompiles/slashing/types_test.go
+++ b/precompiles/slashing/types_test.go
@@ -4,11 +4,13 @@ import (
 	"fmt"
 	"testing"
 
-	sdk "github.com/cosmos/cosmos-sdk/types"
-	authcodec "github.com/cosmos/cosmos-sdk/x/auth/codec"
-	cmn "github.com/cosmos/evm/precompiles/common"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
+
+	cmn "github.com/cosmos/evm/precompiles/common"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	authcodec "github.com/cosmos/cosmos-sdk/x/auth/codec"
 )
 
 func TestParseSigningInfoArgs(t *testing.T) {

--- a/precompiles/staking/query.go
+++ b/precompiles/staking/query.go
@@ -42,7 +42,7 @@ func (p Precompile) Delegation(
 	method *abi.Method,
 	args []interface{},
 ) ([]byte, error) {
-	req, err := NewDelegationRequest(args)
+	req, err := NewDelegationRequest(args, p.addrCdc)
 	if err != nil {
 		return nil, err
 	}
@@ -76,7 +76,7 @@ func (p Precompile) UnbondingDelegation(
 	method *abi.Method,
 	args []interface{},
 ) ([]byte, error) {
-	req, err := NewUnbondingDelegationRequest(args)
+	req, err := NewUnbondingDelegationRequest(args, p.addrCdc)
 	if err != nil {
 		return nil, err
 	}
@@ -180,7 +180,7 @@ func (p Precompile) Redelegations(
 	_ *vm.Contract,
 	args []interface{},
 ) ([]byte, error) {
-	req, err := NewRedelegationsRequest(method, args)
+	req, err := NewRedelegationsRequest(method, args, p.addrCdc)
 	if err != nil {
 		return nil, err
 	}

--- a/precompiles/staking/staking.go
+++ b/precompiles/staking/staking.go
@@ -3,6 +3,7 @@ package staking
 import (
 	"embed"
 
+	addresscodec "github.com/cosmos/cosmos-sdk/codec/address"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/tracing"
@@ -11,6 +12,7 @@ import (
 	cmn "github.com/cosmos/evm/precompiles/common"
 	evmtypes "github.com/cosmos/evm/x/vm/types"
 
+	"cosmossdk.io/core/address"
 	"cosmossdk.io/log"
 	storetypes "cosmossdk.io/store/types"
 
@@ -29,6 +31,7 @@ var f embed.FS
 type Precompile struct {
 	cmn.Precompile
 	stakingKeeper stakingkeeper.Keeper
+	addrCdc       address.Codec
 }
 
 // LoadABI loads the staking ABI from the embedded abi.json file
@@ -54,6 +57,7 @@ func NewPrecompile(
 			TransientKVGasConfig: storetypes.TransientGasConfig(),
 		},
 		stakingKeeper: stakingKeeper,
+		addrCdc:       addresscodec.NewBech32Codec(sdk.GetConfig().GetBech32AccountAddrPrefix()),
 	}
 	// SetAddress defines the address of the staking precompiled contract.
 	p.SetAddress(common.HexToAddress(evmtypes.StakingPrecompileAddress))

--- a/precompiles/staking/staking.go
+++ b/precompiles/staking/staking.go
@@ -15,7 +15,6 @@ import (
 	"cosmossdk.io/log"
 	storetypes "cosmossdk.io/store/types"
 
-	addresscodec "github.com/cosmos/cosmos-sdk/codec/address"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	stakingkeeper "github.com/cosmos/cosmos-sdk/x/staking/keeper"
 )
@@ -44,6 +43,7 @@ func LoadABI() (abi.ABI, error) {
 // PrecompiledContract interface.
 func NewPrecompile(
 	stakingKeeper stakingkeeper.Keeper,
+	addrCdc address.Codec,
 ) (*Precompile, error) {
 	abi, err := LoadABI()
 	if err != nil {
@@ -57,7 +57,7 @@ func NewPrecompile(
 			TransientKVGasConfig: storetypes.TransientGasConfig(),
 		},
 		stakingKeeper: stakingKeeper,
-		addrCdc:       addresscodec.NewBech32Codec(sdk.GetConfig().GetBech32AccountAddrPrefix()),
+		addrCdc:       addrCdc,
 	}
 	// SetAddress defines the address of the staking precompiled contract.
 	p.SetAddress(common.HexToAddress(evmtypes.StakingPrecompileAddress))

--- a/precompiles/staking/staking.go
+++ b/precompiles/staking/staking.go
@@ -3,7 +3,6 @@ package staking
 import (
 	"embed"
 
-	addresscodec "github.com/cosmos/cosmos-sdk/codec/address"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/tracing"
@@ -16,6 +15,7 @@ import (
 	"cosmossdk.io/log"
 	storetypes "cosmossdk.io/store/types"
 
+	addresscodec "github.com/cosmos/cosmos-sdk/codec/address"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	stakingkeeper "github.com/cosmos/cosmos-sdk/x/staking/keeper"
 )

--- a/precompiles/staking/tx.go
+++ b/precompiles/staking/tx.go
@@ -44,7 +44,7 @@ func (p Precompile) CreateValidator(
 	if err != nil {
 		return nil, err
 	}
-	msg, validatorHexAddr, err := NewMsgCreateValidator(args, bondDenom)
+	msg, validatorHexAddr, err := NewMsgCreateValidator(args, bondDenom, p.addrCdc)
 	if err != nil {
 		return nil, err
 	}
@@ -141,7 +141,7 @@ func (p *Precompile) Delegate(
 	if err != nil {
 		return nil, err
 	}
-	msg, delegatorHexAddr, err := NewMsgDelegate(args, bondDenom)
+	msg, delegatorHexAddr, err := NewMsgDelegate(args, bondDenom, p.addrCdc)
 	if err != nil {
 		return nil, err
 	}
@@ -189,7 +189,7 @@ func (p Precompile) Undelegate(
 	if err != nil {
 		return nil, err
 	}
-	msg, delegatorHexAddr, err := NewMsgUndelegate(args, bondDenom)
+	msg, delegatorHexAddr, err := NewMsgUndelegate(args, bondDenom, p.addrCdc)
 	if err != nil {
 		return nil, err
 	}
@@ -239,7 +239,7 @@ func (p Precompile) Redelegate(
 	if err != nil {
 		return nil, err
 	}
-	msg, delegatorHexAddr, err := NewMsgRedelegate(args, bondDenom)
+	msg, delegatorHexAddr, err := NewMsgRedelegate(args, bondDenom, p.addrCdc)
 	if err != nil {
 		return nil, err
 	}
@@ -288,7 +288,7 @@ func (p Precompile) CancelUnbondingDelegation(
 	if err != nil {
 		return nil, err
 	}
-	msg, delegatorHexAddr, err := NewMsgCancelUnbondingDelegation(args, bondDenom)
+	msg, delegatorHexAddr, err := NewMsgCancelUnbondingDelegation(args, bondDenom, p.addrCdc)
 	if err != nil {
 		return nil, err
 	}

--- a/precompiles/staking/types_test.go
+++ b/precompiles/staking/types_test.go
@@ -1,0 +1,650 @@
+package staking
+
+import (
+	"fmt"
+	"math/big"
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	authcodec "github.com/cosmos/cosmos-sdk/x/auth/codec"
+	cmn "github.com/cosmos/evm/precompiles/common"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewMsgCreateValidator(t *testing.T) {
+	addrCodec := authcodec.NewBech32Codec(sdk.GetConfig().GetBech32AccountAddrPrefix())
+
+	validatorAddr := common.HexToAddress("0x1234567890123456789012345678901234567890")
+	description := Description{
+		Moniker:         "test-validator",
+		Identity:        "test-identity",
+		Website:         "https://test.com",
+		SecurityContact: "test@test.com",
+		Details:         "test validator",
+	}
+	commission := Commission{
+		Rate:          big.NewInt(100000000000000000), // 0.1
+		MaxRate:       big.NewInt(200000000000000000), // 0.2
+		MaxChangeRate: big.NewInt(10000000000000000),  // 0.01
+	}
+	minSelfDelegation := big.NewInt(1000000)
+	pubkey := "rOQZYCGGhzjKUOUlM3MfOWFxGKX8L5z5B+/J9NqfLmw="
+	value := big.NewInt(1000000000)
+	denom := "stake"
+
+	expectedValidatorAddr, err := addrCodec.BytesToString(validatorAddr.Bytes())
+	require.NoError(t, err)
+
+	tests := []struct {
+		name               string
+		args               []interface{}
+		wantErr            bool
+		errMsg             string
+		wantDelegatorAddr  string
+		wantValidatorAddr  string
+		wantMinSelfDel     *big.Int
+		wantValue          *big.Int
+	}{
+		{
+			name: "valid",
+			args: []interface{}{description, commission, minSelfDelegation, validatorAddr, pubkey, value},
+			wantErr:            false,
+			wantDelegatorAddr:  expectedValidatorAddr,
+			wantValidatorAddr:  sdk.ValAddress(validatorAddr.Bytes()).String(),
+			wantMinSelfDel:     minSelfDelegation,
+			wantValue:          value,
+		},
+		{
+			name:    "no arguments",
+			args:    []interface{}{},
+			wantErr: true,
+			errMsg:  fmt.Sprintf(cmn.ErrInvalidNumberOfArgs, 6, 0),
+		},
+		{
+			name:    "too many arguments",
+			args:    []interface{}{description, commission, minSelfDelegation, validatorAddr, pubkey, value, "extra"},
+			wantErr: true,
+			errMsg:  fmt.Sprintf(cmn.ErrInvalidNumberOfArgs, 6, 7),
+		},
+		{
+			name:    "invalid description type",
+			args:    []interface{}{"not-a-description", commission, minSelfDelegation, validatorAddr, pubkey, value},
+			wantErr: true,
+			errMsg:  fmt.Sprintf(cmn.ErrInvalidDescription, "not-a-description"),
+		},
+		{
+			name:    "invalid commission type",
+			args:    []interface{}{description, "not-a-commission", minSelfDelegation, validatorAddr, pubkey, value},
+			wantErr: true,
+			errMsg:  fmt.Sprintf(cmn.ErrInvalidCommission, "not-a-commission"),
+		},
+		{
+			name:    "invalid min self delegation type",
+			args:    []interface{}{description, commission, "not-a-big-int", validatorAddr, pubkey, value},
+			wantErr: true,
+			errMsg:  fmt.Sprintf(cmn.ErrInvalidAmount, "not-a-big-int"),
+		},
+		{
+			name:    "invalid validator address type",
+			args:    []interface{}{description, commission, minSelfDelegation, "not-an-address", pubkey, value},
+			wantErr: true,
+			errMsg:  fmt.Sprintf(cmn.ErrInvalidValidator, "not-an-address"),
+		},
+		{
+			name:    "empty validator address",
+			args:    []interface{}{description, commission, minSelfDelegation, common.Address{}, pubkey, value},
+			wantErr: true,
+			errMsg:  fmt.Sprintf(cmn.ErrInvalidValidator, common.Address{}),
+		},
+		{
+			name:    "invalid pubkey type",
+			args:    []interface{}{description, commission, minSelfDelegation, validatorAddr, 123, value},
+			wantErr: true,
+			errMsg:  fmt.Sprintf(cmn.ErrInvalidType, "pubkey", "string", 123),
+		},
+		{
+			name:    "invalid value type",
+			args:    []interface{}{description, commission, minSelfDelegation, validatorAddr, pubkey, "not-a-big-int"},
+			wantErr: true,
+			errMsg:  fmt.Sprintf(cmn.ErrInvalidAmount, "not-a-big-int"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg, returnAddr, err := NewMsgCreateValidator(tt.args, denom, addrCodec)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.errMsg)
+				require.Nil(t, msg)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, msg)
+				require.Equal(t, validatorAddr, returnAddr)
+				require.Equal(t, tt.wantDelegatorAddr, msg.DelegatorAddress)
+				require.Equal(t, tt.wantValidatorAddr, msg.ValidatorAddress)
+				require.Equal(t, tt.wantMinSelfDel, msg.MinSelfDelegation.BigInt())
+				require.Equal(t, tt.wantValue, msg.Value.Amount.BigInt())
+				require.Equal(t, denom, msg.Value.Denom)
+			}
+		})
+	}
+}
+
+func TestNewMsgDelegate(t *testing.T) {
+	addrCodec := authcodec.NewBech32Codec(sdk.GetConfig().GetBech32AccountAddrPrefix())
+
+	delegatorAddr := common.HexToAddress("0x1234567890123456789012345678901234567890")
+	validatorAddr := "cosmosvaloper1qypqxpq9qcrsszg2pvxq6rs0zqg3yyc5a3kaax"
+	amount := big.NewInt(1000000000)
+	denom := "stake"
+
+	expectedDelegatorAddr, err := addrCodec.BytesToString(delegatorAddr.Bytes())
+	require.NoError(t, err)
+
+	tests := []struct {
+		name              string
+		args              []interface{}
+		wantErr           bool
+		errMsg            string
+		wantDelegatorAddr string
+		wantValidatorAddr string
+		wantAmount        *big.Int
+	}{
+		{
+			name:              "valid",
+			args:              []interface{}{delegatorAddr, validatorAddr, amount},
+			wantErr:           false,
+			wantDelegatorAddr: expectedDelegatorAddr,
+			wantValidatorAddr: validatorAddr,
+			wantAmount:        amount,
+		},
+		{
+			name:    "no arguments",
+			args:    []interface{}{},
+			wantErr: true,
+			errMsg:  fmt.Sprintf(cmn.ErrInvalidNumberOfArgs, 3, 0),
+		},
+		{
+			name:    "too many arguments",
+			args:    []interface{}{delegatorAddr, validatorAddr, amount, "extra"},
+			wantErr: true,
+			errMsg:  fmt.Sprintf(cmn.ErrInvalidNumberOfArgs, 3, 4),
+		},
+		{
+			name:    "invalid delegator type",
+			args:    []interface{}{"not-an-address", validatorAddr, amount},
+			wantErr: true,
+			errMsg:  fmt.Sprintf(cmn.ErrInvalidDelegator, "not-an-address"),
+		},
+		{
+			name:    "empty delegator address",
+			args:    []interface{}{common.Address{}, validatorAddr, amount},
+			wantErr: true,
+			errMsg:  fmt.Sprintf(cmn.ErrInvalidDelegator, common.Address{}),
+		},
+		{
+			name:    "invalid validator address type",
+			args:    []interface{}{delegatorAddr, 123, amount},
+			wantErr: true,
+			errMsg:  fmt.Sprintf(cmn.ErrInvalidType, "validatorAddress", "string", 123),
+		},
+		{
+			name:    "invalid amount type",
+			args:    []interface{}{delegatorAddr, validatorAddr, "not-a-big-int"},
+			wantErr: true,
+			errMsg:  fmt.Sprintf(cmn.ErrInvalidAmount, "not-a-big-int"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg, returnAddr, err := NewMsgDelegate(tt.args, denom, addrCodec)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.errMsg)
+				require.Nil(t, msg)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, msg)
+				require.Equal(t, delegatorAddr, returnAddr)
+				require.Equal(t, tt.wantDelegatorAddr, msg.DelegatorAddress)
+				require.Equal(t, tt.wantValidatorAddr, msg.ValidatorAddress)
+				require.Equal(t, tt.wantAmount, msg.Amount.Amount.BigInt())
+				require.Equal(t, denom, msg.Amount.Denom)
+			}
+		})
+	}
+}
+
+func TestNewMsgUndelegate(t *testing.T) {
+	addrCodec := authcodec.NewBech32Codec(sdk.GetConfig().GetBech32AccountAddrPrefix())
+
+	delegatorAddr := common.HexToAddress("0x1234567890123456789012345678901234567890")
+	validatorAddr := "cosmosvaloper1qypqxpq9qcrsszg2pvxq6rs0zqg3yyc5a3kaax"
+	amount := big.NewInt(1000000000)
+	denom := "stake"
+
+	expectedDelegatorAddr, err := addrCodec.BytesToString(delegatorAddr.Bytes())
+	require.NoError(t, err)
+
+	tests := []struct {
+		name              string
+		args              []interface{}
+		wantErr           bool
+		errMsg            string
+		wantDelegatorAddr string
+		wantValidatorAddr string
+		wantAmount        *big.Int
+	}{
+		{
+			name:              "valid",
+			args:              []interface{}{delegatorAddr, validatorAddr, amount},
+			wantErr:           false,
+			wantDelegatorAddr: expectedDelegatorAddr,
+			wantValidatorAddr: validatorAddr,
+			wantAmount:        amount,
+		},
+		{
+			name:    "no arguments",
+			args:    []interface{}{},
+			wantErr: true,
+			errMsg:  fmt.Sprintf(cmn.ErrInvalidNumberOfArgs, 3, 0),
+		},
+		{
+			name:    "too many arguments",
+			args:    []interface{}{delegatorAddr, validatorAddr, amount, "extra"},
+			wantErr: true,
+			errMsg:  fmt.Sprintf(cmn.ErrInvalidNumberOfArgs, 3, 4),
+		},
+		{
+			name:    "invalid delegator type",
+			args:    []interface{}{"not-an-address", validatorAddr, amount},
+			wantErr: true,
+			errMsg:  fmt.Sprintf(cmn.ErrInvalidDelegator, "not-an-address"),
+		},
+		{
+			name:    "empty delegator address",
+			args:    []interface{}{common.Address{}, validatorAddr, amount},
+			wantErr: true,
+			errMsg:  fmt.Sprintf(cmn.ErrInvalidDelegator, common.Address{}),
+		},
+		{
+			name:    "invalid validator address type",
+			args:    []interface{}{delegatorAddr, 123, amount},
+			wantErr: true,
+			errMsg:  fmt.Sprintf(cmn.ErrInvalidType, "validatorAddress", "string", 123),
+		},
+		{
+			name:    "invalid amount type",
+			args:    []interface{}{delegatorAddr, validatorAddr, "not-a-big-int"},
+			wantErr: true,
+			errMsg:  fmt.Sprintf(cmn.ErrInvalidAmount, "not-a-big-int"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg, returnAddr, err := NewMsgUndelegate(tt.args, denom, addrCodec)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.errMsg)
+				require.Nil(t, msg)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, msg)
+				require.Equal(t, delegatorAddr, returnAddr)
+				require.Equal(t, tt.wantDelegatorAddr, msg.DelegatorAddress)
+				require.Equal(t, tt.wantValidatorAddr, msg.ValidatorAddress)
+				require.Equal(t, tt.wantAmount, msg.Amount.Amount.BigInt())
+				require.Equal(t, denom, msg.Amount.Denom)
+			}
+		})
+	}
+}
+
+func TestNewMsgRedelegate(t *testing.T) {
+	addrCodec := authcodec.NewBech32Codec(sdk.GetConfig().GetBech32AccountAddrPrefix())
+
+	delegatorAddr := common.HexToAddress("0x1234567890123456789012345678901234567890")
+	validatorSrcAddr := "cosmosvaloper1qypqxpq9qcrsszg2pvxq6rs0zqg3yyc5a3kaax"
+	validatorDstAddr := "cosmosvaloper1qypqxpq9qcrsszg2pvxq6rs0zqg3yyc5a3kaay"
+	amount := big.NewInt(1000000000)
+	denom := "stake"
+
+	expectedDelegatorAddr, err := addrCodec.BytesToString(delegatorAddr.Bytes())
+	require.NoError(t, err)
+
+	tests := []struct {
+		name                 string
+		args                 []interface{}
+		wantErr              bool
+		errMsg               string
+		wantDelegatorAddr    string
+		wantValidatorSrcAddr string
+		wantValidatorDstAddr string
+		wantAmount           *big.Int
+	}{
+		{
+			name:                 "valid",
+			args:                 []interface{}{delegatorAddr, validatorSrcAddr, validatorDstAddr, amount},
+			wantErr:              false,
+			wantDelegatorAddr:    expectedDelegatorAddr,
+			wantValidatorSrcAddr: validatorSrcAddr,
+			wantValidatorDstAddr: validatorDstAddr,
+			wantAmount:           amount,
+		},
+		{
+			name:    "no arguments",
+			args:    []interface{}{},
+			wantErr: true,
+			errMsg:  fmt.Sprintf(cmn.ErrInvalidNumberOfArgs, 4, 0),
+		},
+		{
+			name:    "too many arguments",
+			args:    []interface{}{delegatorAddr, validatorSrcAddr, validatorDstAddr, amount, "extra"},
+			wantErr: true,
+			errMsg:  fmt.Sprintf(cmn.ErrInvalidNumberOfArgs, 4, 5),
+		},
+		{
+			name:    "invalid delegator type",
+			args:    []interface{}{"not-an-address", validatorSrcAddr, validatorDstAddr, amount},
+			wantErr: true,
+			errMsg:  fmt.Sprintf(cmn.ErrInvalidDelegator, "not-an-address"),
+		},
+		{
+			name:    "empty delegator address",
+			args:    []interface{}{common.Address{}, validatorSrcAddr, validatorDstAddr, amount},
+			wantErr: true,
+			errMsg:  fmt.Sprintf(cmn.ErrInvalidDelegator, common.Address{}),
+		},
+		{
+			name:    "invalid validator src address type",
+			args:    []interface{}{delegatorAddr, 123, validatorDstAddr, amount},
+			wantErr: true,
+			errMsg:  fmt.Sprintf(cmn.ErrInvalidType, "validatorSrcAddress", "string", 123),
+		},
+		{
+			name:    "invalid validator dst address type",
+			args:    []interface{}{delegatorAddr, validatorSrcAddr, 123, amount},
+			wantErr: true,
+			errMsg:  fmt.Sprintf(cmn.ErrInvalidType, "validatorDstAddress", "string", 123),
+		},
+		{
+			name:    "invalid amount type",
+			args:    []interface{}{delegatorAddr, validatorSrcAddr, validatorDstAddr, "not-a-big-int"},
+			wantErr: true,
+			errMsg:  fmt.Sprintf(cmn.ErrInvalidAmount, "not-a-big-int"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg, returnAddr, err := NewMsgRedelegate(tt.args, denom, addrCodec)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.errMsg)
+				require.Nil(t, msg)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, msg)
+				require.Equal(t, delegatorAddr, returnAddr)
+				require.Equal(t, tt.wantDelegatorAddr, msg.DelegatorAddress)
+				require.Equal(t, tt.wantValidatorSrcAddr, msg.ValidatorSrcAddress)
+				require.Equal(t, tt.wantValidatorDstAddr, msg.ValidatorDstAddress)
+				require.Equal(t, tt.wantAmount, msg.Amount.Amount.BigInt())
+				require.Equal(t, denom, msg.Amount.Denom)
+			}
+		})
+	}
+}
+
+func TestNewMsgCancelUnbondingDelegation(t *testing.T) {
+	addrCodec := authcodec.NewBech32Codec(sdk.GetConfig().GetBech32AccountAddrPrefix())
+
+	delegatorAddr := common.HexToAddress("0x1234567890123456789012345678901234567890")
+	validatorAddr := "cosmosvaloper1qypqxpq9qcrsszg2pvxq6rs0zqg3yyc5a3kaax"
+	amount := big.NewInt(1000000000)
+	creationHeight := big.NewInt(100)
+	denom := "stake"
+
+	expectedDelegatorAddr, err := addrCodec.BytesToString(delegatorAddr.Bytes())
+	require.NoError(t, err)
+
+	tests := []struct {
+		name               string
+		args               []interface{}
+		wantErr            bool
+		errMsg             string
+		wantDelegatorAddr  string
+		wantValidatorAddr  string
+		wantAmount         *big.Int
+		wantCreationHeight int64
+	}{
+		{
+			name:               "valid",
+			args:               []interface{}{delegatorAddr, validatorAddr, amount, creationHeight},
+			wantErr:            false,
+			wantDelegatorAddr:  expectedDelegatorAddr,
+			wantValidatorAddr:  validatorAddr,
+			wantAmount:         amount,
+			wantCreationHeight: creationHeight.Int64(),
+		},
+		{
+			name:    "no arguments",
+			args:    []interface{}{},
+			wantErr: true,
+			errMsg:  fmt.Sprintf(cmn.ErrInvalidNumberOfArgs, 4, 0),
+		},
+		{
+			name:    "too many arguments",
+			args:    []interface{}{delegatorAddr, validatorAddr, amount, creationHeight, "extra"},
+			wantErr: true,
+			errMsg:  fmt.Sprintf(cmn.ErrInvalidNumberOfArgs, 4, 5),
+		},
+		{
+			name:    "invalid delegator type",
+			args:    []interface{}{"not-an-address", validatorAddr, amount, creationHeight},
+			wantErr: true,
+			errMsg:  fmt.Sprintf(cmn.ErrInvalidDelegator, "not-an-address"),
+		},
+		{
+			name:    "empty delegator address",
+			args:    []interface{}{common.Address{}, validatorAddr, amount, creationHeight},
+			wantErr: true,
+			errMsg:  fmt.Sprintf(cmn.ErrInvalidDelegator, common.Address{}),
+		},
+		{
+			name:    "invalid validator address type",
+			args:    []interface{}{delegatorAddr, 123, amount, creationHeight},
+			wantErr: true,
+			errMsg:  fmt.Sprintf(cmn.ErrInvalidType, "validatorAddress", "string", 123),
+		},
+		{
+			name:    "invalid amount type",
+			args:    []interface{}{delegatorAddr, validatorAddr, "not-a-big-int", creationHeight},
+			wantErr: true,
+			errMsg:  fmt.Sprintf(cmn.ErrInvalidAmount, "not-a-big-int"),
+		},
+		{
+			name:    "invalid creation height type",
+			args:    []interface{}{delegatorAddr, validatorAddr, amount, "not-a-big-int"},
+			wantErr: true,
+			errMsg:  "invalid creation height",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg, returnAddr, err := NewMsgCancelUnbondingDelegation(tt.args, denom, addrCodec)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.errMsg)
+				require.Nil(t, msg)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, msg)
+				require.Equal(t, delegatorAddr, returnAddr)
+				require.Equal(t, tt.wantDelegatorAddr, msg.DelegatorAddress)
+				require.Equal(t, tt.wantValidatorAddr, msg.ValidatorAddress)
+				require.Equal(t, tt.wantAmount, msg.Amount.Amount.BigInt())
+				require.Equal(t, tt.wantCreationHeight, msg.CreationHeight)
+				require.Equal(t, denom, msg.Amount.Denom)
+			}
+		})
+	}
+}
+
+func TestNewDelegationRequest(t *testing.T) {
+	addrCodec := authcodec.NewBech32Codec(sdk.GetConfig().GetBech32AccountAddrPrefix())
+
+	delegatorAddr := common.HexToAddress("0x1234567890123456789012345678901234567890")
+	validatorAddr := "cosmosvaloper1qypqxpq9qcrsszg2pvxq6rs0zqg3yyc5a3kaax"
+
+	expectedDelegatorAddr, err := addrCodec.BytesToString(delegatorAddr.Bytes())
+	require.NoError(t, err)
+
+	tests := []struct {
+		name              string
+		args              []interface{}
+		wantErr           bool
+		errMsg            string
+		wantDelegatorAddr string
+		wantValidatorAddr string
+	}{
+		{
+			name:              "valid",
+			args:              []interface{}{delegatorAddr, validatorAddr},
+			wantErr:           false,
+			wantDelegatorAddr: expectedDelegatorAddr,
+			wantValidatorAddr: validatorAddr,
+		},
+		{
+			name:    "no arguments",
+			args:    []interface{}{},
+			wantErr: true,
+			errMsg:  fmt.Sprintf(cmn.ErrInvalidNumberOfArgs, 2, 0),
+		},
+		{
+			name:    "too many arguments",
+			args:    []interface{}{delegatorAddr, validatorAddr, "extra"},
+			wantErr: true,
+			errMsg:  fmt.Sprintf(cmn.ErrInvalidNumberOfArgs, 2, 3),
+		},
+		{
+			name:    "invalid delegator type",
+			args:    []interface{}{"not-an-address", validatorAddr},
+			wantErr: true,
+			errMsg:  fmt.Sprintf(cmn.ErrInvalidDelegator, "not-an-address"),
+		},
+		{
+			name:    "empty delegator address",
+			args:    []interface{}{common.Address{}, validatorAddr},
+			wantErr: true,
+			errMsg:  fmt.Sprintf(cmn.ErrInvalidDelegator, common.Address{}),
+		},
+		{
+			name:    "invalid validator address type",
+			args:    []interface{}{delegatorAddr, 123},
+			wantErr: true,
+			errMsg:  fmt.Sprintf(cmn.ErrInvalidType, "validatorAddress", "string", 123),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, err := NewDelegationRequest(tt.args, addrCodec)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.errMsg)
+				require.Nil(t, req)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, req)
+				require.Equal(t, tt.wantDelegatorAddr, req.DelegatorAddr)
+				require.Equal(t, tt.wantValidatorAddr, req.ValidatorAddr)
+			}
+		})
+	}
+}
+
+func TestNewUnbondingDelegationRequest(t *testing.T) {
+	addrCodec := authcodec.NewBech32Codec(sdk.GetConfig().GetBech32AccountAddrPrefix())
+
+	delegatorAddr := common.HexToAddress("0x1234567890123456789012345678901234567890")
+	validatorAddr := "cosmosvaloper1qypqxpq9qcrsszg2pvxq6rs0zqg3yyc5a3kaax"
+
+	expectedDelegatorAddr, err := addrCodec.BytesToString(delegatorAddr.Bytes())
+	require.NoError(t, err)
+
+	tests := []struct {
+		name              string
+		args              []interface{}
+		wantErr           bool
+		errMsg            string
+		wantDelegatorAddr string
+		wantValidatorAddr string
+	}{
+		{
+			name:              "valid",
+			args:              []interface{}{delegatorAddr, validatorAddr},
+			wantErr:           false,
+			wantDelegatorAddr: expectedDelegatorAddr,
+			wantValidatorAddr: validatorAddr,
+		},
+		{
+			name:    "no arguments",
+			args:    []interface{}{},
+			wantErr: true,
+			errMsg:  fmt.Sprintf(cmn.ErrInvalidNumberOfArgs, 2, 0),
+		},
+		{
+			name:    "too many arguments",
+			args:    []interface{}{delegatorAddr, validatorAddr, "extra"},
+			wantErr: true,
+			errMsg:  fmt.Sprintf(cmn.ErrInvalidNumberOfArgs, 2, 3),
+		},
+		{
+			name:    "invalid delegator type",
+			args:    []interface{}{"not-an-address", validatorAddr},
+			wantErr: true,
+			errMsg:  fmt.Sprintf(cmn.ErrInvalidDelegator, "not-an-address"),
+		},
+		{
+			name:    "empty delegator address",
+			args:    []interface{}{common.Address{}, validatorAddr},
+			wantErr: true,
+			errMsg:  fmt.Sprintf(cmn.ErrInvalidDelegator, common.Address{}),
+		},
+		{
+			name:    "invalid validator address type",
+			args:    []interface{}{delegatorAddr, 123},
+			wantErr: true,
+			errMsg:  fmt.Sprintf(cmn.ErrInvalidType, "validatorAddress", "string", 123),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, err := NewUnbondingDelegationRequest(tt.args, addrCodec)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.errMsg)
+				require.Nil(t, req)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, req)
+				require.Equal(t, tt.wantDelegatorAddr, req.DelegatorAddr)
+				require.Equal(t, tt.wantValidatorAddr, req.ValidatorAddr)
+			}
+		})
+	}
+}

--- a/precompiles/staking/types_test.go
+++ b/precompiles/staking/types_test.go
@@ -129,7 +129,7 @@ func TestNewMsgCreateValidator(t *testing.T) {
 				require.NoError(t, err)
 				require.NotNil(t, msg)
 				require.Equal(t, validatorHexAddr, returnAddr)
-				require.Equal(t, tt.wantDelegatorAddr, msg.DelegatorAddress)
+				require.Equal(t, tt.wantDelegatorAddr, msg.DelegatorAddress) //nolint:staticcheck // its populated, we'll check it
 				require.Equal(t, tt.wantValidatorAddr, msg.ValidatorAddress)
 				require.Equal(t, tt.wantMinSelfDel, msg.MinSelfDelegation.BigInt())
 				require.Equal(t, tt.wantValue, msg.Value.Amount.BigInt())

--- a/tests/integration/precompiles/distribution/test_setup.go
+++ b/tests/integration/precompiles/distribution/test_setup.go
@@ -1,6 +1,7 @@
 package distribution
 
 import (
+	"github.com/cosmos/cosmos-sdk/codec/address"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/cosmos/evm/precompiles/distribution"
@@ -117,6 +118,7 @@ func (s *PrecompileTestSuite) SetupTest() {
 		s.network.App.GetDistrKeeper(),
 		*s.network.App.GetStakingKeeper(),
 		s.network.App.GetEVMKeeper(),
+		address.NewBech32Codec(sdk.GetConfig().GetBech32AccountAddrPrefix()),
 	)
 	if err != nil {
 		panic(err)

--- a/tests/integration/precompiles/distribution/test_setup.go
+++ b/tests/integration/precompiles/distribution/test_setup.go
@@ -1,7 +1,6 @@
 package distribution
 
 import (
-	"github.com/cosmos/cosmos-sdk/codec/address"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/cosmos/evm/precompiles/distribution"
@@ -14,6 +13,7 @@ import (
 
 	"cosmossdk.io/math"
 
+	"github.com/cosmos/cosmos-sdk/codec/address"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	distrtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
 	minttypes "github.com/cosmos/cosmos-sdk/x/mint/types"

--- a/tests/integration/precompiles/distribution/test_utils.go
+++ b/tests/integration/precompiles/distribution/test_utils.go
@@ -1,12 +1,12 @@
 package distribution
 
 import (
-	"github.com/cosmos/cosmos-sdk/codec/address"
 	"github.com/cosmos/evm/precompiles/staking"
 	"github.com/cosmos/evm/testutil/keyring"
 
 	"cosmossdk.io/math"
 
+	"github.com/cosmos/cosmos-sdk/codec/address"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	distrtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
 	minttypes "github.com/cosmos/cosmos-sdk/x/mint/types"

--- a/tests/integration/precompiles/distribution/test_utils.go
+++ b/tests/integration/precompiles/distribution/test_utils.go
@@ -1,6 +1,7 @@
 package distribution
 
 import (
+	"github.com/cosmos/cosmos-sdk/codec/address"
 	"github.com/cosmos/evm/precompiles/staking"
 	"github.com/cosmos/evm/testutil/keyring"
 
@@ -83,6 +84,7 @@ func (s *PrecompileTestSuite) fundAccountWithBaseDenom(ctx sdk.Context, addr sdk
 func (s *PrecompileTestSuite) getStakingPrecompile() (*staking.Precompile, error) {
 	return staking.NewPrecompile(
 		*s.network.App.GetStakingKeeper(),
+		address.NewBech32Codec(sdk.GetConfig().GetBech32AccountAddrPrefix()),
 	)
 }
 

--- a/tests/integration/precompiles/gov/test_setup.go
+++ b/tests/integration/precompiles/gov/test_setup.go
@@ -3,7 +3,6 @@ package gov
 import (
 	"time"
 
-	"github.com/cosmos/cosmos-sdk/codec/address"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/cosmos/evm/precompiles/gov"
@@ -15,6 +14,7 @@ import (
 
 	"cosmossdk.io/math"
 
+	"github.com/cosmos/cosmos-sdk/codec/address"
 	"github.com/cosmos/cosmos-sdk/codec/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"

--- a/tests/integration/precompiles/gov/test_setup.go
+++ b/tests/integration/precompiles/gov/test_setup.go
@@ -3,6 +3,7 @@ package gov
 import (
 	"time"
 
+	"github.com/cosmos/cosmos-sdk/codec/address"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/cosmos/evm/precompiles/gov"
@@ -137,6 +138,7 @@ func (s *PrecompileTestSuite) SetupTest() {
 	if s.precompile, err = gov.NewPrecompile(
 		s.network.App.GetGovKeeper(),
 		s.network.App.AppCodec(),
+		address.NewBech32Codec(sdk.GetConfig().GetBech32AccountAddrPrefix()),
 	); err != nil {
 		panic(err)
 	}

--- a/tests/integration/precompiles/slashing/test_setup.go
+++ b/tests/integration/precompiles/slashing/test_setup.go
@@ -1,7 +1,6 @@
 package slashing
 
 import (
-	"github.com/cosmos/cosmos-sdk/codec/address"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/cosmos/evm/precompiles/slashing"
@@ -10,6 +9,7 @@ import (
 	"github.com/cosmos/evm/testutil/integration/evm/network"
 	testkeyring "github.com/cosmos/evm/testutil/keyring"
 
+	"github.com/cosmos/cosmos-sdk/codec/address"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 

--- a/tests/integration/precompiles/slashing/test_setup.go
+++ b/tests/integration/precompiles/slashing/test_setup.go
@@ -1,6 +1,7 @@
 package slashing
 
 import (
+	"github.com/cosmos/cosmos-sdk/codec/address"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/cosmos/evm/precompiles/slashing"
@@ -55,6 +56,8 @@ func (s *PrecompileTestSuite) SetupTest() {
 
 	if s.precompile, err = slashing.NewPrecompile(
 		s.network.App.GetSlashingKeeper(),
+		address.NewBech32Codec(sdk.GetConfig().GetBech32ValidatorAddrPrefix()),
+		address.NewBech32Codec(sdk.GetConfig().GetBech32ConsensusAddrPrefix()),
 	); err != nil {
 		panic(err)
 	}

--- a/tests/integration/precompiles/staking/test_setup.go
+++ b/tests/integration/precompiles/staking/test_setup.go
@@ -1,7 +1,6 @@
 package staking
 
 import (
-	"github.com/cosmos/cosmos-sdk/codec/address"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/cosmos/evm/precompiles/staking"
@@ -13,6 +12,7 @@ import (
 
 	sdkmath "cosmossdk.io/math"
 
+	"github.com/cosmos/cosmos-sdk/codec/address"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"

--- a/tests/integration/precompiles/staking/test_setup.go
+++ b/tests/integration/precompiles/staking/test_setup.go
@@ -1,6 +1,7 @@
 package staking
 
 import (
+	"github.com/cosmos/cosmos-sdk/codec/address"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/cosmos/evm/precompiles/staking"
@@ -79,6 +80,7 @@ func (s *PrecompileTestSuite) SetupTest() {
 
 	if s.precompile, err = staking.NewPrecompile(
 		*s.network.App.GetStakingKeeper(),
+		address.NewBech32Codec(sdk.GetConfig().GetBech32AccountAddrPrefix()),
 	); err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
# Description

uses address codecs in precompiles

closes: EVM-77

---

## Author Checklist

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.

I have...

- [ ] tackled an existing issue or discussed with a team member
- [ ] left instructions on how to review the changes
- [ ] targeted the `main` branch

## Reviewers Checklist

**All** items are required.
Please add a note if the item is not applicable
and please add your handle next to the items reviewed
if you only reviewed selected items.

I have...

- [ ] added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] confirmed all author checklist items have been addressed
- [ ] confirmed that this PR does not change production code
- [ ] reviewed content
- [ ] tested instructions (if applicable)
- [ ] confirmed all CI checks have passed
