### PR TITLE
(chore):Simplify Mempool Config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 - [\#467](https://github.com/cosmos/evm/pull/467) Replace GlobalEVMMempool by passing to JSONRPC on initiate.
 - [\#352](https://github.com/cosmos/evm/pull/352) Remove the creation of a Geth EVM instance, stateDB during the AnteHandler balance check.
+- [\#496](https://github.com/cosmos/evm/pull/496) Simplify mempool instantiation by using configs instead of objects.
 
 ### FEATURES
 

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -67,11 +67,11 @@ type (
 // It allows customization of the underlying mempools, verification functions,
 // and broadcasting functions used by the sdkmempool.
 type EVMMempoolConfig struct {
-	TxPool        *txpool.TxPool
-	CosmosPool    sdkmempool.ExtMempool
-	AnteHandler   sdk.AnteHandler
-	BroadCastTxFn func(txs []*ethtypes.Transaction) error
-	BlockGasLimit uint64 // Block gas limit from consensus parameters
+	LegacyPoolConfig *legacypool.Config
+	CosmosPoolConfig *sdkmempool.PriorityNonceMempoolConfig[math.Int]
+	AnteHandler      sdk.AnteHandler
+	BroadCastTxFn    func(txs []*ethtypes.Transaction) error
+	BlockGasLimit    uint64 // Block gas limit from consensus parameters
 }
 
 // NewExperimentalEVMMempool creates a new unified mempool for EVM and Cosmos transactions.
@@ -106,30 +106,32 @@ func NewExperimentalEVMMempool(getCtxCallback func(height int64, prove bool) (sd
 		config.BlockGasLimit = 100_000_000
 	}
 
-	// Default txPool
-	txPool = config.TxPool
-	if txPool == nil {
-		legacyPool := legacypool.New(legacypool.DefaultConfig, blockchain)
-
-		// Set up broadcast function using clientCtx
-		if config.BroadCastTxFn != nil {
-			legacyPool.BroadcastTxFn = config.BroadCastTxFn
-		} else {
-			// Create default broadcast function using clientCtx.
-			// The EVM mempool will broadcast transactions when it promotes them
-			// from queued into pending, noting their readiness to be executed.
-			legacyPool.BroadcastTxFn = func(txs []*ethtypes.Transaction) error {
-				logger.Debug("broadcasting EVM transactions", "tx_count", len(txs))
-				return broadcastEVMTransactions(clientCtx, txConfig, txs)
-			}
-		}
-
-		txPoolInit, err := txpool.New(uint64(0), blockchain, []txpool.SubPool{legacyPool})
-		if err != nil {
-			panic(err)
-		}
-		txPool = txPoolInit
+	// Create txPool from configuration
+	legacyConfig := legacypool.DefaultConfig
+	if config.LegacyPoolConfig != nil {
+		legacyConfig = *config.LegacyPoolConfig
 	}
+
+	legacyPool := legacypool.New(legacyConfig, blockchain)
+
+	// Set up broadcast function using clientCtx
+	if config.BroadCastTxFn != nil {
+		legacyPool.BroadcastTxFn = config.BroadCastTxFn
+	} else {
+		// Create default broadcast function using clientCtx.
+		// The EVM mempool will broadcast transactions when it promotes them
+		// from queued into pending, noting their readiness to be executed.
+		legacyPool.BroadcastTxFn = func(txs []*ethtypes.Transaction) error {
+			logger.Debug("broadcasting EVM transactions", "tx_count", len(txs))
+			return broadcastEVMTransactions(clientCtx, txConfig, txs)
+		}
+	}
+
+	txPoolInit, err := txpool.New(uint64(0), blockchain, []txpool.SubPool{legacyPool})
+	if err != nil {
+		panic(err)
+	}
+	txPool = txPoolInit
 
 	if len(txPool.Subpools) != 1 {
 		panic("tx pool should contain one subpool")
@@ -138,11 +140,12 @@ func NewExperimentalEVMMempool(getCtxCallback func(height int64, prove bool) (sd
 		panic("tx pool should contain only legacypool")
 	}
 
-	// Default Cosmos Mempool
-	cosmosPool = config.CosmosPool
-	if cosmosPool == nil {
-		priorityConfig := sdkmempool.PriorityNonceMempoolConfig[math.Int]{}
-		priorityConfig.TxPriority = sdkmempool.TxPriority[math.Int]{
+	// Create Cosmos Mempool from configuration
+	cosmosPoolConfig := config.CosmosPoolConfig
+	if cosmosPoolConfig == nil {
+		// Default configuration
+		defaultConfig := sdkmempool.PriorityNonceMempoolConfig[math.Int]{}
+		defaultConfig.TxPriority = sdkmempool.TxPriority[math.Int]{
 			GetTxPriority: func(goCtx context.Context, tx sdk.Tx) math.Int {
 				cosmosTxFee, ok := tx.(sdk.FeeTx)
 				if !ok {
@@ -162,8 +165,10 @@ func NewExperimentalEVMMempool(getCtxCallback func(height int64, prove bool) (sd
 			},
 			MinValue: math.ZeroInt(),
 		}
-		cosmosPool = sdkmempool.NewPriorityMempool(priorityConfig)
+		cosmosPoolConfig = &defaultConfig
 	}
+
+	cosmosPool = sdkmempool.NewPriorityMempool(*cosmosPoolConfig)
 
 	evmMempool := &ExperimentalEVMMempool{
 		vmKeeper:      vmKeeper,

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -127,11 +127,10 @@ func NewExperimentalEVMMempool(getCtxCallback func(height int64, prove bool) (sd
 		}
 	}
 
-	txPoolInit, err := txpool.New(uint64(0), blockchain, []txpool.SubPool{legacyPool})
+	txPool, err := txpool.New(uint64(0), blockchain, []txpool.SubPool{legacyPool})
 	if err != nil {
 		panic(err)
 	}
-	txPool = txPoolInit
 
 	if len(txPool.Subpools) != 1 {
 		panic("tx pool should contain one subpool")


### PR DESCRIPTION
closes: #460 

Not a breaking change - uses configs instead of the actual objects during initialization, with sensible defaults still provided.