### PR TITLE
fix: properly bubble up errors in BlockHash rpcs and fix flaky tests

### DIFF
--- a/precompiles/gov/types.go
+++ b/precompiles/gov/types.go
@@ -724,7 +724,7 @@ func (po *ProposalsOutput) FromResponse(res *govv1.QueryProposalsResponse) *Prop
 			return nil
 		}
 
-		po.Proposals[i] = ProposalData{
+		proposalData := ProposalData{
 			Id:       p.Id,
 			Messages: msgs,
 			Status:   uint32(p.Status), //nolint:gosec // G115
@@ -734,16 +734,24 @@ func (po *ProposalsOutput) FromResponse(res *govv1.QueryProposalsResponse) *Prop
 				No:         p.FinalTallyResult.NoCount,
 				NoWithVeto: p.FinalTallyResult.NoWithVetoCount,
 			},
-			SubmitTime:      uint64(p.SubmitTime.Unix()),     //nolint:gosec // G115
-			DepositEndTime:  uint64(p.DepositEndTime.Unix()), //nolint:gosec // G115
-			TotalDeposit:    coins,
-			VotingStartTime: uint64(p.VotingStartTime.Unix()), //nolint:gosec // G115
-			VotingEndTime:   uint64(p.VotingEndTime.Unix()),   //nolint:gosec // G115
-			Metadata:        p.Metadata,
-			Title:           p.Title,
-			Summary:         p.Summary,
-			Proposer:        proposer,
+			SubmitTime:     uint64(p.SubmitTime.Unix()),     //nolint:gosec // G115
+			DepositEndTime: uint64(p.DepositEndTime.Unix()), //nolint:gosec // G115
+			TotalDeposit:   coins,
+			Metadata:       p.Metadata,
+			Title:          p.Title,
+			Summary:        p.Summary,
+			Proposer:       proposer,
 		}
+
+		// The following fields are nil when proposal is in deposit period
+		if p.VotingStartTime != nil {
+			proposalData.VotingStartTime = uint64(p.VotingStartTime.Unix()) //nolint:gosec // G115
+		}
+		if p.VotingEndTime != nil {
+			proposalData.VotingEndTime = uint64(p.VotingEndTime.Unix()) //nolint:gosec // G115
+		}
+
+		po.Proposals[i] = proposalData
 	}
 
 	if res.Pagination != nil {

--- a/precompiles/p256/p256.go
+++ b/precompiles/p256/p256.go
@@ -77,7 +77,9 @@ func (p *Precompile) Run(_ *vm.EVM, contract *vm.Contract, _ bool) (bz []byte, e
 	// Verify the secp256r1 signature
 	if secp256r1.Verify(hash, r, s, x, y) {
 		// Signature is valid
-		return common.LeftPadBytes(common.Big1.Bytes(), 32), nil
+		result := make([]byte, 32)
+		common.Big1.FillBytes(result)
+		return result, nil
 	}
 
 	// Signature is invalid

--- a/rpc/backend/blocks.go
+++ b/rpc/backend/blocks.go
@@ -186,7 +186,12 @@ func (b *Backend) TendermintBlockByNumber(blockNum rpctypes.BlockNumber) (*tmrpc
 // TendermintBlockResultByNumber returns a Tendermint-formatted block result
 // by block number
 func (b *Backend) TendermintBlockResultByNumber(height *int64) (*tmrpctypes.ResultBlockResults, error) {
-	return b.RPCClient.BlockResults(b.Ctx, height)
+	res, err := b.RPCClient.BlockResults(b.Ctx, height)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch block result from Tendermint %d: %w", *height, err)
+	}
+
+	return res, nil
 }
 
 // TendermintBlockByHash returns a Tendermint-formatted block by block number
@@ -199,7 +204,7 @@ func (b *Backend) TendermintBlockByHash(blockHash common.Hash) (*tmrpctypes.Resu
 
 	if resBlock == nil || resBlock.Block == nil {
 		b.Logger.Debug("TendermintBlockByHash block not found", "blockHash", blockHash.Hex())
-		return nil, nil
+		return nil, fmt.Errorf("block not found for hash %s", blockHash.Hex())
 	}
 
 	return resBlock, nil

--- a/rpc/backend/node_info.go
+++ b/rpc/backend/node_info.go
@@ -101,7 +101,7 @@ func (b *Backend) SetEtherbase(etherbase common.Address) bool {
 	// Assemble transaction from fields
 	builder, ok := b.ClientCtx.TxConfig.NewTxBuilder().(authtx.ExtensionOptionsTxBuilder)
 	if !ok {
-		b.Logger.Debug("clientCtx.TxConfig.NewTxBuilder returns unsupported builder", "error", err.Error())
+		b.Logger.Debug("clientCtx.TxConfig.NewTxBuilder returns unsupported builder")
 		return false
 	}
 

--- a/rpc/namespaces/ethereum/eth/filters/filters.go
+++ b/rpc/namespaces/ethereum/eth/filters/filters.go
@@ -108,7 +108,7 @@ func (f *Filter) Logs(_ context.Context, logLimit int, blockLimit int64) ([]*eth
 		blockRes, err := f.backend.TendermintBlockResultByNumber(&resBlock.Block.Height)
 		if err != nil {
 			f.logger.Debug("failed to fetch block result from Tendermint", "height", resBlock.Block.Height, "error", err.Error())
-			return nil, nil
+			return nil, err
 		}
 
 		bloom, err := f.backend.BlockBloom(blockRes)

--- a/tests/integration/precompiles/p256/test_integration.go
+++ b/tests/integration/precompiles/p256/test_integration.go
@@ -110,10 +110,10 @@ func TestPrecompileIntegrationTestSuite(t *testing.T, create network.CreateEvmAp
 						copy(input[0:32], hash)
 
 						// ALWAYS left-pad to 32 bytes:
-						copy(input[32:64], common.LeftPadBytes(rInt.Bytes(), 32))
-						copy(input[64:96], common.LeftPadBytes(sInt.Bytes(), 32))
-						copy(input[96:128], common.LeftPadBytes(pub.X.Bytes(), 32))
-						copy(input[128:160], common.LeftPadBytes(pub.Y.Bytes(), 32))
+						rInt.FillBytes(input[32:64])
+						sInt.FillBytes(input[64:96])
+						pub.X.FillBytes(input[96:128])
+						pub.Y.FillBytes(input[128:160])
 						return input, nil, ""
 					},
 				),
@@ -170,10 +170,10 @@ func TestPrecompileIntegrationTestSuite(t *testing.T, create network.CreateEvmAp
 
 						input = make([]byte, p256.VerifyInputLength)
 						copy(input[0:32], hash)
-						copy(input[32:64], rInt.Bytes())
-						copy(input[64:96], sInt.Bytes())
-						copy(input[96:128], privB.PublicKey.X.Bytes())
-						copy(input[128:160], privB.PublicKey.Y.Bytes())
+						rInt.FillBytes(input[32:64])
+						sInt.FillBytes(input[64:96])
+						privB.PublicKey.X.FillBytes(input[96:128])
+						privB.PublicKey.Y.FillBytes(input[128:160])
 						return input
 					},
 				),

--- a/tests/integration/precompiles/p256/test_p256.go
+++ b/tests/integration/precompiles/p256/test_p256.go
@@ -41,10 +41,10 @@ func (s *PrecompileTestSuite) TestRun() {
 
 				input := make([]byte, p256.VerifyInputLength)
 				copy(input[0:32], hash)
-				copy(input[32:64], rInt.Bytes())
-				copy(input[64:96], sInt.Bytes())
-				copy(input[96:128], s.p256Priv.X.Bytes())
-				copy(input[128:160], s.p256Priv.Y.Bytes())
+				copy(input[32:64], common.LeftPadBytes(rInt.Bytes(), 32))
+				copy(input[64:96], common.LeftPadBytes(sInt.Bytes(), 32))
+				copy(input[96:128], common.LeftPadBytes(s.p256Priv.X.Bytes(), 32))
+				copy(input[128:160], common.LeftPadBytes(s.p256Priv.Y.Bytes(), 32))
 
 				return input
 			},
@@ -64,10 +64,10 @@ func (s *PrecompileTestSuite) TestRun() {
 
 				input := make([]byte, p256.VerifyInputLength)
 				copy(input[0:32], hash)
-				copy(input[32:64], rBz)
-				copy(input[64:96], sBz)
-				copy(input[96:128], s.p256Priv.X.Bytes())
-				copy(input[128:160], s.p256Priv.Y.Bytes())
+				copy(input[32:64], common.LeftPadBytes(rBz, 32))
+				copy(input[64:96], common.LeftPadBytes(sBz, 32))
+				copy(input[96:128], common.LeftPadBytes(s.p256Priv.X.Bytes(), 32))
+				copy(input[128:160], common.LeftPadBytes(s.p256Priv.Y.Bytes(), 32))
 
 				return input
 			},
@@ -90,10 +90,10 @@ func (s *PrecompileTestSuite) TestRun() {
 
 				input := make([]byte, p256.VerifyInputLength)
 				copy(input[0:32], hash)
-				copy(input[32:64], rInt.Bytes())
-				copy(input[64:96], sInt.Bytes())
-				copy(input[96:128], privB.X.Bytes())
-				copy(input[128:160], privB.Y.Bytes())
+				copy(input[32:64], common.LeftPadBytes(rInt.Bytes(), 32))
+				copy(input[64:96], common.LeftPadBytes(sInt.Bytes(), 32))
+				copy(input[96:128], common.LeftPadBytes(privB.X.Bytes(), 32))
+				copy(input[128:160], common.LeftPadBytes(privB.Y.Bytes(), 32))
 
 				return input
 			},

--- a/tests/integration/precompiles/p256/test_p256.go
+++ b/tests/integration/precompiles/p256/test_p256.go
@@ -4,6 +4,7 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
+	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/vm"
@@ -41,10 +42,10 @@ func (s *PrecompileTestSuite) TestRun() {
 
 				input := make([]byte, p256.VerifyInputLength)
 				copy(input[0:32], hash)
-				copy(input[32:64], common.LeftPadBytes(rInt.Bytes(), 32))
-				copy(input[64:96], common.LeftPadBytes(sInt.Bytes(), 32))
-				copy(input[96:128], common.LeftPadBytes(s.p256Priv.X.Bytes(), 32))
-				copy(input[128:160], common.LeftPadBytes(s.p256Priv.Y.Bytes(), 32))
+				rInt.FillBytes(input[32:64])
+				sInt.FillBytes(input[64:96])
+				s.p256Priv.X.FillBytes(input[96:128])
+				s.p256Priv.Y.FillBytes(input[128:160])
 
 				return input
 			},
@@ -60,14 +61,15 @@ func (s *PrecompileTestSuite) TestRun() {
 				s.Require().NoError(err)
 
 				rBz, sBz, err := parseSignature(sig)
+				rInt, sInt := new(big.Int).SetBytes(rBz), new(big.Int).SetBytes(sBz)
 				s.Require().NoError(err)
 
 				input := make([]byte, p256.VerifyInputLength)
 				copy(input[0:32], hash)
-				copy(input[32:64], common.LeftPadBytes(rBz, 32))
-				copy(input[64:96], common.LeftPadBytes(sBz, 32))
-				copy(input[96:128], common.LeftPadBytes(s.p256Priv.X.Bytes(), 32))
-				copy(input[128:160], common.LeftPadBytes(s.p256Priv.Y.Bytes(), 32))
+				rInt.FillBytes(input[32:64])
+				sInt.FillBytes(input[64:96])
+				s.p256Priv.X.FillBytes(input[96:128])
+				s.p256Priv.Y.FillBytes(input[128:160])
 
 				return input
 			},
@@ -90,10 +92,10 @@ func (s *PrecompileTestSuite) TestRun() {
 
 				input := make([]byte, p256.VerifyInputLength)
 				copy(input[0:32], hash)
-				copy(input[32:64], common.LeftPadBytes(rInt.Bytes(), 32))
-				copy(input[64:96], common.LeftPadBytes(sInt.Bytes(), 32))
-				copy(input[96:128], common.LeftPadBytes(privB.X.Bytes(), 32))
-				copy(input[128:160], common.LeftPadBytes(privB.Y.Bytes(), 32))
+				rInt.FillBytes(input[32:64])
+				sInt.FillBytes(input[64:96])
+				privB.X.FillBytes(input[96:128])
+				privB.Y.FillBytes(input[128:160])
 
 				return input
 			},

--- a/tests/integration/precompiles/p256/test_setup.go
+++ b/tests/integration/precompiles/p256/test_setup.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/cosmos/evm/precompiles/p256"
 	"github.com/cosmos/evm/testutil/integration/evm/network"
+	"github.com/ethereum/go-ethereum/common"
 )
 
 type PrecompileTestSuite struct {
@@ -48,10 +49,10 @@ func signMsg(msg []byte, priv *ecdsa.PrivateKey) ([]byte, error) {
 
 	input := make([]byte, p256.VerifyInputLength)
 	copy(input[0:32], hash)
-	copy(input[32:64], rInt.Bytes())
-	copy(input[64:96], sInt.Bytes())
-	copy(input[96:128], priv.X.Bytes())
-	copy(input[128:160], priv.Y.Bytes())
+	copy(input[32:64], common.LeftPadBytes(rInt.Bytes(), 32))
+	copy(input[64:96], common.LeftPadBytes(sInt.Bytes(), 32))
+	copy(input[96:128], common.LeftPadBytes(priv.X.Bytes(), 32))
+	copy(input[128:160], common.LeftPadBytes(priv.Y.Bytes(), 32))
 
 	return input, nil
 }

--- a/tests/integration/precompiles/p256/test_setup.go
+++ b/tests/integration/precompiles/p256/test_setup.go
@@ -6,7 +6,6 @@ import (
 	"crypto/rand"
 	"errors"
 
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/suite"
 	"golang.org/x/crypto/cryptobyte"
 	"golang.org/x/crypto/cryptobyte/asn1"
@@ -49,10 +48,10 @@ func signMsg(msg []byte, priv *ecdsa.PrivateKey) ([]byte, error) {
 
 	input := make([]byte, p256.VerifyInputLength)
 	copy(input[0:32], hash)
-	copy(input[32:64], common.LeftPadBytes(rInt.Bytes(), 32))
-	copy(input[64:96], common.LeftPadBytes(sInt.Bytes(), 32))
-	copy(input[96:128], common.LeftPadBytes(priv.X.Bytes(), 32))
-	copy(input[128:160], common.LeftPadBytes(priv.Y.Bytes(), 32))
+	rInt.FillBytes(input[32:64])
+	sInt.FillBytes(input[64:96])
+	priv.X.FillBytes(input[96:128])
+	priv.Y.FillBytes(input[128:160])
 
 	return input, nil
 }

--- a/tests/integration/precompiles/p256/test_setup.go
+++ b/tests/integration/precompiles/p256/test_setup.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rand"
 	"errors"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/suite"
 	"golang.org/x/crypto/cryptobyte"
 	"golang.org/x/crypto/cryptobyte/asn1"
@@ -14,7 +15,6 @@ import (
 
 	"github.com/cosmos/evm/precompiles/p256"
 	"github.com/cosmos/evm/testutil/integration/evm/network"
-	"github.com/ethereum/go-ethereum/common"
 )
 
 type PrecompileTestSuite struct {

--- a/tests/integration/rpc/backend/test_blocks.go
+++ b/tests/integration/rpc/backend/test_blocks.go
@@ -262,7 +262,7 @@ func (s *TestSuite) TestGetBlockByHash() {
 			false,
 		},
 		{
-			"noop - tendermint blockres not found",
+			"fail - tendermint blockres not found",
 			common.BytesToHash(block.Hash()),
 			true,
 			math.NewInt(1).BigInt(),
@@ -273,8 +273,8 @@ func (s *TestSuite) TestGetBlockByHash() {
 				client := s.backend.ClientCtx.Client.(*mocks.Client)
 				RegisterBlockByHashNotFound(client, hash, txBz)
 			},
-			true,
-			true,
+			false,
+			false,
 		},
 		{
 			"noop - tendermint failed to fetch block result",


### PR DESCRIPTION
# Description

Addresses: [EVM-172](https://github.com/cosmos/evm/issues/172)

> We found in the rpc package that some calls made to Tendermint RPC are not handled properly. In specific, the eth_getLogs rpc call when providing a blockHash.

---

## Author Checklist

- [x] tackled an existing issue or discussed with a team member
- [x] left instructions on how to review the changes
- [x] targeted the `main` branch

## Reviewers Checklist

**All** items are required.
Please add a note if the item is not applicable
and please add your handle next to the items reviewed
if you only reviewed selected items.

I have...

- [ ] added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] confirmed all author checklist items have been addressed
- [ ] confirmed that this PR does not change production code
- [ ] reviewed content
- [ ] tested instructions (if applicable)
- [ ] confirmed all CI checks have passed
