### PR TITLE
fix: CometBlockResultByNumber when height is 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - [\#492](https://github.com/cosmos/evm/pull/492) Duplicate case switch to avoid empty execution block
 - [\#509](https://github.com/cosmos/evm/pull/509) Allow value with slashes when query token_pairs
 - [\#495](https://github.com/cosmos/evm/pull/495) Allow immediate SIGINT interrupt when mempool is not empty
+- [\#416](https://github.com/cosmos/evm/pull/416) Fix regression in CometBlockResultByNumber when height is 0 to use the latest block. This fixes eth_getFilterLogs RPC.
 
 ### IMPROVEMENTS
 

--- a/rpc/backend/blocks.go
+++ b/rpc/backend/blocks.go
@@ -203,6 +203,9 @@ func (b *Backend) CometHeaderByNumber(blockNum rpctypes.BlockNumber) (*cmtrpctyp
 // CometBlockResultByNumber returns a CometBFT-formatted block result
 // by block number
 func (b *Backend) CometBlockResultByNumber(height *int64) (*cmtrpctypes.ResultBlockResults, error) {
+	if height != nil && *height == 0 {
+		height = nil
+	}
 	res, err := b.RPCClient.BlockResults(b.Ctx, height)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch block result from CometBFT %d: %w", *height, err)


### PR DESCRIPTION
At the moment, when calling TendermintBlockResultByNumber with height=0, an error is returned:

```
failed to fetch block result from Tendermint: failed to fetch block result from Tendermint 0: height must be greater than 0, but got 0
```

This PR replaces 0 with `nil`, making the Tendermint client happy.

This issue happens when trying to filter logs.

Fixes #488 