### PR TITLE
fix: net NewPublicAPI use server context also

### DIFF
--- a/rpc/apis.go
+++ b/rpc/apis.go
@@ -87,12 +87,12 @@ func init() {
 				},
 			}
 		},
-		NetNamespace: func(_ *server.Context, clientCtx client.Context, _ *rpcclient.WSClient, _ bool, _ types.EVMTxIndexer) []rpc.API {
+		NetNamespace: func(ctx *server.Context, clientCtx client.Context, _ *rpcclient.WSClient, _ bool, _ types.EVMTxIndexer) []rpc.API {
 			return []rpc.API{
 				{
 					Namespace: NetNamespace,
 					Version:   apiVersion,
-					Service:   net.NewPublicAPI(clientCtx),
+					Service:   net.NewPublicAPI(ctx, clientCtx),
 					Public:    true,
 				},
 			}

--- a/rpc/namespaces/ethereum/net/api.go
+++ b/rpc/namespaces/ethereum/net/api.go
@@ -9,6 +9,7 @@ import (
 	"github.com/cosmos/evm/server/config"
 
 	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/server"
 )
 
 // PublicAPI is the eth_ prefixed set of APIs in the Web3 JSON-RPC spec.
@@ -18,8 +19,8 @@ type PublicAPI struct {
 }
 
 // NewPublicAPI creates an instance of the public Net Web3 API.
-func NewPublicAPI(clientCtx client.Context) *PublicAPI {
-	cfg, err := config.GetConfig(clientCtx.Viper)
+func NewPublicAPI(ctx *server.Context, clientCtx client.Context) *PublicAPI {
+	cfg, err := config.GetConfig(ctx.Viper)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
# Description

The `net.NewPublicAPI` refers the config through client context and there is no `evm-chain-id`, `PublicAPI.networkVersion` is always set default value.
Then the ethereum rpc method `net_version` always returns `262144`, so I fixed it to use server context.

Closes: #411 

---

## Author Checklist

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.

I have...

- [ ] tackled an existing issue or discussed with a team member
- [ ] left instructions on how to review the changes
- [ ] targeted the `main` branch
