### PR TITLE
chore: cleanup x/vm params logic

### DIFF
--- a/x/vm/types/params.go
+++ b/x/vm/types/params.go
@@ -5,7 +5,6 @@ import (
 	"math/big"
 	"slices"
 
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/params"
 
@@ -121,16 +120,6 @@ func (p Params) EIPs() []int {
 	return eips
 }
 
-// GetActiveStaticPrecompilesAddrs is a util function that the Active Precompiles
-// as a slice of addresses.
-func (p Params) GetActiveStaticPrecompilesAddrs() []common.Address {
-	precompiles := make([]common.Address, len(p.ActiveStaticPrecompiles))
-	for i, precompile := range p.ActiveStaticPrecompiles {
-		precompiles[i] = common.HexToAddress(precompile)
-	}
-	return precompiles
-}
-
 // IsEVMChannel returns true if the channel provided is in the list of
 // EVM channels
 func (p Params) IsEVMChannel(channel string) bool {
@@ -151,12 +140,7 @@ func (act AccessControlType) Validate() error {
 	return validateAllowlistAddresses(act.AccessControlList)
 }
 
-func validateAccessType(i interface{}) error {
-	accessType, ok := i.(AccessType)
-	if !ok {
-		return fmt.Errorf("invalid access type type: %T", i)
-	}
-
+func validateAccessType(accessType AccessType) error {
 	switch accessType {
 	case AccessTypePermissionless, AccessTypeRestricted, AccessTypePermissioned:
 		return nil
@@ -165,12 +149,7 @@ func validateAccessType(i interface{}) error {
 	}
 }
 
-func validateAllowlistAddresses(i interface{}) error {
-	addresses, ok := i.([]string)
-	if !ok {
-		return fmt.Errorf("invalid whitelist addresses type: %T", i)
-	}
-
+func validateAllowlistAddresses(addresses []string) error {
 	for _, address := range addresses {
 		if err := utils.ValidateAddress(address); err != nil {
 			return fmt.Errorf("invalid whitelist address: %s", address)
@@ -179,12 +158,7 @@ func validateAllowlistAddresses(i interface{}) error {
 	return nil
 }
 
-func validateEIPs(i interface{}) error {
-	eips, ok := i.([]int64)
-	if !ok {
-		return fmt.Errorf("invalid EIP slice type: %T", i)
-	}
-
+func validateEIPs(eips []int64) error {
 	uniqueEIPs := make(map[int64]struct{})
 
 	for _, eip := range eips {
@@ -203,12 +177,7 @@ func validateEIPs(i interface{}) error {
 }
 
 // ValidatePrecompiles checks if the precompile addresses are valid and unique.
-func ValidatePrecompiles(i interface{}) error {
-	precompiles, ok := i.([]string)
-	if !ok {
-		return fmt.Errorf("invalid precompile slice type: %T", i)
-	}
-
+func ValidatePrecompiles(precompiles []string) error {
 	seenPrecompiles := make(map[string]struct{})
 	for _, precompile := range precompiles {
 		if _, ok := seenPrecompiles[precompile]; ok {

--- a/x/vm/types/params_test.go
+++ b/x/vm/types/params_test.go
@@ -84,7 +84,6 @@ func TestParamsEIPs(t *testing.T) {
 }
 
 func TestParamsValidatePriv(t *testing.T) {
-	require.Error(t, validateEIPs(""))
 	require.NoError(t, validateEIPs([]int64{1884}))
 	require.ErrorContains(t, validateEIPs([]int64{1884, 1884, 1885}), "duplicate EIP: 1884")
 	require.NoError(t, validateChannels([]string{"channel-0"}))

--- a/x/vm/types/permissions.go
+++ b/x/vm/types/permissions.go
@@ -95,7 +95,7 @@ func getCanCreateFn(accessControl *AccessControl, signer common.Address) callerF
 	return func(_ common.Address) bool { return false }
 }
 
-// CanCreate implements the PermissionPolicy interface.
+// CanCall implements the PermissionPolicy interface.
 // It allows calls if access type is set to everybody.
 // Otherwise, it checks if:
 // - The signer is allowed to do so.


### PR DESCRIPTION
We no longer need to do any of this interface testing as we are using concrete types