### PR TITLE
chore: Remove go tool cover in make test-unit-cover

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -169,8 +169,6 @@ test-unit-cover: run-tests
 	@tail -n +2 evmd/coverage_evmd.txt >> coverage.txt && rm evmd/coverage_evmd.txt
 	@echo "🧹 Filtering ignored files from coverage.txt..."
 	@grep -v -E '/cmd/|/client/|/proto/|/testutil/|/mocks/|/test_.*\.go:|\.pb\.go:|\.pb\.gw\.go:|/x/[^/]+/module\.go:|/scripts/|/ibc/testing/|/version/|\.md:|\.pulsar\.go:' coverage.txt > tmp_coverage.txt && mv tmp_coverage.txt coverage.txt
-	@echo "📊 Coverage summary:"
-	@go tool cover -func=coverage.txt
 
 test: test-unit
 


### PR DESCRIPTION
# Description

Remove `go tool cover` from `make test-unit-cover`. 

This is currently failing because of a removed file which is having its coverage data be cached via the depot runners.

We don't really need to print out the coverage data at the end of the command--we have codecov for CI and developers can run this command locally if they want to as well.

We've now setup the codecov app so it should comment on PRs and I've setup a token for CI uploads since the codecov uploads on main were previously failing w/o it (for example, https://github.com/cosmos/evm/actions/runs/18999087463/job/54263172587)

---

## Author Checklist

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.

I have...

- [ ] tackled an existing issue or discussed with a team member
- [ ] left instructions on how to review the changes
- [ ] targeted the `main` branch
