### PR TITLE
fix: avoid insufficient funds error when fund and send tx within same block

### DIFF
--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/ethereum/go-ethereum/common"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/holiman/uint256"
 
@@ -172,10 +173,15 @@ func NewExperimentalEVMMempool(getCtxCallback func(height int64, prove bool) (sd
 		blockGasLimit: config.BlockGasLimit,
 		anteHandler:   anteHandler,
 	}
+	evmMempool.legacyTxPool.SpendableCoin = vmKeeper.(VMKeeper).SpendableCoin
 
 	vmKeeper.SetEvmMempool(evmMempool)
 
 	return evmMempool
+}
+
+type VMKeeper interface {
+	SpendableCoin(ctx sdk.Context, addr common.Address) *uint256.Int
 }
 
 // GetBlockchain returns the blockchain interface used for chain head event notifications.


### PR DESCRIPTION
# Description

* get SpendableCoin from sdk ctx to reflect uncommitted balance change
* for test [info](https://github.com/MANTRA-Chain/mantrachain/pull/412) about `failed to broadcast transaction: insufficient funds for gas * price + value`

Closes: #XXXX

---

## Author Checklist

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.

I have...

- [ ] tackled an existing issue or discussed with a team member
- [ ] left instructions on how to review the changes
- [ ] targeted the `main` branch
