### PR TITLE
Problem: AddPrecompileFn on stateObject not needed

### DIFF
--- a/x/vm/statedb/state_object.go
+++ b/x/vm/statedb/state_object.go
@@ -8,8 +8,6 @@ import (
 	"github.com/holiman/uint256"
 
 	"github.com/cosmos/evm/x/vm/types"
-
-	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 // Account is the Ethereum consensus representation of accounts.
@@ -134,16 +132,6 @@ func (s *stateObject) SetBalance(amount *uint256.Int) uint256.Int {
 	})
 	s.setBalance(amount)
 	return prev
-}
-
-// AddPrecompileFn appends to the journal an entry
-// with a snapshot of the multi-store and events
-// previous to the precompile call
-func (s *stateObject) AddPrecompileFn(snapshot int, events sdk.Events) {
-	s.db.journal.append(precompileCallChange{
-		snapshot: snapshot,
-		events:   events,
-	})
 }
 
 func (s *stateObject) setBalance(amount *uint256.Int) {

--- a/x/vm/statedb/statedb.go
+++ b/x/vm/statedb/statedb.go
@@ -435,11 +435,10 @@ func (s *StateDB) setStateObject(object *stateObject) {
 // with a snapshot of the multi-store and events previous
 // to the precompile call.
 func (s *StateDB) AddPrecompileFn(addr common.Address, snapshot int, events sdk.Events) error {
-	stateObject := s.getOrNewStateObject(addr)
-	if stateObject == nil {
-		return fmt.Errorf("could not add precompile call to address %s. State object not found", addr)
-	}
-	stateObject.AddPrecompileFn(snapshot, events)
+	s.journal.append(precompileCallChange{
+		snapshot: snapshot,
+		events:   events,
+	})
 	s.precompileCallsCounter++
 	if s.precompileCallsCounter > types.MaxPrecompileCalls {
 		return fmt.Errorf("max calls to precompiles (%d) reached", types.MaxPrecompileCalls)


### PR DESCRIPTION
what is does is only add a journal entry, not related to the state object at all.

Solution:
- remove the method, move the logic to statedb directly.

# Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

<!-- Please keep your PR as draft until it's ready for review -->

<!-- Pull requests that sit inactive for longer than 30 days will be closed.  -->

Closes: #XXXX

---

## Author Checklist

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.

I have...

- [ ] tackled an existing issue or discussed with a team member
- [ ] left instructions on how to review the changes
- [ ] targeted the `main` branch
