### PR TITLE
fix: avoid tx with unsupported extension option for ExtensionOptionDynamicFeeTx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - [\#689](https://github.com/cosmos/evm/pull/689) Align debug addr for hex address.
 - [\#668](https://github.com/cosmos/evm/pull/668) Fix panic in legacy mempool when Reset() was called with a skipped header between old and new block.
 - [\#730](https://github.com/cosmos/evm/pull/730) Fix panic if evm mempool not used.
+- [\#733](https://github.com/cosmos/evm/pull/733) Avoid rejecting tx with unsupported extension option for ExtensionOptionDynamicFeeTx.
 
 ### IMPROVEMENTS
 

--- a/ante/ante.go
+++ b/ante/ante.go
@@ -85,7 +85,7 @@ func NewAnteHandler(options HandlerOptions) sdk.AnteHandler {
 				case "/cosmos.evm.vm.v1.ExtensionOptionsEthereumTx":
 					// handle as *evmtypes.MsgEthereumTx
 					anteHandler = newMonoEVMAnteHandler(ctx, options)
-				case "/cosmos.evm.types.v1.ExtensionOptionDynamicFeeTx":
+				case "/cosmos.evm.ante.v1.ExtensionOptionDynamicFeeTx":
 					// cosmos-sdk tx with dynamic fee extension
 					anteHandler = newCosmosAnteHandler(ctx, options)
 				default:


### PR DESCRIPTION
# Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

this change should have been included in https://github.com/cosmos/evm/commit/61eedfcf340e8140b82e9e02478b086b81f63eda

pytest -v -s test_priority.py::[test_native_tx_priority](https://github.com/MANTRA-Chain/mantrachain-e2e/blob/release/v5/integration_tests/test_priority.py#L151) --chain-config evmd

---

## Author Checklist

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.

I have...

- [ ] tackled an existing issue or discussed with a team member
- [ ] left instructions on how to review the changes
- [ ] targeted the `main` branch
