### PR TITLE
fix: ledger nano x on linux

### DIFF
--- a/wallets/usbwallet/hub.go
+++ b/wallets/usbwallet/hub.go
@@ -152,7 +152,11 @@ func (hub *Hub) refreshWallets() {
 	for _, info := range infos {
 		for _, id := range hub.productIDs {
 			// Windows and macOS use UsageID matching, Linux uses Interface matching
-			if info.ProductID == id && (info.UsagePage == hub.usageID || info.Interface == hub.endpointID) {
+			// Ledger product IDs use MMII format where MM is device model and II is interface flags.
+			// Match either exact legacy IDs (0x0001, 0x0004, etc.) or device model prefix for
+			// WebUSB/app-specific IDs (e.g., 0x4011 matches 0x4000 prefix for Nano X with Ethereum app).
+			modelMatch := id >= 0x1000 && (info.ProductID>>8 == id>>8)
+			if (info.ProductID == id || modelMatch) && (info.UsagePage == hub.usageID || info.Interface == hub.endpointID) {
 				devices = append(devices, info)
 				break
 			}


### PR DESCRIPTION
# Description

Requesting backport to 0.5.x as well.

Fixes

```
Error: failed to generate ledger key
ERR failure when running app err="failed to generate ledger key"
 ```

closes https://github.com/cosmos/evm/issues/607

Before change (yes my EVM app is open in both cases)
<img width="1879" height="916" alt="image" src="https://github.com/user-attachments/assets/8ab4c511-8e24-41a2-a6c7-7cd5a0269bf3" />

After change

<img width="1876" height="151" alt="image" src="https://github.com/user-attachments/assets/52de261e-b6b3-439a-a210-cba174e30158" />

Tested in another EVM based repo as well to same effect.

---

## Author Checklist

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.

I have...

- [x] tackled an existing issue or discussed with a team member
- [x] left instructions on how to review the changes
- [x] targeted the `main` branch
