### PR TITLE
fix: enable all geth metrics

### DIFF
--- a/metrics/geth.go
+++ b/metrics/geth.go
@@ -14,6 +14,7 @@ import (
 
 // StartGethMetricServer starts the geth metrics server on the specified address.
 func StartGethMetricServer(ctx context.Context, log log.Logger, addr string) error {
+	gethmetrics.Enable()
 	mux := http.NewServeMux()
 	mux.Handle("/metrics", gethprom.Handler(gethmetrics.DefaultRegistry))
 


### PR DESCRIPTION
# Description

previously only some metrics were reporting. but others were being discarded due to a metrics loop not starting. this PR enables the metrics so _ALL_ geth metrics show up on the prom endpoint.

---

## Author Checklist

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.

I have...

- [ ] tackled an existing issue or discussed with a team member
- [ ] left instructions on how to review the changes
- [ ] targeted the `main` branch
