### PR TITLE
docs: add InitEvmCoinInfo code example to migration guide

### DIFF
--- a/docs/migrations/v0.4.0_to_v0.5.0.md
+++ b/docs/migrations/v0.4.0_to_v0.5.0.md
@@ -352,8 +352,16 @@ In your UpgradeHandler:
 
 - **If your chain does not have DenomMetadata set for the EVM Denom, you must include it.**
 - **If your chain's EVM denom is *not* 18 decimals, you must add ExtendedDenomOptions to your `x/vm` params.**
+- **After setting metadata, initialize EVM coin info:**
 
-Please refer to the [upgrade example](https://github.com/cosmos/evm/blob/0995962c2fd77a7a23e93001d5a531abbb1b61e5/evmd/upgrades.go) for more information.
+```go
+// After setting denom metadata
+if err := app.EVMKeeper.InitEvmCoinInfo(ctx); err != nil {
+    return nil, err
+}
+```
+
+Please refer to the [upgrade example](https://github.com/cosmos/evm/blob/main/evmd/upgrades.go) for the complete implementation.
 
 ---
 


### PR DESCRIPTION
# Description

Adds example to v0.4>v0.5 migration guide to align with main docs page. Taken from the example that is referenced for clarity.

---

I have...

- [Y] tackled an existing issue or discussed with a team member
- [N/A] left instructions on how to review the changes
- [Y] targeted the `main` branch
