### PR TITLE
fix: avoid panic on close if evm mempool not used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### BUG FIXES
 
 - [\#748](https://github.com/cosmos/evm/pull/748) Fix DynamicFeeChecker in Cosmos ante handler to respect NoBaseFee feemarkets' parameter.
+- [\#772](https://github.com/cosmos/evm/pull/772) Avoid panic on close if evm mempool not used.
 
 ## v0.5.0
 

--- a/evmd/app.go
+++ b/evmd/app.go
@@ -1080,7 +1080,7 @@ func (app *EVMD) SetClientCtx(clientCtx client.Context) { // TODO:VLAD - Remove 
 // Close unsubscribes from the CometBFT event bus (if set) and closes the mempool and underlying BaseApp.
 func (app *EVMD) Close() error {
 	var err error
-	if m, ok := app.GetMempool().(*evmmempool.ExperimentalEVMMempool); ok {
+	if m, ok := app.GetMempool().(*evmmempool.ExperimentalEVMMempool); ok && m != nil {
 		app.Logger().Info("Shutting down mempool")
 		err = m.Close()
 	}


### PR DESCRIPTION
# Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

<!-- Please keep your PR as draft until it's ready for review -->

<!-- Pull requests that sit inactive for longer than 30 days will be closed.  -->

Closes: https://github.com/cosmos/evm/issues/771

---

## Author Checklist

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.

I have...

- [ ] tackled an existing issue or discussed with a team member
- [ ] left instructions on how to review the changes
- [ ] targeted the `main` branch
