### PR TITLE
fix: p256 flaky test

### DIFF
--- a/tests/integration/precompiles/p256/test_integration.go
+++ b/tests/integration/precompiles/p256/test_integration.go
@@ -170,10 +170,11 @@ func TestPrecompileIntegrationTestSuite(t *testing.T, create network.CreateEvmAp
 
 						input = make([]byte, p256.VerifyInputLength)
 						copy(input[0:32], hash)
-						copy(input[32:64], rInt.Bytes())
-						copy(input[64:96], sInt.Bytes())
-						copy(input[96:128], privB.PublicKey.X.Bytes())
-						copy(input[128:160], privB.PublicKey.Y.Bytes())
+						// ALWAYS left-pad to 32 bytes:
+						copy(input[32:64], common.LeftPadBytes(rInt.Bytes(), 32))
+						copy(input[64:96], common.LeftPadBytes(sInt.Bytes(), 32))
+						copy(input[96:128], common.LeftPadBytes(privB.PublicKey.X.Bytes(), 32))
+						copy(input[128:160], common.LeftPadBytes(privB.PublicKey.Y.Bytes(), 32))
 						return input
 					},
 				),

--- a/tests/integration/precompiles/p256/test_p256.go
+++ b/tests/integration/precompiles/p256/test_p256.go
@@ -65,8 +65,9 @@ func (s *PrecompileTestSuite) TestRun() {
 
 				input := make([]byte, p256.VerifyInputLength)
 				copy(input[0:32], hash)
-				copy(input[32:64], rBz)
-				copy(input[64:96], sBz)
+				// ALWAYS left-pad to 32 bytes:
+				copy(input[32:64], common.LeftPadBytes(rBz, 32))
+				copy(input[64:96], common.LeftPadBytes(sBz, 32))
 				s.p256Priv.X.FillBytes(input[96:128])
 				s.p256Priv.Y.FillBytes(input[128:160])
 


### PR DESCRIPTION
# Description
The pull request references are PR https://github.com/cosmos/evm/pull/332 and PR https://github.com/cosmos/evm/pull/274.

I believe PR https://github.com/cosmos/evm/pull/274 also requires a modification in another location.

https://github.com/cosmos/evm/blob/cffad658f84748008a47f15cb63829060d54bc6e/tests/integration/precompiles/p256/test_p256.go#L63-L69

Referring to issue https://github.com/cosmos/evm/issues/273, I think rBz, rBz(when shorter than 32 bytes) has the same issue.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

<!-- Please keep your PR as draft until it's ready for review -->

<!-- Pull requests that sit inactive for longer than 30 days will be closed.  -->

Closes: #XXXX

---

## Author Checklist

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.

I have...

- [ ] tackled an existing issue or discussed with a team member
- [ ] left instructions on how to review the changes
- [ ] targeted the `main` branch

## Reviewers Checklist

**All** items are required.
Please add a note if the item is not applicable
and please add your handle next to the items reviewed
if you only reviewed selected items.

I have...

- [ ] added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] confirmed all author checklist items have been addressed
- [ ] confirmed that this PR does not change production code
- [ ] reviewed content
- [ ] tested instructions (if applicable)
- [ ] confirmed all CI checks have passed
