### PR TITLE
fix: rpc accessibility in docker

### DIFF
--- a/evmd/cmd/evmd/cmd/testnet.go
+++ b/evmd/cmd/evmd/cmd/testnet.go
@@ -299,6 +299,10 @@ func initTestnetFiles(
 	for i := 0; i < args.numValidators; i++ {
 		var portOffset int
 		var evmPortOffset int
+		evmCfg.JSONRPC.Enable = true
+		evmCfg.JSONRPC.EnableIndexer = true
+		evmCfg.JSONRPC.API = []string{"eth", "txpool", "personal", "net", "debug", "web3"}
+		evmCfg.API.Enable = true
 		if args.singleMachine {
 			portOffset = i
 			evmPortOffset = i * 10
@@ -313,10 +317,9 @@ func initTestnetFiles(
 			evmCfg.JSONRPC.Address = fmt.Sprintf("127.0.0.1:%d", evmJSONRPC+evmPortOffset)
 			evmCfg.JSONRPC.MetricsAddress = fmt.Sprintf("127.0.0.1:%d", evmJSONRPCMetrics+evmPortOffset)
 			evmCfg.JSONRPC.WsAddress = fmt.Sprintf("127.0.0.1:%d", evmJSONRPCWS+evmPortOffset)
-			evmCfg.JSONRPC.Enable = true
-			evmCfg.JSONRPC.EnableIndexer = true
-			evmCfg.JSONRPC.API = []string{"eth", "txpool", "personal", "net", "debug", "web3"}
-			evmCfg.API.Enable = true
+		} else {
+			evmCfg.JSONRPC.WsAddress = fmt.Sprintf("0.0.0.0:%d", evmJSONRPCWS)
+			evmCfg.JSONRPC.Address = fmt.Sprintf("0.0.0.0:%d", evmJSONRPC)
 		}
 		nodeDirName := fmt.Sprintf("%s%d", args.nodeDirPrefix, i)
 		nodeDir := filepath.Join(args.outputDir, nodeDirName, args.nodeDaemonHome)


### PR DESCRIPTION
# Description

fixes an issue where the JSON RPC and Websocket RPC were not available when running in docker. Now, each node's JSON/Websocket RPCs can be accessed via localhost:8545 / localhost:8546. for each subsequent node, add 10 to the port (i.e. [8555, 8556], [8565, 8566]...)

---

## Author Checklist

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.

I have...

- [ ] tackled an existing issue or discussed with a team member
- [ ] left instructions on how to review the changes
- [ ] targeted the `main` branch
