### PR TITLE
refactor: replace TestEncodingConfig with production EncodingConfig

### DIFF
--- a/encoding/config.go
+++ b/encoding/config.go
@@ -14,14 +14,23 @@ import (
 	amino "github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/codec/address"
 	"github.com/cosmos/cosmos-sdk/codec/types"
+	"github.com/cosmos/cosmos-sdk/client"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdktestutil "github.com/cosmos/cosmos-sdk/types/module/testutil"
 	"github.com/cosmos/cosmos-sdk/x/auth/migrations/legacytx"
 	"github.com/cosmos/cosmos-sdk/x/auth/tx"
 )
 
+// EncodingConfig specifies the concrete encoding types to use for a given app.
+// This is provided for compatibility between protobuf and amino implementations.
+type EncodingConfig struct {
+	InterfaceRegistry types.InterfaceRegistry
+	Codec             amino.Codec
+	TxConfig          client.TxConfig
+	Amino             *amino.LegacyAmino
+}
+
 // MakeConfig creates a new EncodingConfig and returns it
-func MakeConfig(evmChainID uint64) sdktestutil.TestEncodingConfig {
+func MakeConfig(evmChainID uint64) EncodingConfig {
 	cdc := amino.NewLegacyAmino()
 	signingOptions := signing.Options{
 		AddressCodec: address.Bech32Codec{
@@ -49,7 +58,7 @@ func MakeConfig(evmChainID uint64) sdktestutil.TestEncodingConfig {
 	legacytx.RegressionTestingAminoCodec = cdc
 	eip712.SetEncodingConfig(cdc, interfaceRegistry, evmChainID)
 
-	return sdktestutil.TestEncodingConfig{
+	return EncodingConfig{
 		InterfaceRegistry: interfaceRegistry,
 		Codec:             codec,
 		TxConfig:          tx.NewTxConfig(codec, tx.DefaultSignModes),


### PR DESCRIPTION
## Summary
- Replaced `sdktestutil.TestEncodingConfig` with a production-ready `EncodingConfig` struct
- Removed dependency on test utilities in production code

## Changes
- Defined custom `EncodingConfig` struct with same fields as `TestEncodingConfig`
- Removed import of `cosmos-sdk/types/module/testutil`
- Updated `MakeConfig` return type to use the new production struct

## Test plan
- [x] Code compiles successfully (`go build ./encoding/...`)
- [x] Tests pass (`go test ./encoding/...`)

## Why this change is needed
Using test utilities in production code is an anti-pattern that can lead to:
- Unnecessary dependencies on test packages
- Potential issues if test utilities change their behavior
- Confusion about whether code is meant for production or testing

This change improves code quality by ensuring production code only uses production-appropriate types and utilities.

🤖 Generated with [Claude Code](https://claude.ai/code)