### PR TITLE
fix(mempool): checkTxHandler handles "invalid nonce" tx

### DIFF
--- a/mempool/check_tx.go
+++ b/mempool/check_tx.go
@@ -18,7 +18,7 @@ func NewCheckTxHandler(mempool *ExperimentalEVMMempool) types.CheckTxHandler {
 		gInfo, result, anteEvents, err := runTx(request.Tx, nil)
 		if err != nil {
 			// detect if there is a nonce gap error (only returned for EVM transactions)
-			if errors.Is(err, ErrNonceGap) {
+			if errors.Is(err, ErrNonceGap) || errors.Is(err, sdkerrors.ErrInvalidSequence) {
 				// send it to the mempool for further triage
 				err := mempool.InsertInvalidNonce(request.Tx)
 				if err != nil {

--- a/tests/integration/mempool/test_helpers.go
+++ b/tests/integration/mempool/test_helpers.go
@@ -67,6 +67,29 @@ func (s *IntegrationTestSuite) createEVMValueTransferTx(key keyring.Key, nonce i
 	return tx
 }
 
+// createEVMTransaction creates an EVM transaction using the provided key
+func (s *IntegrationTestSuite) createEVMValueTransferDynamicFeeTx(key keyring.Key, nonce int, gasFeeCap, gasTipCap *big.Int) sdk.Tx {
+	to := s.keyring.GetKey(1).Addr
+
+	if nonce < 0 {
+		s.Require().NoError(fmt.Errorf("nonce must be non-negative"))
+	}
+
+	ethTxArgs := evmtypes.EvmTxArgs{
+		Nonce:     uint64(nonce),
+		To:        &to,
+		Amount:    big.NewInt(1000),
+		GasLimit:  TxGas,
+		GasFeeCap: gasFeeCap,
+		GasTipCap: gasTipCap,
+		Input:     nil,
+	}
+	tx, err := s.factory.GenerateSignedEthTx(key.Priv, ethTxArgs)
+	s.Require().NoError(err)
+
+	return tx
+}
+
 // createEVMContractDeployTx creates an EVM transaction for contract deployment
 func (s *IntegrationTestSuite) createEVMContractDeployTx(key keyring.Key, gasPrice *big.Int, data []byte) sdk.Tx {
 	ethTxArgs := evmtypes.EvmTxArgs{


### PR DESCRIPTION
# Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

<!-- Please keep your PR as draft until it's ready for review -->

<!-- Pull requests that sit inactive for longer than 30 days will be closed.  -->

Fix `CheckTxHandler` to allow tx with "invalid sequence" error.

The purpose of this pr is aligning appside mempool with geth mempool.

Because current anteHandler rejects valid tx whose nonce is lower than tx in mempool, `CheckTxHandler` should handle this error and insert that tx into mempool.

The reason why does not modify anteHandler but `CheckTxHandler` is, if appside mempool is not enabled, validation of anteHandler is correct. So, we should modify `CheckTxHandler` that is used for appside mempool.


Closes: #590 

---

## Author Checklist

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.

I have...

- [ ] tackled an existing issue or discussed with a team member
- [ ] left instructions on how to review the changes
- [ ] targeted the `main` branch
