### PR TITLE
feat: enforce app creator returning application implement AppWithPendingTxStream in build time

### DIFF
--- a/evmd/app.go
+++ b/evmd/app.go
@@ -132,6 +132,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/staking"
 	stakingkeeper "github.com/cosmos/cosmos-sdk/x/staking/keeper"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+	cosmosevmserver "github.com/cosmos/evm/server"
 )
 
 func init() {
@@ -147,9 +148,9 @@ const appName = "evmd"
 var defaultNodeHome string
 
 var (
-	_ runtime.AppI            = (*EVMD)(nil)
-	_ servertypes.Application = (*EVMD)(nil)
-	_ ibctesting.TestingApp   = (*EVMD)(nil)
+	_ runtime.AppI                = (*EVMD)(nil)
+	_ cosmosevmserver.Application = (*EVMD)(nil)
+	_ ibctesting.TestingApp       = (*EVMD)(nil)
 )
 
 // EVMD extends an ABCI application, but with most of its parameters exported.

--- a/server/start.go
+++ b/server/start.go
@@ -34,6 +34,7 @@ import (
 	cosmosevmtypes "github.com/cosmos/evm/types"
 
 	errorsmod "cosmossdk.io/errors"
+	"cosmossdk.io/log"
 	pruningtypes "cosmossdk.io/store/pruning/types"
 
 	"github.com/cosmos/cosmos-sdk/client"
@@ -53,6 +54,13 @@ import (
 // DBOpener is a function to open `application.db`, potentially with customized options.
 type DBOpener func(opts types.AppOptions, rootDir string, backend dbm.BackendType) (dbm.DB, error)
 
+type Application interface {
+	types.Application
+	AppWithPendingTxStream
+}
+
+type AppCreator func(log.Logger, dbm.DB, io.Writer, types.AppOptions) Application
+
 // StartOptions defines options that can be customized in `StartCmd`
 type StartOptions struct {
 	AppCreator      types.AppCreator
@@ -61,9 +69,11 @@ type StartOptions struct {
 }
 
 // NewDefaultStartOptions use the default db opener provided in tm-db.
-func NewDefaultStartOptions(appCreator types.AppCreator, defaultNodeHome string) StartOptions {
+func NewDefaultStartOptions(appCreator AppCreator, defaultNodeHome string) StartOptions {
 	return StartOptions{
-		AppCreator:      appCreator,
+		AppCreator: func(l log.Logger, d dbm.DB, w io.Writer, ao types.AppOptions) types.Application {
+			return appCreator(l, d, w, ao)
+		},
 		DefaultNodeHome: defaultNodeHome,
 		DBOpener:        cosmosevmserverconfig.OpenDB,
 	}


### PR DESCRIPTION
# Description

* update application interface and app creator wiring for EVM server integration
* use cosmosevmserver.Application interface instead of servertypes.Application with assertion
* add new Application interface and AppCreator type to support pending tx stream

Closes: https://github.com/cosmos/evm/issues/439

---

## Author Checklist

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.

I have...

- [ ] tackled an existing issue or discussed with a team member
- [ ] left instructions on how to review the changes
- [ ] targeted the `main` branch
