### PR TITLE
refactor: decouple keeper using interface on precompile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@
 
 ### API-BREAKING
 
+- [\#477](https://github.com/cosmos/evm/pull/477) Refactor precompile constructors to accept keeper interfaces instead of concrete implementations, breaking the existing `NewPrecompile` function signatures.
 - [\#456](https://github.com/cosmos/evm/pull/456) Remove non–go-ethereum JSON-RPC methods to align with Geth’s surface
 - [\#443](https://github.com/cosmos/evm/pull/443) Move `ante` logic from the `evmd` Go package to the `evm` package to
 be exported as a library.

--- a/evmd/precompiles.go
+++ b/evmd/precompiles.go
@@ -101,13 +101,21 @@ func NewAvailableStaticPrecompiles(
 		panic(fmt.Errorf("failed to instantiate bech32 precompile: %w", err))
 	}
 
-	stakingPrecompile, err := stakingprecompile.NewPrecompile(stakingKeeper, bankKeeper, options.AddressCodec)
+	stakingPrecompile, err := stakingprecompile.NewPrecompile(
+		stakingKeeper,
+		stakingkeeper.NewMsgServerImpl(&stakingKeeper),
+		stakingkeeper.NewQuerier(&stakingKeeper),
+		bankKeeper,
+		options.AddressCodec,
+	)
 	if err != nil {
 		panic(fmt.Errorf("failed to instantiate staking precompile: %w", err))
 	}
 
 	distributionPrecompile, err := distprecompile.NewPrecompile(
 		distributionKeeper,
+		distributionkeeper.NewMsgServerImpl(distributionKeeper),
+		distributionkeeper.NewQuerier(distributionKeeper),
 		stakingKeeper,
 		bankKeeper,
 		options.AddressCodec,
@@ -121,7 +129,6 @@ func NewAvailableStaticPrecompiles(
 		stakingKeeper,
 		transferKeeper,
 		channelKeeper,
-		evmKeeper,
 	)
 	if err != nil {
 		panic(fmt.Errorf("failed to instantiate ICS20 precompile: %w", err))
@@ -132,12 +139,24 @@ func NewAvailableStaticPrecompiles(
 		panic(fmt.Errorf("failed to instantiate bank precompile: %w", err))
 	}
 
-	govPrecompile, err := govprecompile.NewPrecompile(govKeeper, bankKeeper, codec, options.AddressCodec)
+	govPrecompile, err := govprecompile.NewPrecompile(
+		govkeeper.NewMsgServerImpl(&govKeeper),
+		govkeeper.NewQueryServer(&govKeeper),
+		bankKeeper,
+		codec,
+		options.AddressCodec,
+	)
 	if err != nil {
 		panic(fmt.Errorf("failed to instantiate gov precompile: %w", err))
 	}
 
-	slashingPrecompile, err := slashingprecompile.NewPrecompile(slashingKeeper, bankKeeper, options.ValidatorAddrCodec, options.ConsensusAddrCodec)
+	slashingPrecompile, err := slashingprecompile.NewPrecompile(
+		slashingKeeper,
+		slashingkeeper.NewMsgServerImpl(slashingKeeper),
+		bankKeeper,
+		options.ValidatorAddrCodec,
+		options.ConsensusAddrCodec,
+	)
 	if err != nil {
 		panic(fmt.Errorf("failed to instantiate slashing precompile: %w", err))
 	}

--- a/evmd/tests/ibc/ics20_precompile_transfer_test.go
+++ b/evmd/tests/ibc/ics20_precompile_transfer_test.go
@@ -51,7 +51,6 @@ func (suite *ICS20TransferTestSuite) SetupTest() {
 		*evmAppA.StakingKeeper,
 		evmAppA.TransferKeeper,
 		evmAppA.IBCKeeper.ChannelKeeper,
-		evmAppA.EVMKeeper,
 	)
 	evmAppB := suite.chainB.App.(*evmd.EVMD)
 	suite.chainBPrecompile, _ = ics20.NewPrecompile(
@@ -59,7 +58,6 @@ func (suite *ICS20TransferTestSuite) SetupTest() {
 		*evmAppB.StakingKeeper,
 		evmAppB.TransferKeeper,
 		evmAppB.IBCKeeper.ChannelKeeper,
-		evmAppB.EVMKeeper,
 	)
 }
 

--- a/evmd/tests/ibc/v2_ics20_precompile_transfer_test.go
+++ b/evmd/tests/ibc/v2_ics20_precompile_transfer_test.go
@@ -52,7 +52,6 @@ func (suite *ICS20TransferV2TestSuite) SetupTest() {
 		*evmAppA.StakingKeeper,
 		evmAppA.TransferKeeper,
 		evmAppA.IBCKeeper.ChannelKeeper,
-		evmAppA.EVMKeeper,
 	)
 	evmAppB := suite.chainB.App.(*evmd.EVMD)
 	suite.chainBPrecompile, _ = ics20.NewPrecompile(
@@ -60,7 +59,6 @@ func (suite *ICS20TransferV2TestSuite) SetupTest() {
 		*evmAppB.StakingKeeper,
 		evmAppB.TransferKeeper,
 		evmAppB.IBCKeeper.ChannelKeeper,
-		evmAppB.EVMKeeper,
 	)
 }
 

--- a/ibc/interfaces.go
+++ b/ibc/interfaces.go
@@ -1,0 +1,13 @@
+package ibc
+
+import (
+	cmtbytes "github.com/cometbft/cometbft/libs/bytes"
+
+	ibctypes "github.com/cosmos/ibc-go/v10/modules/apps/transfer/types"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+type TransferKeeper interface {
+	GetDenom(ctx sdk.Context, denomHash cmtbytes.HexBytes) (ibctypes.Denom, bool)
+}

--- a/ibc/utils.go
+++ b/ibc/utils.go
@@ -4,7 +4,6 @@ import (
 	"strings"
 
 	"github.com/cosmos/evm/utils"
-	transferkeeper "github.com/cosmos/evm/x/ibc/transfer/keeper"
 	transfertypes "github.com/cosmos/ibc-go/v10/modules/apps/transfer/types"
 	channeltypes "github.com/cosmos/ibc-go/v10/modules/core/04-channel/types"
 
@@ -108,7 +107,7 @@ func GetSentCoin(rawDenom, rawAmt string) sdk.Coin {
 // GetDenom returns the denomination from the corresponding IBC denomination. If the
 // denomination is not an IBC voucher or the trace is not found, it returns an error.
 func GetDenom(
-	transferKeeper transferkeeper.Keeper,
+	transferKeeper TransferKeeper,
 	ctx sdk.Context,
 	voucherDenom string,
 ) (transfertypes.Denom, error) {

--- a/precompiles/bank/bank.go
+++ b/precompiles/bank/bank.go
@@ -15,7 +15,6 @@ import (
 	"github.com/ethereum/go-ethereum/core/vm"
 
 	cmn "github.com/cosmos/evm/precompiles/common"
-	erc20keeper "github.com/cosmos/evm/x/erc20/keeper"
 	evmtypes "github.com/cosmos/evm/x/vm/types"
 
 	storetypes "cosmossdk.io/store/types"
@@ -43,14 +42,14 @@ var f embed.FS
 type Precompile struct {
 	cmn.Precompile
 	bankKeeper  cmn.BankKeeper
-	erc20Keeper erc20keeper.Keeper
+	erc20Keeper cmn.ERC20Keeper
 }
 
 // NewPrecompile creates a new bank Precompile instance implementing the
 // PrecompiledContract interface.
 func NewPrecompile(
 	bankKeeper cmn.BankKeeper,
-	erc20Keeper erc20keeper.Keeper,
+	erc20Keeper cmn.ERC20Keeper,
 ) (*Precompile, error) {
 	newABI, err := cmn.LoadABI(f, "abi.json")
 	if err != nil {

--- a/precompiles/common/interfaces.go
+++ b/precompiles/common/interfaces.go
@@ -3,8 +3,17 @@ package common
 import (
 	"context"
 
+	ethcommon "github.com/ethereum/go-ethereum/common"
+
+	erc20types "github.com/cosmos/evm/x/erc20/types"
+	ibctypes "github.com/cosmos/ibc-go/v10/modules/apps/transfer/types"
+	connectiontypes "github.com/cosmos/ibc-go/v10/modules/core/03-connection/types"
+	channeltypes "github.com/cosmos/ibc-go/v10/modules/core/04-channel/types"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	slashingtypes "github.com/cosmos/cosmos-sdk/x/slashing/types"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 )
 
 type BankKeeper interface {
@@ -17,4 +26,40 @@ type BankKeeper interface {
 	SendCoins(ctx context.Context, fromAddr sdk.AccAddress, toAddr sdk.AccAddress, amt sdk.Coins) error
 	SpendableCoin(ctx context.Context, addr sdk.AccAddress, denom string) sdk.Coin
 	BlockedAddr(addr sdk.AccAddress) bool
+}
+
+type TransferKeeper interface {
+	Denom(ctx context.Context, req *ibctypes.QueryDenomRequest) (*ibctypes.QueryDenomResponse, error)
+	Denoms(ctx context.Context, req *ibctypes.QueryDenomsRequest) (*ibctypes.QueryDenomsResponse, error)
+	DenomHash(ctx context.Context, req *ibctypes.QueryDenomHashRequest) (*ibctypes.QueryDenomHashResponse, error)
+	Transfer(ctx context.Context, msg *ibctypes.MsgTransfer) (*ibctypes.MsgTransferResponse, error)
+}
+
+type ChannelKeeper interface {
+	GetChannel(ctx sdk.Context, portID, channelID string) (channeltypes.Channel, bool)
+	GetConnection(ctx sdk.Context, connectionID string) (connectiontypes.ConnectionEnd, error)
+}
+
+type DistributionKeeper interface {
+	WithdrawDelegationRewards(ctx context.Context, delAddr sdk.AccAddress, valAddr sdk.ValAddress) (sdk.Coins, error)
+}
+
+type StakingKeeper interface {
+	BondDenom(ctx context.Context) (string, error)
+	MaxValidators(ctx context.Context) (uint32, error)
+	GetDelegatorValidators(ctx context.Context, delegatorAddr sdk.AccAddress, maxRetrieve uint32) (stakingtypes.Validators, error)
+	GetRedelegation(ctx context.Context, delAddr sdk.AccAddress, valSrcAddr, valDstAddr sdk.ValAddress) (red stakingtypes.Redelegation, err error)
+	GetValidator(ctx context.Context, addr sdk.ValAddress) (validator stakingtypes.Validator, err error)
+}
+
+type SlashingKeeper interface {
+	Params(ctx context.Context, req *slashingtypes.QueryParamsRequest) (*slashingtypes.QueryParamsResponse, error)
+	SigningInfo(ctx context.Context, req *slashingtypes.QuerySigningInfoRequest) (*slashingtypes.QuerySigningInfoResponse, error)
+	SigningInfos(ctx context.Context, req *slashingtypes.QuerySigningInfosRequest) (*slashingtypes.QuerySigningInfosResponse, error)
+}
+
+type ERC20Keeper interface {
+	GetCoinAddress(ctx sdk.Context, denom string) (ethcommon.Address, error)
+	GetERC20Map(ctx sdk.Context, erc20 ethcommon.Address) []byte
+	GetTokenPair(ctx sdk.Context, id []byte) (erc20types.TokenPair, bool)
 }

--- a/precompiles/distribution/distribution.go
+++ b/precompiles/distribution/distribution.go
@@ -15,8 +15,7 @@ import (
 	"cosmossdk.io/core/address"
 	storetypes "cosmossdk.io/store/types"
 
-	distributionkeeper "github.com/cosmos/cosmos-sdk/x/distribution/keeper"
-	stakingkeeper "github.com/cosmos/cosmos-sdk/x/staking/keeper"
+	distributiontypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
 )
 
 var _ vm.PrecompiledContract = &Precompile{}
@@ -29,16 +28,20 @@ var f embed.FS
 // Precompile defines the precompiled contract for distribution.
 type Precompile struct {
 	cmn.Precompile
-	distributionKeeper distributionkeeper.Keeper
-	stakingKeeper      stakingkeeper.Keeper
-	addrCdc            address.Codec
+	distributionKeeper    cmn.DistributionKeeper
+	distributionMsgServer distributiontypes.MsgServer
+	distributionQuerier   distributiontypes.QueryServer
+	stakingKeeper         cmn.StakingKeeper
+	addrCdc               address.Codec
 }
 
 // NewPrecompile creates a new distribution Precompile instance as a
 // PrecompiledContract interface.
 func NewPrecompile(
-	distributionKeeper distributionkeeper.Keeper,
-	stakingKeeper stakingkeeper.Keeper,
+	distributionKeeper cmn.DistributionKeeper,
+	distributionMsgServer distributiontypes.MsgServer,
+	distributionQuerier distributiontypes.QueryServer,
+	stakingKeeper cmn.StakingKeeper,
 	bankKeeper cmn.BankKeeper,
 	addrCdc address.Codec,
 ) (*Precompile, error) {
@@ -53,9 +56,11 @@ func NewPrecompile(
 			KvGasConfig:          storetypes.KVGasConfig(),
 			TransientKVGasConfig: storetypes.TransientGasConfig(),
 		},
-		stakingKeeper:      stakingKeeper,
-		distributionKeeper: distributionKeeper,
-		addrCdc:            addrCdc,
+		stakingKeeper:         stakingKeeper,
+		distributionKeeper:    distributionKeeper,
+		distributionMsgServer: distributionMsgServer,
+		distributionQuerier:   distributionQuerier,
+		addrCdc:               addrCdc,
 	}
 
 	// SetAddress defines the address of the distribution compile contract.

--- a/precompiles/distribution/query.go
+++ b/precompiles/distribution/query.go
@@ -7,7 +7,6 @@ import (
 	cmn "github.com/cosmos/evm/precompiles/common"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	distributionkeeper "github.com/cosmos/cosmos-sdk/x/distribution/keeper"
 )
 
 const (
@@ -52,9 +51,7 @@ func (p Precompile) ValidatorDistributionInfo(
 		return nil, err
 	}
 
-	querier := distributionkeeper.Querier{Keeper: p.distributionKeeper}
-
-	res, err := querier.ValidatorDistributionInfo(ctx, req)
+	res, err := p.distributionQuerier.ValidatorDistributionInfo(ctx, req)
 	if err != nil {
 		return nil, err
 	}
@@ -76,9 +73,7 @@ func (p Precompile) ValidatorOutstandingRewards(
 		return nil, err
 	}
 
-	querier := distributionkeeper.Querier{Keeper: p.distributionKeeper}
-
-	res, err := querier.ValidatorOutstandingRewards(ctx, req)
+	res, err := p.distributionQuerier.ValidatorOutstandingRewards(ctx, req)
 	if err != nil {
 		return nil, err
 	}
@@ -98,9 +93,7 @@ func (p Precompile) ValidatorCommission(
 		return nil, err
 	}
 
-	querier := distributionkeeper.Querier{Keeper: p.distributionKeeper}
-
-	res, err := querier.ValidatorCommission(ctx, req)
+	res, err := p.distributionQuerier.ValidatorCommission(ctx, req)
 	if err != nil {
 		return nil, err
 	}
@@ -120,9 +113,7 @@ func (p Precompile) ValidatorSlashes(
 		return nil, err
 	}
 
-	querier := distributionkeeper.Querier{Keeper: p.distributionKeeper}
-
-	res, err := querier.ValidatorSlashes(ctx, req)
+	res, err := p.distributionQuerier.ValidatorSlashes(ctx, req)
 	if err != nil {
 		return nil, err
 	}
@@ -144,8 +135,7 @@ func (p Precompile) DelegationRewards(
 		return nil, err
 	}
 
-	querier := distributionkeeper.Querier{Keeper: p.distributionKeeper}
-	res, err := querier.DelegationRewards(ctx, req)
+	res, err := p.distributionQuerier.DelegationRewards(ctx, req)
 	if err != nil {
 		return nil, err
 	}
@@ -165,9 +155,7 @@ func (p Precompile) DelegationTotalRewards(
 		return nil, err
 	}
 
-	querier := distributionkeeper.Querier{Keeper: p.distributionKeeper}
-
-	res, err := querier.DelegationTotalRewards(ctx, req)
+	res, err := p.distributionQuerier.DelegationTotalRewards(ctx, req)
 	if err != nil {
 		return nil, err
 	}
@@ -189,9 +177,7 @@ func (p Precompile) DelegatorValidators(
 		return nil, err
 	}
 
-	querier := distributionkeeper.Querier{Keeper: p.distributionKeeper}
-
-	res, err := querier.DelegatorValidators(ctx, req)
+	res, err := p.distributionQuerier.DelegatorValidators(ctx, req)
 	if err != nil {
 		return nil, err
 	}
@@ -211,9 +197,7 @@ func (p Precompile) DelegatorWithdrawAddress(
 		return nil, err
 	}
 
-	querier := distributionkeeper.Querier{Keeper: p.distributionKeeper}
-
-	res, err := querier.DelegatorWithdrawAddress(ctx, req)
+	res, err := p.distributionQuerier.DelegatorWithdrawAddress(ctx, req)
 	if err != nil {
 		return nil, err
 	}
@@ -233,9 +217,7 @@ func (p Precompile) CommunityPool(
 		return nil, err
 	}
 
-	querier := distributionkeeper.Querier{Keeper: p.distributionKeeper}
-
-	res, err := querier.CommunityPool(ctx, req)
+	res, err := p.distributionQuerier.CommunityPool(ctx, req)
 	if err != nil {
 		return nil, err
 	}

--- a/precompiles/distribution/tx.go
+++ b/precompiles/distribution/tx.go
@@ -9,7 +9,6 @@ import (
 	cmn "github.com/cosmos/evm/precompiles/common"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	distributionkeeper "github.com/cosmos/cosmos-sdk/x/distribution/keeper"
 )
 
 const (
@@ -103,8 +102,7 @@ func (p Precompile) SetWithdrawAddress(
 		return nil, fmt.Errorf(cmn.ErrRequesterIsNotMsgSender, msgSender.String(), delegatorHexAddr.String())
 	}
 
-	msgSrv := distributionkeeper.NewMsgServerImpl(p.distributionKeeper)
-	if _, err = msgSrv.SetWithdrawAddress(ctx, msg); err != nil {
+	if _, err = p.distributionMsgServer.SetWithdrawAddress(ctx, msg); err != nil {
 		return nil, err
 	}
 
@@ -133,8 +131,7 @@ func (p *Precompile) WithdrawDelegatorReward(
 		return nil, fmt.Errorf(cmn.ErrRequesterIsNotMsgSender, msgSender.String(), delegatorHexAddr.String())
 	}
 
-	msgSrv := distributionkeeper.NewMsgServerImpl(p.distributionKeeper)
-	res, err := msgSrv.WithdrawDelegatorReward(ctx, msg)
+	res, err := p.distributionMsgServer.WithdrawDelegatorReward(ctx, msg)
 	if err != nil {
 		return nil, err
 	}
@@ -164,8 +161,7 @@ func (p *Precompile) WithdrawValidatorCommission(
 		return nil, fmt.Errorf(cmn.ErrRequesterIsNotMsgSender, msgSender.String(), validatorHexAddr.String())
 	}
 
-	msgSrv := distributionkeeper.NewMsgServerImpl(p.distributionKeeper)
-	res, err := msgSrv.WithdrawValidatorCommission(ctx, msg)
+	res, err := p.distributionMsgServer.WithdrawValidatorCommission(ctx, msg)
 	if err != nil {
 		return nil, err
 	}
@@ -195,8 +191,7 @@ func (p *Precompile) FundCommunityPool(
 		return nil, fmt.Errorf(cmn.ErrRequesterIsNotMsgSender, msgSender.String(), depositorHexAddr.String())
 	}
 
-	msgSrv := distributionkeeper.NewMsgServerImpl(p.distributionKeeper)
-	_, err = msgSrv.FundCommunityPool(ctx, msg)
+	_, err = p.distributionMsgServer.FundCommunityPool(ctx, msg)
 	if err != nil {
 		return nil, err
 	}
@@ -227,8 +222,7 @@ func (p *Precompile) DepositValidatorRewardsPool(
 		return nil, fmt.Errorf(cmn.ErrRequesterIsNotMsgSender, msgSender.String(), depositorHexAddr.String())
 	}
 
-	msgSrv := distributionkeeper.NewMsgServerImpl(p.distributionKeeper)
-	_, err = msgSrv.DepositValidatorRewardsPool(ctx, msg)
+	_, err = p.distributionMsgServer.DepositValidatorRewardsPool(ctx, msg)
 	if err != nil {
 		return nil, err
 	}

--- a/precompiles/erc20/erc20.go
+++ b/precompiles/erc20/erc20.go
@@ -8,9 +8,9 @@ import (
 	"github.com/ethereum/go-ethereum/core/tracing"
 	"github.com/ethereum/go-ethereum/core/vm"
 
+	ibcutils "github.com/cosmos/evm/ibc"
 	cmn "github.com/cosmos/evm/precompiles/common"
 	erc20types "github.com/cosmos/evm/x/erc20/types"
-	transferkeeper "github.com/cosmos/evm/x/ibc/transfer/keeper"
 
 	storetypes "cosmossdk.io/store/types"
 
@@ -50,7 +50,7 @@ var _ vm.PrecompiledContract = &Precompile{}
 type Precompile struct {
 	cmn.Precompile
 	tokenPair      erc20types.TokenPair
-	transferKeeper transferkeeper.Keeper
+	transferKeeper ibcutils.TransferKeeper
 	erc20Keeper    Erc20Keeper
 	// BankKeeper is a public field so that the werc20 precompile can use it.
 	BankKeeper cmn.BankKeeper
@@ -62,7 +62,7 @@ func NewPrecompile(
 	tokenPair erc20types.TokenPair,
 	bankKeeper cmn.BankKeeper,
 	erc20Keeper Erc20Keeper,
-	transferKeeper transferkeeper.Keeper,
+	transferKeeper ibcutils.TransferKeeper,
 ) (*Precompile, error) {
 	newABI, err := cmn.LoadABI(f, abiPath)
 	if err != nil {

--- a/precompiles/gov/gov.go
+++ b/precompiles/gov/gov.go
@@ -18,7 +18,7 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	govkeeper "github.com/cosmos/cosmos-sdk/x/gov/keeper"
+	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
 )
 
 var _ vm.PrecompiledContract = &Precompile{}
@@ -31,9 +31,10 @@ var f embed.FS
 // Precompile defines the precompiled contract for gov.
 type Precompile struct {
 	cmn.Precompile
-	govKeeper govkeeper.Keeper
-	codec     codec.Codec
-	addrCdc   address.Codec
+	govMsgServer govtypes.MsgServer
+	govQuerier   govtypes.QueryServer
+	codec        codec.Codec
+	addrCdc      address.Codec
 }
 
 // LoadABI loads the gov ABI from the embedded abi.json file
@@ -45,7 +46,8 @@ func LoadABI() (abi.ABI, error) {
 // NewPrecompile creates a new gov Precompile instance as a
 // PrecompiledContract interface.
 func NewPrecompile(
-	govKeeper govkeeper.Keeper,
+	govMsgServer govtypes.MsgServer,
+	govQuerier govtypes.QueryServer,
 	bankKeeper cmn.BankKeeper,
 	codec codec.Codec,
 	addrCdc address.Codec,
@@ -61,9 +63,10 @@ func NewPrecompile(
 			KvGasConfig:          storetypes.KVGasConfig(),
 			TransientKVGasConfig: storetypes.TransientGasConfig(),
 		},
-		govKeeper: govKeeper,
-		codec:     codec,
-		addrCdc:   addrCdc,
+		govMsgServer: govMsgServer,
+		govQuerier:   govQuerier,
+		codec:        codec,
+		addrCdc:      addrCdc,
 	}
 
 	// SetAddress defines the address of the gov precompiled contract.

--- a/precompiles/gov/query.go
+++ b/precompiles/gov/query.go
@@ -5,7 +5,6 @@ import (
 	"github.com/ethereum/go-ethereum/core/vm"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	govkeeper "github.com/cosmos/cosmos-sdk/x/gov/keeper"
 )
 
 const (
@@ -41,8 +40,7 @@ func (p *Precompile) GetVotes(
 		return nil, err
 	}
 
-	queryServer := govkeeper.NewQueryServer(&p.govKeeper)
-	res, err := queryServer.Votes(ctx, queryVotesReq)
+	res, err := p.govQuerier.Votes(ctx, queryVotesReq)
 	if err != nil {
 		return nil, err
 	}
@@ -66,8 +64,7 @@ func (p *Precompile) GetVote(
 		return nil, err
 	}
 
-	queryServer := govkeeper.NewQueryServer(&p.govKeeper)
-	res, err := queryServer.Vote(ctx, queryVotesReq)
+	res, err := p.govQuerier.Vote(ctx, queryVotesReq)
 	if err != nil {
 		return nil, err
 	}
@@ -91,8 +88,7 @@ func (p *Precompile) GetDeposit(
 		return nil, err
 	}
 
-	queryServer := govkeeper.NewQueryServer(&p.govKeeper)
-	res, err := queryServer.Deposit(ctx, queryDepositReq)
+	res, err := p.govQuerier.Deposit(ctx, queryDepositReq)
 	if err != nil {
 		return nil, err
 	}
@@ -116,8 +112,7 @@ func (p *Precompile) GetDeposits(
 		return nil, err
 	}
 
-	queryServer := govkeeper.NewQueryServer(&p.govKeeper)
-	res, err := queryServer.Deposits(ctx, queryDepositsReq)
+	res, err := p.govQuerier.Deposits(ctx, queryDepositsReq)
 	if err != nil {
 		return nil, err
 	}
@@ -141,8 +136,7 @@ func (p *Precompile) GetTallyResult(
 		return nil, err
 	}
 
-	queryServer := govkeeper.NewQueryServer(&p.govKeeper)
-	res, err := queryServer.TallyResult(ctx, queryTallyResultReq)
+	res, err := p.govQuerier.TallyResult(ctx, queryTallyResultReq)
 	if err != nil {
 		return nil, err
 	}
@@ -163,8 +157,7 @@ func (p *Precompile) GetProposal(
 		return nil, err
 	}
 
-	queryServer := govkeeper.NewQueryServer(&p.govKeeper)
-	res, err := queryServer.Proposal(ctx, queryProposalReq)
+	res, err := p.govQuerier.Proposal(ctx, queryProposalReq)
 	if err != nil {
 		return nil, err
 	}
@@ -188,8 +181,7 @@ func (p *Precompile) GetProposals(
 		return nil, err
 	}
 
-	queryServer := govkeeper.NewQueryServer(&p.govKeeper)
-	res, err := queryServer.Proposals(ctx, queryProposalsReq)
+	res, err := p.govQuerier.Proposals(ctx, queryProposalsReq)
 	if err != nil {
 		return nil, err
 	}
@@ -213,8 +205,7 @@ func (p *Precompile) GetParams(
 		return nil, err
 	}
 
-	queryServer := govkeeper.NewQueryServer(&p.govKeeper)
-	res, err := queryServer.Params(ctx, queryParamsReq)
+	res, err := p.govQuerier.Params(ctx, queryParamsReq)
 	if err != nil {
 		return nil, err
 	}
@@ -235,7 +226,7 @@ func (p *Precompile) GetConstitution(
 		return nil, err
 	}
 
-	res, err := govkeeper.NewQueryServer(&p.govKeeper).Constitution(ctx, req)
+	res, err := p.govQuerier.Constitution(ctx, req)
 	if err != nil {
 		return nil, err
 	}

--- a/precompiles/gov/tx.go
+++ b/precompiles/gov/tx.go
@@ -9,7 +9,6 @@ import (
 	cmn "github.com/cosmos/evm/precompiles/common"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	govkeeper "github.com/cosmos/cosmos-sdk/x/gov/keeper"
 )
 
 const (
@@ -43,7 +42,7 @@ func (p *Precompile) SubmitProposal(
 		return nil, fmt.Errorf(cmn.ErrRequesterIsNotMsgSender, msgSender.String(), proposerHexAddr.String())
 	}
 
-	res, err := govkeeper.NewMsgServerImpl(&p.govKeeper).SubmitProposal(ctx, msg)
+	res, err := p.govMsgServer.SubmitProposal(ctx, msg)
 	if err != nil {
 		return nil, err
 	}
@@ -73,7 +72,7 @@ func (p *Precompile) Deposit(
 		return nil, fmt.Errorf(cmn.ErrRequesterIsNotMsgSender, msgSender.String(), depositorHexAddr.String())
 	}
 
-	if _, err = govkeeper.NewMsgServerImpl(&p.govKeeper).Deposit(ctx, msg); err != nil {
+	if _, err = p.govMsgServer.Deposit(ctx, msg); err != nil {
 		return nil, err
 	}
 
@@ -102,7 +101,7 @@ func (p *Precompile) CancelProposal(
 		return nil, fmt.Errorf(cmn.ErrRequesterIsNotMsgSender, msgSender.String(), proposerHexAddr.String())
 	}
 
-	if _, err = govkeeper.NewMsgServerImpl(&p.govKeeper).CancelProposal(ctx, msg); err != nil {
+	if _, err = p.govMsgServer.CancelProposal(ctx, msg); err != nil {
 		return nil, err
 	}
 
@@ -131,8 +130,7 @@ func (p Precompile) Vote(
 		return nil, fmt.Errorf(cmn.ErrRequesterIsNotMsgSender, msgSender.String(), voterHexAddr.String())
 	}
 
-	msgSrv := govkeeper.NewMsgServerImpl(&p.govKeeper)
-	if _, err = msgSrv.Vote(ctx, msg); err != nil {
+	if _, err = p.govMsgServer.Vote(ctx, msg); err != nil {
 		return nil, err
 	}
 
@@ -161,8 +159,7 @@ func (p Precompile) VoteWeighted(
 		return nil, fmt.Errorf(cmn.ErrRequesterIsNotMsgSender, msgSender.String(), voterHexAddr.String())
 	}
 
-	msgSrv := govkeeper.NewMsgServerImpl(&p.govKeeper)
-	if _, err = msgSrv.VoteWeighted(ctx, msg); err != nil {
+	if _, err = p.govMsgServer.VoteWeighted(ctx, msg); err != nil {
 		return nil, err
 	}
 

--- a/precompiles/ics20/ics20.go
+++ b/precompiles/ics20/ics20.go
@@ -10,14 +10,9 @@ import (
 	"github.com/ethereum/go-ethereum/core/vm"
 
 	cmn "github.com/cosmos/evm/precompiles/common"
-	transferkeeper "github.com/cosmos/evm/x/ibc/transfer/keeper"
-	evmkeeper "github.com/cosmos/evm/x/vm/keeper"
 	evmtypes "github.com/cosmos/evm/x/vm/types"
-	channelkeeper "github.com/cosmos/ibc-go/v10/modules/core/04-channel/keeper"
 
 	storetypes "cosmossdk.io/store/types"
-
-	stakingkeeper "github.com/cosmos/cosmos-sdk/x/staking/keeper"
 )
 
 // PrecompileAddress of the ICS-20 EVM extension in hex format.
@@ -33,20 +28,18 @@ var f embed.FS
 type Precompile struct {
 	cmn.Precompile
 	bankKeeper     cmn.BankKeeper
-	stakingKeeper  stakingkeeper.Keeper
-	transferKeeper transferkeeper.Keeper
-	channelKeeper  *channelkeeper.Keeper
-	evmKeeper      *evmkeeper.Keeper
+	stakingKeeper  cmn.StakingKeeper
+	transferKeeper cmn.TransferKeeper
+	channelKeeper  cmn.ChannelKeeper
 }
 
 // NewPrecompile creates a new ICS-20 Precompile instance as a
 // PrecompiledContract interface.
 func NewPrecompile(
 	bankKeeper cmn.BankKeeper,
-	stakingKeeper stakingkeeper.Keeper,
-	transferKeeper transferkeeper.Keeper,
-	channelKeeper *channelkeeper.Keeper,
-	evmKeeper *evmkeeper.Keeper,
+	stakingKeeper cmn.StakingKeeper,
+	transferKeeper cmn.TransferKeeper,
+	channelKeeper cmn.ChannelKeeper,
 ) (*Precompile, error) {
 	newAbi, err := cmn.LoadABI(f, "abi.json")
 	if err != nil {
@@ -63,7 +56,6 @@ func NewPrecompile(
 		transferKeeper: transferKeeper,
 		channelKeeper:  channelKeeper,
 		stakingKeeper:  stakingKeeper,
-		evmKeeper:      evmKeeper,
 	}
 
 	// SetAddress defines the address of the ICS-20 compile contract.

--- a/precompiles/slashing/slashing.go
+++ b/precompiles/slashing/slashing.go
@@ -18,7 +18,7 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/runtime"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	slashingkeeper "github.com/cosmos/cosmos-sdk/x/slashing/keeper"
+	slashingtypes "github.com/cosmos/cosmos-sdk/x/slashing/types"
 )
 
 var _ vm.PrecompiledContract = &Precompile{}
@@ -31,9 +31,10 @@ var f embed.FS
 // Precompile defines the precompiled contract for slashing.
 type Precompile struct {
 	cmn.Precompile
-	slashingKeeper slashingkeeper.Keeper
-	consCodec      runtime.ConsensusAddressCodec
-	valCodec       runtime.ValidatorAddressCodec
+	slashingKeeper    cmn.SlashingKeeper
+	slashingMsgServer slashingtypes.MsgServer
+	consCodec         runtime.ConsensusAddressCodec
+	valCodec          runtime.ValidatorAddressCodec
 }
 
 // LoadABI loads the slashing ABI from the embedded abi.json file
@@ -45,7 +46,8 @@ func LoadABI() (abi.ABI, error) {
 // NewPrecompile creates a new slashing Precompile instance as a
 // PrecompiledContract interface.
 func NewPrecompile(
-	slashingKeeper slashingkeeper.Keeper,
+	slashingKeeper cmn.SlashingKeeper,
+	slashingMsgServer slashingtypes.MsgServer,
 	bankKeeper cmn.BankKeeper,
 	valCdc, consCdc address.Codec,
 ) (*Precompile, error) {
@@ -60,9 +62,10 @@ func NewPrecompile(
 			KvGasConfig:          storetypes.KVGasConfig(),
 			TransientKVGasConfig: storetypes.TransientGasConfig(),
 		},
-		slashingKeeper: slashingKeeper,
-		valCodec:       valCdc,
-		consCodec:      consCdc,
+		slashingKeeper:    slashingKeeper,
+		slashingMsgServer: slashingMsgServer,
+		valCodec:          valCdc,
+		consCodec:         consCdc,
 	}
 
 	// SetAddress defines the address of the slashing precompiled contract.

--- a/precompiles/slashing/tx.go
+++ b/precompiles/slashing/tx.go
@@ -10,7 +10,6 @@ import (
 	cmn "github.com/cosmos/evm/precompiles/common"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	slashingkeeper "github.com/cosmos/cosmos-sdk/x/slashing/keeper"
 	"github.com/cosmos/cosmos-sdk/x/slashing/types"
 )
 
@@ -52,8 +51,7 @@ func (p Precompile) Unjail(
 		ValidatorAddr: valAddr,
 	}
 
-	msgSrv := slashingkeeper.NewMsgServerImpl(p.slashingKeeper)
-	if _, err := msgSrv.Unjail(ctx, msg); err != nil {
+	if _, err := p.slashingMsgServer.Unjail(ctx, msg); err != nil {
 		return nil, err
 	}
 

--- a/precompiles/staking/query.go
+++ b/precompiles/staking/query.go
@@ -11,7 +11,6 @@ import (
 	cmn "github.com/cosmos/evm/precompiles/common"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	stakingkeeper "github.com/cosmos/cosmos-sdk/x/staking/keeper"
 )
 
 const (
@@ -47,9 +46,7 @@ func (p Precompile) Delegation(
 		return nil, err
 	}
 
-	queryServer := stakingkeeper.Querier{Keeper: &p.stakingKeeper}
-
-	res, err := queryServer.Delegation(ctx, req)
+	res, err := p.stakingQuerier.Delegation(ctx, req)
 	if err != nil {
 		// If there is no delegation found, return the response with zero values.
 		if strings.Contains(err.Error(), fmt.Sprintf(ErrNoDelegationFound, req.DelegatorAddr, req.ValidatorAddr)) {
@@ -81,9 +78,7 @@ func (p Precompile) UnbondingDelegation(
 		return nil, err
 	}
 
-	queryServer := stakingkeeper.Querier{Keeper: &p.stakingKeeper}
-
-	res, err := queryServer.UnbondingDelegation(ctx, req)
+	res, err := p.stakingQuerier.UnbondingDelegation(ctx, req)
 	if err != nil {
 		// return empty unbonding delegation output if the unbonding delegation is not found
 		expError := fmt.Sprintf("unbonding delegation with delegator %s not found for validator %s", req.DelegatorAddr, req.ValidatorAddr)
@@ -110,9 +105,7 @@ func (p Precompile) Validator(
 		return nil, err
 	}
 
-	queryServer := stakingkeeper.Querier{Keeper: &p.stakingKeeper}
-
-	res, err := queryServer.Validator(ctx, req)
+	res, err := p.stakingQuerier.Validator(ctx, req)
 	if err != nil {
 		// return empty validator info if the validator is not found
 		expError := fmt.Sprintf("validator %s not found", req.ValidatorAddr)
@@ -139,9 +132,7 @@ func (p Precompile) Validators(
 		return nil, err
 	}
 
-	queryServer := stakingkeeper.Querier{Keeper: &p.stakingKeeper}
-
-	res, err := queryServer.Validators(ctx, req)
+	res, err := p.stakingQuerier.Validators(ctx, req)
 	if err != nil {
 		return nil, err
 	}
@@ -185,9 +176,7 @@ func (p Precompile) Redelegations(
 		return nil, err
 	}
 
-	queryServer := stakingkeeper.Querier{Keeper: &p.stakingKeeper}
-
-	res, err := queryServer.Redelegations(ctx, req)
+	res, err := p.stakingQuerier.Redelegations(ctx, req)
 	if err != nil {
 		return nil, err
 	}

--- a/precompiles/staking/staking.go
+++ b/precompiles/staking/staking.go
@@ -16,7 +16,7 @@ import (
 	storetypes "cosmossdk.io/store/types"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	stakingkeeper "github.com/cosmos/cosmos-sdk/x/staking/keeper"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 )
 
 var _ vm.PrecompiledContract = &Precompile{}
@@ -29,8 +29,10 @@ var f embed.FS
 // Precompile defines the precompiled contract for staking.
 type Precompile struct {
 	cmn.Precompile
-	stakingKeeper stakingkeeper.Keeper
-	addrCdc       address.Codec
+	stakingKeeper    cmn.StakingKeeper
+	stakingMsgServer stakingtypes.MsgServer
+	stakingQuerier   stakingtypes.QueryServer
+	addrCdc          address.Codec
 }
 
 // LoadABI loads the staking ABI from the embedded abi.json file
@@ -42,7 +44,9 @@ func LoadABI() (abi.ABI, error) {
 // NewPrecompile creates a new staking Precompile instance as a
 // PrecompiledContract interface.
 func NewPrecompile(
-	stakingKeeper stakingkeeper.Keeper,
+	stakingKeeper cmn.StakingKeeper,
+	stakingMsgServer stakingtypes.MsgServer,
+	stakingQuerier stakingtypes.QueryServer,
 	bankKeeper cmn.BankKeeper,
 	addrCdc address.Codec,
 ) (*Precompile, error) {
@@ -57,8 +61,10 @@ func NewPrecompile(
 			KvGasConfig:          storetypes.KVGasConfig(),
 			TransientKVGasConfig: storetypes.TransientGasConfig(),
 		},
-		stakingKeeper: stakingKeeper,
-		addrCdc:       addrCdc,
+		stakingKeeper:    stakingKeeper,
+		stakingMsgServer: stakingMsgServer,
+		stakingQuerier:   stakingQuerier,
+		addrCdc:          addrCdc,
 	}
 	// SetAddress defines the address of the staking precompiled contract.
 	p.SetAddress(common.HexToAddress(evmtypes.StakingPrecompileAddress))

--- a/precompiles/staking/tx.go
+++ b/precompiles/staking/tx.go
@@ -10,7 +10,6 @@ import (
 	cmn "github.com/cosmos/evm/precompiles/common"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	stakingkeeper "github.com/cosmos/cosmos-sdk/x/staking/keeper"
 )
 
 const (
@@ -69,8 +68,7 @@ func (p Precompile) CreateValidator(
 	}
 
 	// Execute the transaction using the message server
-	msgSrv := stakingkeeper.NewMsgServerImpl(&p.stakingKeeper)
-	if _, err = msgSrv.CreateValidator(ctx, msg); err != nil {
+	if _, err = p.stakingMsgServer.CreateValidator(ctx, msg); err != nil {
 		return nil, err
 	}
 
@@ -116,8 +114,7 @@ func (p Precompile) EditValidator(
 	}
 
 	// Execute the transaction using the message server
-	msgSrv := stakingkeeper.NewMsgServerImpl(&p.stakingKeeper)
-	if _, err = msgSrv.EditValidator(ctx, msg); err != nil {
+	if _, err = p.stakingMsgServer.EditValidator(ctx, msg); err != nil {
 		return nil, err
 	}
 
@@ -163,8 +160,7 @@ func (p *Precompile) Delegate(
 	}
 
 	// Execute the transaction using the message server
-	msgSrv := stakingkeeper.NewMsgServerImpl(&p.stakingKeeper)
-	if _, err = msgSrv.Delegate(ctx, msg); err != nil {
+	if _, err = p.stakingMsgServer.Delegate(ctx, msg); err != nil {
 		return nil, err
 	}
 
@@ -211,8 +207,7 @@ func (p Precompile) Undelegate(
 	}
 
 	// Execute the transaction using the message server
-	msgSrv := stakingkeeper.NewMsgServerImpl(&p.stakingKeeper)
-	res, err := msgSrv.Undelegate(ctx, msg)
+	res, err := p.stakingMsgServer.Undelegate(ctx, msg)
 	if err != nil {
 		return nil, err
 	}
@@ -261,8 +256,7 @@ func (p Precompile) Redelegate(
 		return nil, fmt.Errorf(cmn.ErrRequesterIsNotMsgSender, msgSender.String(), delegatorHexAddr.String())
 	}
 
-	msgSrv := stakingkeeper.NewMsgServerImpl(&p.stakingKeeper)
-	res, err := msgSrv.BeginRedelegate(ctx, msg)
+	res, err := p.stakingMsgServer.BeginRedelegate(ctx, msg)
 	if err != nil {
 		return nil, err
 	}
@@ -310,8 +304,7 @@ func (p Precompile) CancelUnbondingDelegation(
 		return nil, fmt.Errorf(cmn.ErrRequesterIsNotMsgSender, msgSender.String(), delegatorHexAddr.String())
 	}
 
-	msgSrv := stakingkeeper.NewMsgServerImpl(&p.stakingKeeper)
-	if _, err = msgSrv.CancelUnbondingDelegation(ctx, msg); err != nil {
+	if _, err = p.stakingMsgServer.CancelUnbondingDelegation(ctx, msg); err != nil {
 		return nil, err
 	}
 

--- a/precompiles/werc20/werc20.go
+++ b/precompiles/werc20/werc20.go
@@ -10,10 +10,10 @@ import (
 	"github.com/ethereum/go-ethereum/core/tracing"
 	"github.com/ethereum/go-ethereum/core/vm"
 
+	ibcutils "github.com/cosmos/evm/ibc"
 	cmn "github.com/cosmos/evm/precompiles/common"
 	erc20 "github.com/cosmos/evm/precompiles/erc20"
 	erc20types "github.com/cosmos/evm/x/erc20/types"
-	transferkeeper "github.com/cosmos/evm/x/ibc/transfer/keeper"
 )
 
 // abiPath defines the path to the WERC-20 precompile ABI JSON file.
@@ -51,7 +51,7 @@ func NewPrecompile(
 	tokenPair erc20types.TokenPair,
 	bankKeeper cmn.BankKeeper,
 	erc20Keeper Erc20Keeper,
-	transferKeeper transferkeeper.Keeper,
+	transferKeeper ibcutils.TransferKeeper,
 ) (*Precompile, error) {
 	newABI, err := LoadABI()
 	if err != nil {

--- a/tests/integration/precompiles/distribution/test_setup.go
+++ b/tests/integration/precompiles/distribution/test_setup.go
@@ -18,6 +18,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	distrkeeper "github.com/cosmos/cosmos-sdk/x/distribution/keeper"
 	distrtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
 	minttypes "github.com/cosmos/cosmos-sdk/x/mint/types"
 )
@@ -131,6 +132,8 @@ func (s *PrecompileTestSuite) SetupTest() {
 	s.network = nw
 	s.precompile, err = distribution.NewPrecompile(
 		s.network.App.GetDistrKeeper(),
+		distrkeeper.NewMsgServerImpl(s.network.App.GetDistrKeeper()),
+		distrkeeper.NewQuerier(s.network.App.GetDistrKeeper()),
 		*s.network.App.GetStakingKeeper(),
 		s.network.App.GetBankKeeper(),
 		address.NewBech32Codec(sdk.GetConfig().GetBech32AccountAddrPrefix()),

--- a/tests/integration/precompiles/distribution/test_utils.go
+++ b/tests/integration/precompiles/distribution/test_utils.go
@@ -10,6 +10,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	distrtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
 	minttypes "github.com/cosmos/cosmos-sdk/x/mint/types"
+	stakingkeeper "github.com/cosmos/cosmos-sdk/x/staking/keeper"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 )
 
@@ -84,6 +85,8 @@ func (s *PrecompileTestSuite) fundAccountWithBaseDenom(ctx sdk.Context, addr sdk
 func (s *PrecompileTestSuite) getStakingPrecompile() (*staking.Precompile, error) {
 	return staking.NewPrecompile(
 		*s.network.App.GetStakingKeeper(),
+		stakingkeeper.NewMsgServerImpl(s.network.App.GetStakingKeeper()),
+		stakingkeeper.NewQuerier(s.network.App.GetStakingKeeper()),
 		s.network.App.GetBankKeeper(),
 		address.NewBech32Codec(sdk.GetConfig().GetBech32AccountAddrPrefix()),
 	)

--- a/tests/integration/precompiles/gov/test_setup.go
+++ b/tests/integration/precompiles/gov/test_setup.go
@@ -19,6 +19,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	govkeeper "github.com/cosmos/cosmos-sdk/x/gov/keeper"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	govv1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
 )
@@ -136,8 +137,10 @@ func (s *PrecompileTestSuite) SetupTest() {
 	s.keyring = keyring
 	s.network = nw
 
+	govKeeper := s.network.App.GetGovKeeper()
 	if s.precompile, err = gov.NewPrecompile(
-		s.network.App.GetGovKeeper(),
+		govkeeper.NewMsgServerImpl(&govKeeper),
+		govkeeper.NewQueryServer(&govKeeper),
 		s.network.App.GetBankKeeper(),
 		s.network.App.AppCodec(),
 		address.NewBech32Codec(sdk.GetConfig().GetBech32AccountAddrPrefix()),

--- a/tests/integration/precompiles/ics20/test_setup.go
+++ b/tests/integration/precompiles/ics20/test_setup.go
@@ -48,7 +48,6 @@ func (s *PrecompileTestSuite) SetupTest() {
 		*evmAppA.GetStakingKeeper(),
 		evmAppA.GetTransferKeeper(),
 		evmAppA.GetIBCKeeper().ChannelKeeper,
-		evmAppA.GetEVMKeeper(),
 	)
 	s.chainABondDenom, _ = evmAppA.GetStakingKeeper().BondDenom(s.chainA.GetContext())
 	evmAppB := s.chainB.App.(evm.EvmApp)
@@ -57,7 +56,6 @@ func (s *PrecompileTestSuite) SetupTest() {
 		*evmAppB.GetStakingKeeper(),
 		evmAppB.GetTransferKeeper(),
 		evmAppB.GetIBCKeeper().ChannelKeeper,
-		evmAppB.GetEVMKeeper(),
 	)
 	s.chainBBondDenom, _ = evmAppB.GetStakingKeeper().BondDenom(s.chainB.GetContext())
 }

--- a/tests/integration/precompiles/slashing/test_setup.go
+++ b/tests/integration/precompiles/slashing/test_setup.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/codec/address"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	slashingkeeper "github.com/cosmos/cosmos-sdk/x/slashing/keeper"
 )
 
 type PrecompileTestSuite struct {
@@ -56,6 +57,7 @@ func (s *PrecompileTestSuite) SetupTest() {
 
 	if s.precompile, err = slashing.NewPrecompile(
 		s.network.App.GetSlashingKeeper(),
+		slashingkeeper.NewMsgServerImpl(s.network.App.GetSlashingKeeper()),
 		s.network.App.GetBankKeeper(),
 		address.NewBech32Codec(sdk.GetConfig().GetBech32ValidatorAddrPrefix()),
 		address.NewBech32Codec(sdk.GetConfig().GetBech32ConsensusAddrPrefix()),

--- a/tests/integration/precompiles/staking/test_setup.go
+++ b/tests/integration/precompiles/staking/test_setup.go
@@ -16,6 +16,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	stakingkeeper "github.com/cosmos/cosmos-sdk/x/staking/keeper"
 )
 
 const InitialTestBalance = 1000000000000000000 // 1 atom
@@ -82,6 +83,8 @@ func (s *PrecompileTestSuite) SetupTest() {
 
 	if s.precompile, err = staking.NewPrecompile(
 		*s.network.App.GetStakingKeeper(),
+		stakingkeeper.NewMsgServerImpl(s.network.App.GetStakingKeeper()),
+		stakingkeeper.NewQuerier(s.network.App.GetStakingKeeper()),
 		s.network.App.GetBankKeeper(),
 		address.NewBech32Codec(sdk.GetConfig().GetBech32AccountAddrPrefix()),
 	); err != nil {


### PR DESCRIPTION
# Description

This commit refactors the precompile modules to rely on interfaces for their keeper dependencies instead of concrete implementations. This significantly improves the modularity and testability of the precompile system.
Previously, precompiles directly depended on specific keeper structs (e.g., `*stakingkeeper.Keeper`) and instantiated `MsgServer` or `Querier` implementations within their methods. This created tight coupling between the precompiles and the internal structure of other modules.
This change follows the dependency inversion principle, making the precompiles more robust, easier to maintain, and significantly simpler to unit-test with mocks.

- Define a set of keeper interfaces in precompiles/common/interfaces.go that specify the exact methods required by the precompiles.
- Update all precompile constructors and internal structs to use these new interfaces.
- Modifie the precompile assembly in `evmd/precompiles.go` to inject the concrete `MsgServer` and `Querier` implementations, which satisfy the required interfaces.
- Removed unnecessary keeper dependencies from the function signatures of several precompiles

Closes: #399 

---

## Author Checklist

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.

I have...

- [ ] tackled an existing issue or discussed with a team member
- [ ] left instructions on how to review the changes
- [x] targeted the `main` branch
