### PR TITLE
post-audit: add bigger depot runners to gh workflows

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,7 +10,7 @@ permissions: read-all
 jobs:
   golangci:
     name: Run golangci-lint
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04-8
     timeout-minutes: 15
     steps:
       - uses: actions/setup-go@v5

--- a/.github/workflows/solidity-test.yml
+++ b/.github/workflows/solidity-test.yml
@@ -8,7 +8,7 @@ permissions: read-all
 
 jobs:
   test-solidity:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04-4
     steps:
       - uses: actions/setup-go@v5
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     if: "!startsWith(github.ref, 'refs/tags/') && github.ref != 'refs/heads/main'"
 
   test-unit-cover:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04-16
     steps:
       - uses: actions/setup-go@v5
         with:
@@ -72,7 +72,7 @@ jobs:
         if: env.GIT_DIFF
 
   test-fuzz:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04-4
     steps:
       - uses: actions/setup-go@v5
         with:


### PR DESCRIPTION
# Description

Instance sizes chosen based on:
- Average historical runtime (how slow it is)
- How well the workflow scales with cores (whether it pins a subset of cores or scales linearly)

Should be merged after #369 and #373 
