### PR TITLE
docs(migration): update 0.4.0 to 0.5.0 to properly describe mempool.max-tx flag usage change

### DIFF
--- a/docs/migrations/v0.4.0_to_v0.5.0.md
+++ b/docs/migrations/v0.4.0_to_v0.5.0.md
@@ -207,7 +207,7 @@ These options can also be set via CLI flags:
 
 ##### Cosmos Mempool Max Transactions
 
-A new flag `--mempool.max-txs` allows limiting the maximum number of transactions in the Cosmos mempool. Set to 0 or -1 for unbounded (default: 0).
+The --mempool.max-txs SDK flag is now actually ingested into the Cosmos mempool (`ExtMempool`) config inside `ExperimentalEVMMempool` (this was previously always a zeroed `int` value and could not be overridden). This allows limiting the maximum number of transactions in the Cosmos mempool. Set to -1 (disabled, no-op), 0 (unbounded), or positive integer. The [default value here](https://github.com/cosmos/evm/blob/f6ce772cd8dabfc5804aeb94ee21c63cc3d112fa/server/start.go#L189-L192) is `0`, which differs from the default SDK value of `-1`, since we want the mempool enabled by default.
 
 The function signature for `NewExperimentalEVMMempool` also changed to add a cosmosPoolMaxTx field:
 

--- a/server/start.go
+++ b/server/start.go
@@ -185,7 +185,7 @@ which accepts a path for the resulting pprof file.
 	cmd.Flags().Uint64(server.FlagMinRetainBlocks, 0, "Minimum block height offset during ABCI commit to prune CometBFT blocks")
 	cmd.Flags().String(srvflags.AppDBBackend, "", "The type of database for application and snapshots databases")
 
-	cmd.Flags().Int32(server.FlagMempoolMaxTxs, 0, "The maximum number of transactions in the mempool")
+	cmd.Flags().Int(server.FlagMempoolMaxTxs, 0, "The maximum number of transactions in the mempool")
 	// explicitly override the app.toml default value, as normally config file takes precedence over flag defaults
 	if err := cmd.Flags().Set(server.FlagMempoolMaxTxs, "0"); err != nil {
 		panic(err)


### PR DESCRIPTION
# Description

- Updates 0.4.0 to 0.5.0 migration docs to properly describe new mempool.max-tx flag usage
- Updates `server.go` flag binding to `int32`->`int` to match SDK usage for the same flag

Closes: https://github.com/cosmos/evm/issues/797

@aljo242 and @Eric-Warehime to review wording and accuracy.

---

## Author Checklist
I have...

- [x] tackled an existing issue or discussed with a team member
- [x] left instructions on how to review the changes
- [x] targeted the `main` branch
