### PR TITLE
Fix/Benchmark Antehandler

### DIFF
--- a/evmd/test_helpers.go
+++ b/evmd/test_helpers.go
@@ -40,7 +40,8 @@ type SetupOptions struct {
 
 func init() {
 	// we're setting the minimum gas price to 0 to simplify the tests
-	feemarkettypes.DefaultMinGasPrice = math.LegacyZeroDec()
+	//feemarkettypes.DefaultMinGasPrice = math.LegacyZeroDec()
+	feemarkettypes.DefaultMinGasPrice = math.LegacyNewDec(1)
 
 	// Set the global SDK config for the tests
 	cfg := sdk.GetConfig()

--- a/testutil/integration/base/factory/helper.go
+++ b/testutil/integration/base/factory/helper.go
@@ -87,7 +87,7 @@ func (tf *baseTxFactory) calculateFees(gasPrice *sdkmath.Int, gasLimit uint64) (
 			return sdktypes.Coins{}, errorsmod.Wrap(err, "failed to get base fee")
 		}
 		price := resp.BaseFee
-		fees = sdktypes.Coins{{Denom: denom, Amount: price.MulInt64(int64(gasLimit)).TruncateInt()}} //#nosec G115
+		fees = sdktypes.Coins{{Denom: denom, Amount: price.MulInt64(int64(gasLimit)).Ceil().RoundInt()}} //#nosec G115
 	}
 	return fees, nil
 }


### PR DESCRIPTION
# Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

<!-- Please keep your PR as draft until it's ready for review -->

<!-- Pull requests that sit inactive for longer than 30 days will be closed.  -->

Closes: [#338 ](https://github.com/cosmos/evm/issues/338)

---

## Summary
This PR fixes two benchmark-breaking sub-issues:
1. **Invalid gas cap** - prevented by setting `DefaultMinGasPrice` to 1 so the basefee can no longer decay to zero. 
2. **Fee rounding error** - resolved by replacing `TruncateInt()` with `Ceil().RoundInt()` in fee calculation, ensuring the total fee is never under-priced. 

## Details 
These issues surfaced only after commit [9fd2afe](https://github.com/cosmos/evm/pull/60) the one that introduced EIP-1559. 
You can reproduce this errors by 
```
cd evmd/ante
go test -benchmem -run=^$ -bench ^BenchmarkAnteHandler$ github.com/cosmos/evm/evmd/ante
```

### First sub-issues : Fix for "invalid gas cap" in benchmark
During BenchmarkAnteHandler, each tx is placed into its own block. Because every block then consumes only a tiny amount of gas, the EIP-1559 algorithm repeatedly lowers the baseFee until it eventually reaches 0 atom. Here's some log for this. 
```
base fee: 29965
base fee: 26220
…
base fee: 9
base fee: 8
…
base fee: 1
base fee: 0
--- FAIL: BenchmarkAnteHandler/tx_type_evm_transfer_sim-10
    failed to validate transaction: max priority fee per gas higher than max fee per gas (1 > 0): invalid gas cap
```
Once baseFee hits zero, the back-calculated maxFeePerGas for new tx also becomes zero, whereas default `maxPriorityFeePerGas = 1 `. The inequality `maxPriorityFeePerGas (1) > maxFeePerGas (0)` violates protocol rules, and each transaction is rejected with an invalid gas cap error.

Fix : in the test initializer we raise the network's floor by setting [(ref)](https://github.com/cosmos/evm/commit/830dff9584a5666ff759e5c2efd3f51d7e25adc2)

So baseFee can never decay below 1 aatom. With this safeguard in place, maxFeePerGas is always >=1 atatom, the inequality is avoided, and the benchmark suite runs to completion without errors. 

### Second sub-issues : Insufficient fee caused by fee rounding error
In the test environment, a Cosmos transaction's fee is calculated like this [(ref)](https://github.com/cosmos/evm/blob/main/testutil/integration/base/factory/helper.go#L79C1-L93C2)
So the code multiplies `baseFee × gasLimit` and then uses `TruncateInt()` to drop the fractional part (This is a test shortcut; in production it should be `maxFeePerGas × gasLimit`).

But here's the benchmark fails. 
FeeChecker later re-derives `maxFeePerGas` by dividing the total fee by gasLimit and compares it to baseFee [(ref)](https://github.com/cosmos/evm/blob/main/ante/evm/fee_checker.go#L60-L101). Because the total fee was truncated, it is up to 1 aatom lower, making `maxFeePerGas < baseFee` and triggering 'gas prices too low; insufficient fee'. Here's some log for this. 
```
...
114486203125000aatom-fees (Truncate)
114486203125000aatom-fees (ceil)
feeCap: 765625000.000000000000000000, baseFee: 765625000.000000000000000000
100175427734375aatom-fees (Truncate)
100175427734375aatom-fees (ceil)
feeCap: 669921875.000000000000000000, baseFee: 669921875.000000000000000000
87653499267578aatom-fees (Truncate)
87653499267579aatom-fees (ceil)
feeCap: 586181640.624999164064119625, baseFee: 586181640.625000000000000000
--- FAIL: BenchmarkAnteHandler/tx_type_bank_msg_send-10
    evm_antehandler_benchmark_test.go:108: failed to run ante handler: gas prices too low, got: 586181640.624999164064119625aatom required: 586181640.625000000000000000aatom. Please retry using a higher gas price or a higher fee: insufficient fee 
```
Fix : Replace `TruncateInt() `with `Ceil().RoundInt()` [(ref)](https://github.com/cosmos/evm/commit/86633589103f0ed5311725805676efc29af83f2f)

So the total fee is always ≥ `baseFee × gasLimit`, guaranteeing `maxFeePerGas ≥ baseFee`

cc. @zsystm @cloudgray 
## Author Checklist

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.

I have...

- [x] tackled an existing issue or discussed with a team member
- [x] left instructions on how to review the changes
- [x] targeted the `main` branch

## Reviewers Checklist

**All** items are required.
Please add a note if the item is not applicable
and please add your handle next to the items reviewed
if you only reviewed selected items.

I have...

- [ ] added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] confirmed all author checklist items have been addressed
- [ ] confirmed that this PR does not change production code
- [ ] reviewed content
- [ ] tested instructions (if applicable)
- [ ] confirmed all CI checks have passed
