### PR TITLE
test: v0.4.1 -> main upgrade test

### DIFF
--- a/.github/workflows/system-test.yml
+++ b/.github/workflows/system-test.yml
@@ -29,6 +29,9 @@ jobs:
         with:
           version: stable
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
       - uses: technote-space/get-diff-action@v6.1.2
         with:
           PATTERNS: |

--- a/Makefile
+++ b/Makefile
@@ -379,7 +379,6 @@ test-rpc-compat-stop:
 .PHONY: localnet-start localnet-stop localnet-build-env localnet-build-nodes test-rpc-compat test-rpc-compat-stop
 
 test-system: build
-	ulimit -n 1300
 	mkdir -p ./tests/systemtests/binaries/
 	cp $(BUILDDIR)/evmd ./tests/systemtests/binaries/
 	$(MAKE) -C tests/systemtests test

--- a/Makefile
+++ b/Makefile
@@ -378,7 +378,7 @@ test-rpc-compat-stop:
 
 .PHONY: localnet-start localnet-stop localnet-build-env localnet-build-nodes test-rpc-compat test-rpc-compat-stop
 
-test-system: build build-v04
+test-system: build-v04 build
 	mkdir -p ./tests/systemtests/binaries/
 	cp $(BUILDDIR)/evmd ./tests/systemtests/binaries/
 	$(MAKE) -C tests/systemtests test

--- a/Makefile
+++ b/Makefile
@@ -378,10 +378,17 @@ test-rpc-compat-stop:
 
 .PHONY: localnet-start localnet-stop localnet-build-env localnet-build-nodes test-rpc-compat test-rpc-compat-stop
 
-test-system: build
+test-system: build build-v04
 	mkdir -p ./tests/systemtests/binaries/
 	cp $(BUILDDIR)/evmd ./tests/systemtests/binaries/
 	$(MAKE) -C tests/systemtests test
+
+build-v04:
+	mkdir -p ./tests/systemtests/binaries/v0.4
+	git checkout v0.4.1
+	make build
+	cp $(BUILDDIR)/evmd ./tests/systemtests/binaries/v0.4
+	git checkout -
 
 mocks:
 	@echo "--> generating mocks"

--- a/evmd/upgrades.go
+++ b/evmd/upgrades.go
@@ -1,5 +1,42 @@
 package evmd
 
+import (
+	"context"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+
+	storetypes "cosmossdk.io/store/types"
+	upgradetypes "cosmossdk.io/x/upgrade/types"
+)
+
+// UpgradeName defines the on-chain upgrade name for the sample EVMD upgrade
+// from v0.4.0 to v0.5.0.
+//
+// NOTE: This upgrade defines a reference implementation of what an upgrade
+// could look like when an application is migrating from EVMD version
+// v0.4.0 to v0.5.x
+const UpgradeName = "v0.4.0-to-v0.5.0"
+
 func (app EVMD) RegisterUpgradeHandlers() {
-	// No upgrades registered yet
+	app.UpgradeKeeper.SetUpgradeHandler(
+		UpgradeName,
+		func(ctx context.Context, _ upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
+			sdk.UnwrapSDKContext(ctx).Logger().Debug("this is a debug level message to test that verbose logging mode has properly been enabled during a chain upgrade")
+			return app.ModuleManager.RunMigrations(ctx, app.Configurator(), fromVM)
+		},
+	)
+
+	upgradeInfo, err := app.UpgradeKeeper.ReadUpgradeInfoFromDisk()
+	if err != nil {
+		panic(err)
+	}
+
+	if upgradeInfo.Name == UpgradeName && !app.UpgradeKeeper.IsSkipHeight(upgradeInfo.Height) {
+		storeUpgrades := storetypes.StoreUpgrades{
+			Added: []string{},
+		}
+		// configure store loader that checks if version == upgradeHeight and applies store upgrades
+		app.SetStoreLoader(upgradetypes.UpgradeStoreLoader(upgradeInfo.Height, &storeUpgrades))
+	}
 }

--- a/tests/systemtests/Makefile
+++ b/tests/systemtests/Makefile
@@ -3,5 +3,5 @@
 WAIT_TIME ?= 20s
 
 test:
-	go test -mod=readonly -failfast -timeout=15m -tags='system_test' ./... --wait-time=$(WAIT_TIME) --verbose -run=TestChainUpgrade --binary evmd --chain-id local-4221
+	go test -mod=readonly -failfast -timeout=15m -tags='system_test' ./... --wait-time=$(WAIT_TIME) --verbose --binary evmd --chain-id local-4221
 

--- a/tests/systemtests/Makefile
+++ b/tests/systemtests/Makefile
@@ -3,5 +3,5 @@
 WAIT_TIME ?= 20s
 
 test:
-	go test -mod=readonly -failfast -timeout=15m -tags='system_test' ./... --wait-time=$(WAIT_TIME) --verbose --binary evmd --chain-id local-4221
+	go test -mod=readonly -failfast -timeout=15m -tags='system_test' ./... --wait-time=$(WAIT_TIME) --verbose -run=TestChainUpgrade --binary evmd --chain-id local-4221
 

--- a/tests/systemtests/upgrade_test.go
+++ b/tests/systemtests/upgrade_test.go
@@ -18,7 +18,7 @@ import (
 
 const (
 	upgradeHeight int64 = 22
-	upgradeName         = "v0.4.0-to-v0.5.0" // must match UpgradeName in simapp/upgrades.go
+	upgradeName         = "v0.4.0-to-v0.5.0" // must match UpgradeName in evmd/upgrades.go
 )
 
 func TestChainUpgrade(t *testing.T) {
@@ -68,7 +68,7 @@ func TestChainUpgrade(t *testing.T) {
 	require.NotEmpty(t, proposals, raw)
 	proposalID := proposals[len(proposals)-1].String()
 
-	for i := range 4 {
+	for i := range systest.Sut.NodesCount() {
 		go func(i int) { // do parallel
 			systest.Sut.Logf("Voting: validator %d\n", i)
 			rsp := cli.Run("tx", "gov", "vote", proposalID, "yes", "--fees=10000000000000000000atest", "--from", cli.GetKeyAddr(fmt.Sprintf("node%d", i)))

--- a/tests/systemtests/upgrade_test.go
+++ b/tests/systemtests/upgrade_test.go
@@ -1,0 +1,95 @@
+//go:build system_test
+
+package systemtests
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+
+	systest "cosmossdk.io/systemtests"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/address"
+)
+
+const (
+	testSeed            = "scene learn remember glide apple expand quality spawn property shoe lamp carry upset blossom draft reject aim file trash miss script joy only measure"
+	upgradeHeight int64 = 22
+	upgradeName         = "v0.4.0-to-v0.5.0" // must match UpgradeName in simapp/upgrades.go
+)
+
+func TestChainUpgrade(t *testing.T) {
+	// Scenario:
+	// start a legacy chain with some state
+	// when a chain upgrade proposal is executed
+	// then the chain upgrades successfully
+	systest.Sut.StopChain()
+
+	currentBranchBinary := systest.Sut.ExecBinary()
+	currentInitializer := systest.Sut.TestnetInitializer()
+
+	legacyBinary := systest.WorkDir + "/binaries/v0.4/evmd"
+	systest.Sut.SetExecBinary(legacyBinary)
+	systest.Sut.SetupChain()
+
+	votingPeriod := 5 * time.Second // enough time to vote
+	systest.Sut.ModifyGenesisJSON(t, systest.SetGovVotingPeriod(t, votingPeriod))
+
+	systest.Sut.StartChain(t, fmt.Sprintf("--halt-height=%d", upgradeHeight+1))
+
+	cli := systest.NewCLIWrapper(t, systest.Sut, systest.Verbose)
+	govAddr := sdk.AccAddress(address.Module("gov")).String()
+	// submit upgrade proposal
+	proposal := fmt.Sprintf(`
+{
+ "messages": [
+  {
+   "@type": "/cosmos.upgrade.v1beta1.MsgSoftwareUpgrade",
+   "authority": %q,
+   "plan": {
+    "name": %q,
+    "height": "%d"
+   }
+  }
+ ],
+ "metadata": "ipfs://CID",
+ "deposit": "100000000atest",
+ "title": "my upgrade",
+ "summary": "testing"
+}`, govAddr, upgradeName, upgradeHeight)
+	proposalID := cli.SubmitAndVoteGovProposal(proposal)
+	t.Logf("current_height: %d\n", systest.Sut.CurrentHeight())
+	raw := cli.CustomQuery("q", "gov", "proposal", proposalID)
+	t.Log(raw)
+
+	systest.Sut.AwaitBlockHeight(t, upgradeHeight-1, 60*time.Second)
+	t.Logf("current_height: %d\n", systest.Sut.CurrentHeight())
+	raw = cli.CustomQuery("q", "gov", "proposal", proposalID)
+	proposalStatus := gjson.Get(raw, "proposal.status").String()
+	require.Equal(t, "PROPOSAL_STATUS_PASSED", proposalStatus, raw)
+
+	t.Log("waiting for upgrade info")
+	systest.Sut.AwaitUpgradeInfo(t)
+	systest.Sut.StopChain()
+
+	t.Log("Upgrade height was reached. Upgrading chain")
+	systest.Sut.SetExecBinary(currentBranchBinary)
+	systest.Sut.SetTestnetInitializer(currentInitializer)
+	systest.Sut.StartChain(t)
+
+	require.True(t, upgradeHeight+1 <= systest.Sut.CurrentHeight())
+
+	regex, err := regexp.Compile("DBG this is a debug level message to test that verbose logging mode has properly been enabled during a chain upgrade")
+	require.NoError(t, err)
+	require.Equal(t, systest.Sut.NodesCount(), systest.Sut.FindLogMessage(regex))
+
+	// smoke test that new version runs
+	cli = systest.NewCLIWrapper(t, systest.Sut, systest.Verbose)
+	got := cli.Run("tx", "bank", "node0", govAddr, "100atest", "--from=node0")
+	systest.RequireTxSuccess(t, got)
+}


### PR DESCRIPTION
# Description

closes: STACK-1444


adds a systemtest that ensures the chain can execute an upgrade from v0.4.0 to main.

---

## Author Checklist

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.

I have...

- [ ] tackled an existing issue or discussed with a team member
- [ ] left instructions on how to review the changes
- [ ] targeted the `main` branch
