### PR TITLE
Fix typo on evmd slashing integration test suite naming

### DIFF
--- a/evmd/tests/integration/precompiles/slashing/precompile_slashing_test.go
+++ b/evmd/tests/integration/precompiles/slashing/precompile_slashing_test.go
@@ -14,6 +14,6 @@ func TestSlashingPrecompileTestSuite(t *testing.T) {
 	suite.Run(t, s)
 }
 
-func TestStakingPrecompileIntegrationTestSuite(t *testing.T) {
+func TestSlashingPrecompileIntegrationTestSuite(t *testing.T) {
 	slashing.TestPrecompileIntegrationTestSuite(t, integration.CreateEvmd)
 }


### PR DESCRIPTION
# Description

Fixes a typo on the naming of evmd slashing integration

---

## Author Checklist

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.

I have...

- [ ] tackled an existing issue or discussed with a team member
It's a simple typo fix
- [ ] left instructions on how to review the changes
It's a simple typo fix
- [x] targeted the `main` branch
