### PR TITLE
fix: EmitApprovalEvent should use owner address

### DIFF
--- a/precompiles/erc20/approve.go
+++ b/precompiles/erc20/approve.go
@@ -66,8 +66,7 @@ func (p Precompile) Approve(
 		return nil, err
 	}
 
-	// TODO: check owner?
-	if err := p.EmitApprovalEvent(ctx, stateDB, p.Address(), spender, amount); err != nil {
+	if err := p.EmitApprovalEvent(ctx, stateDB, owner, spender, amount); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
# Description

EmitApprovalEvent should emit the owner's address instead of the precompile address.

Otherwise, when transferFrom is called, the emitted event incorrectly shows the precompile address as the approver instead of the actual owner.

Closes: #XXXX

---

## Author Checklist

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.

I have...

- [ ] tackled an existing issue or discussed with a team member
- [ ] left instructions on how to review the changes
- [ ] targeted the `main` branch

## Reviewers Checklist

**All** items are required.
Please add a note if the item is not applicable
and please add your handle next to the items reviewed
if you only reviewed selected items.

I have...

- [ ] added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] confirmed all author checklist items have been addressed
- [ ] confirmed that this PR does not change production code
- [ ] reviewed content
- [ ] tested instructions (if applicable)
- [ ] confirmed all CI checks have passed
