### PR TITLE
fix(mempool): race condition

### DIFF
--- a/mempool/blockchain.go
+++ b/mempool/blockchain.go
@@ -83,7 +83,7 @@ func (b *Blockchain) Config() *params.ChainConfig {
 // including block height, timestamp, gas limits, and base fee (if London fork is active).
 // Returns a zero header as placeholder if the context is not yet available.
 func (b *Blockchain) CurrentBlock() *types.Header {
-	ctx, err := b.GetLatestContext()
+	ctx, err := b.newLatestContext()
 	if err != nil {
 		return b.zeroHeader
 	}


### PR DESCRIPTION
# Description

Fixes a race condition where the caching of the latest block context causes concurrent reads/writes to the kv store gas meter in `blockchain.CurrentBlock` and `recheckTxFactory` called in `demoteUnexecutables.

Stack trace below
```
WARNING: DATA RACE
Read at 0x00c01195f9e8 by goroutine 20845:
  cosmossdk.io/store/types.(*basicGasMeter).ConsumeGas()
      /home/runner/go/pkg/mod/cosmossdk.io/store@v1.3.0-beta.0/types/gas.go:109 +0x44
  cosmossdk.io/store/gaskv.(*GStore[go.shape.[]uint8]).Get()
      /home/runner/go/pkg/mod/cosmossdk.io/store@v1.3.0-beta.0/gaskv/store.go:66 +0x7d
  cosmossdk.io/store/gaskv.(*GStore[[]uint8]).Get()
      /home/runner/go/pkg/mod/cosmossdk.io/store@v1.3.0-beta.0/gaskv/store.go:65 +0x58
  github.com/cosmos/evm/x/feemarket/keeper.Keeper.GetBlockGasWanted()
      /home/runner/work/evm/evm/x/feemarket/keeper/keeper.go:60 +0x141
  github.com/cosmos/evm/x/feemarket/keeper.(*Keeper).GetBlockGasWanted()
      <autogenerated>:1 +0x108
  github.com/cosmos/evm/mempool.(*Blockchain).CurrentBlock()
      /home/runner/work/evm/evm/mempool/blockchain.go:99 +0x3b4
  github.com/cosmos/evm/mempool.(*EVMMempoolIterator).getCurrentBaseFee()
      /home/runner/work/evm/evm/mempool/iterator.go:302 +0xd5
  github.com/cosmos/evm/mempool.(*EVMMempoolIterator).extractCosmosEffectiveTip()
      /home/runner/work/evm/evm/mempool/iterator.go:275 +0x7ca
  github.com/cosmos/evm/mempool.(*EVMMempoolIterator).getNextCosmosTx()
      /home/runner/work/evm/evm/mempool/iterator.go:186 +0x104
  github.com/cosmos/evm/mempool.(*EVMMempoolIterator).Tx()
      /home/runner/work/evm/evm/mempool/iterator.go:106 +0x290
  github.com/cosmos/evm/mempool.(*ExperimentalEVMMempool).SelectBy()
      /home/runner/work/evm/evm/mempool/mempool.go:400 +0x832
  github.com/cosmos/cosmos-sdk/types/mempool.SelectBy()
      /home/runner/go/pkg/mod/github.com/cosmos/cosmos-sdk@v0.54.0-rc.1.0.20251129050143-8448784ada84/types/mempool/mempool.go:58 +0xd5
  github.com/cosmos/evm/evmd.(*EVMD).configureEVMMempool.(*DefaultProposalHandler).PrepareProposalHandler.func3()
      /home/runner/go/pkg/mod/github.com/cosmos/cosmos-sdk@v0.54.0-rc.1.0.20251129050143-8448784ada84/baseapp/abci_utils.go:294 +0x6a4
  github.com/cosmos/cosmos-sdk/baseapp.(*BaseApp).PrepareProposal()
      /home/runner/go/pkg/mod/github.com/cosmos/cosmos-sdk@v0.54.0-rc.1.0.20251129050143-8448784ada84/baseapp/abci.go:473 +0x133c
  github.com/cosmos/evm/testutil/app.(*EvmAppAdapter).PrepareProposal()
      <autogenerated>:1 +0x54
  github.com/cosmos/evm/testutil/app.(*EvmAppAdapter).PrepareProposal()
      <autogenerated>:1 +0x54
  github.com/cosmos/evm/tests/integration/mempool.(*IntegrationTestSuite).TestTransactionOrderingWithABCIMethodCalls.func8()
      /home/runner/work/evm/evm/tests/integration/mempool/test_mempool_integration_abci.go:185 +0x2b4
  github.com/cosmos/evm/testutil/app.(*EvmAppAdapter).FinalizeBlock()
      <autogenerated>:1 +0x51
  github.com/cosmos/evm/testutil/integration/evm/network.(*IntegrationNetwork).FinalizeBlock()
      /home/runner/work/evm/evm/testutil/integration/evm/network/abci.go:49 +0x7a5
  github.com/cosmos/evm/tests/integration/mempool.(*IntegrationTestSuite).TestTransactionOrderingWithABCIMethodCalls.func8()
      /home/runner/work/evm/evm/tests/integration/mempool/test_mempool_integration_abci.go:181 +0x190
  github.com/cosmos/evm/testutil/app.(*EvmAppAdapter).CheckTx()
      <autogenerated>:1 +0x51
  github.com/cosmos/evm/testutil/app.(*EvmAppAdapter).CheckTx()
      <autogenerated>:1 +0x51
  github.com/cosmos/evm/tests/integration/mempool.(*IntegrationTestSuite).checkTx()
      /home/runner/work/evm/evm/tests/integration/mempool/test_helpers.go:133 +0x297
  github.com/cosmos/evm/tests/integration/mempool.(*IntegrationTestSuite).checkTxs()
      /home/runner/work/evm/evm/tests/integration/mempool/test_helpers.go:113 +0x118
  github.com/cosmos/evm/tests/integration/mempool.(*IntegrationTestSuite).checkTxs()
      /home/runner/work/evm/evm/tests/integration/mempool/test_helpers.go:113 +0x118
  github.com/cosmos/evm/tests/integration/mempool.(*IntegrationTestSuite).TestTransactionOrderingWithABCIMethodCalls.func8()
      /home/runner/work/evm/evm/tests/integration/mempool/test_mempool_integration_abci.go:177 +0x126
  github.com/cosmos/evm/tests/integration/mempool.(*IntegrationTestSuite).TestTransactionOrderingWithABCIMethodCalls.func8()
      /home/runner/work/evm/evm/tests/integration/mempool/test_mempool_integration_abci.go:174 +0xf8
  github.com/cosmos/evm/mempool.(*Blockchain).NotifyNewBlock()
      /home/runner/work/evm/evm/mempool/blockchain.go:182 +0x311
  github.com/cosmos/evm/tests/integration/mempool.(*IntegrationTestSuite).SetupTestWithChainID()
      /home/runner/work/evm/evm/tests/integration/mempool/test_setup.go:104 +0xaa4
  github.com/cosmos/evm/evmd.(*EVMD).FinalizeBlock()
      /home/runner/work/evm/evm/evmd/app.go:856 +0x44
  github.com/cosmos/evm/testutil/app.(*EvmAppAdapter).FinalizeBlock()
      <autogenerated>:1 +0x51
  github.com/cosmos/evm/testutil/integration/evm/network.(*IntegrationNetwork).finalizeBlockAndCommit()
      /home/runner/work/evm/evm/testutil/integration/evm/network/abci.go:71 +0x8b0
  github.com/cosmos/evm/testutil/integration/evm/network.(*IntegrationNetwork).NextBlockAfter()
      /home/runner/work/evm/evm/testutil/integration/evm/network/abci.go:24 +0x8f1
  github.com/cosmos/evm/testutil/integration/evm/network.(*IntegrationNetwork).NextBlock()
      /home/runner/work/evm/evm/testutil/integration/evm/network/abci.go:18 +0x887
  github.com/cosmos/evm/tests/integration/mempool.(*IntegrationTestSuite).SetupTestWithChainID()
      /home/runner/work/evm/evm/tests/integration/mempool/test_setup.go:91 +0x838
  github.com/cosmos/evm/evmd.(*EVMD).FinalizeBlock()
      /home/runner/work/evm/evm/evmd/app.go:856 +0x44
  github.com/cosmos/evm/testutil/app.(*EvmAppAdapter).FinalizeBlock()
      <autogenerated>:1 +0x51
  github.com/cosmos/evm/testutil/integration/evm/network.(*IntegrationNetwork).finalizeBlockAndCommit()
      /home/runner/work/evm/evm/testutil/integration/evm/network/abci.go:71 +0x8b0
  github.com/cosmos/evm/testutil/integration/evm/network.(*IntegrationNetwork).NextBlockAfter()
      /home/runner/work/evm/evm/testutil/integration/evm/network/abci.go:24 +0x804
  github.com/cosmos/evm/testutil/integration/evm/network.(*IntegrationNetwork).NextBlock()
      /home/runner/work/evm/evm/testutil/integration/evm/network/abci.go:18 +0x797
  github.com/cosmos/evm/tests/integration/mempool.(*IntegrationTestSuite).SetupTestWithChainID()
      /home/runner/work/evm/evm/tests/integration/mempool/test_setup.go:89 +0x748
  github.com/cosmos/evm/testutil/integration/evm/network.New()
      /home/runner/work/evm/evm/testutil/integration/evm/network/network.go:96 +0x7e6
  github.com/cosmos/evm/testutil/integration/evm/network.NewUnitTestNetwork()
      /home/runner/work/evm/evm/testutil/integration/evm/network/unit_network.go:28 +0x3f9
  github.com/cosmos/evm/tests/integration/mempool.(*IntegrationTestSuite).SetupTestWithChainID()
      /home/runner/work/evm/evm/tests/integration/mempool/test_setup.go:83 +0x365
  github.com/cosmos/evm/tests/integration/mempool.(*IntegrationTestSuite).SetupTest()
      /home/runner/work/evm/evm/tests/integration/mempool/test_setup.go:43 +0xeb
  github.com/cosmos/evm/tests/integration/mempool.(*IntegrationTestSuite).TestTransactionOrderingWithABCIMethodCalls.func8()
      /home/runner/work/evm/evm/tests/integration/mempool/test_mempool_integration_abci.go:172 +0x65
  github.com/stretchr/testify/suite.(*Suite).Run.func1()
      /home/runner/go/pkg/mod/github.com/stretchr/testify@v1.11.1/suite/suite.go:115 +0x288
  testing.tRunner()
      /opt/hostedtoolcache/go/1.25.5/x64/src/testing/testing.go:1934 +0x21c
  testing.(*T).Run.gowrap1()
      /opt/hostedtoolcache/go/1.25.5/x64/src/testing/testing.go:1997 +0x44

Previous write at 0x00c01195f9e8 by goroutine 21179:
  cosmossdk.io/store/types.(*basicGasMeter).ConsumeGas()
      /home/runner/go/pkg/mod/cosmossdk.io/store@v1.3.0-beta.0/types/gas.go:109 +0x70
  cosmossdk.io/store/gaskv.(*GStore[go.shape.[]uint8]).Get()
      /home/runner/go/pkg/mod/cosmossdk.io/store@v1.3.0-beta.0/gaskv/store.go:70 +0x117
  cosmossdk.io/store/gaskv.(*GStore[[]uint8]).Get()
      /home/runner/go/pkg/mod/cosmossdk.io/store@v1.3.0-beta.0/gaskv/store.go:65 +0x58
  github.com/cosmos/evm/x/feemarket/keeper.Keeper.GetParams()
      /home/runner/work/evm/evm/x/feemarket/keeper/params.go:14 +0x15e
  github.com/cosmos/evm/x/feemarket/keeper.(*Keeper).GetParams()
      <autogenerated>:1 +0x124
  github.com/cosmos/evm/ante.newMonoEVMAnteHandler()
      /home/runner/work/evm/evm/ante/evm.go:12 +0x1d4
  github.com/cosmos/evm/ante.newMonoEVMAnteHandler()
      /home/runner/work/evm/evm/ante/evm.go:11 +0xd4
  github.com/cosmos/evm/evmd.(*EVMD).setAnteHandler.NewAnteHandler.func1()
      /home/runner/work/evm/evm/ante/ante.go:87 +0x4b7
  github.com/cosmos/evm/mempool.NewExperimentalEVMMempool.recheckTxFactory.func3.1()
      /home/runner/work/evm/evm/mempool/mempool.go:528 +0x3e9
  github.com/cosmos/evm/mempool/txpool/legacypool.(*LegacyPool).demoteUnexecutables.func1()
      /home/runner/work/evm/evm/mempool/txpool/legacypool/legacypool.go:1652 +0x45
  github.com/cosmos/evm/mempool/txpool/legacypool.(*SortedMap).filter()
      /home/runner/work/evm/evm/mempool/txpool/legacypool/list.go:142 +0x1b7
  github.com/cosmos/evm/mempool/txpool/legacypool.(*SortedMap).Filter()
      /home/runner/work/evm/evm/mempool/txpool/legacypool/list.go:116 +0x87
  github.com/cosmos/evm/mempool/txpool/legacypool.(*list).Filter()
      /home/runner/work/evm/evm/mempool/txpool/legacypool/list.go:381 +0xb7
  github.com/cosmos/evm/mempool/txpool/legacypool.(*LegacyPool).demoteUnexecutables()
      /home/runner/work/evm/evm/mempool/txpool/legacypool/legacypool.go:1651 +0x4a9
  github.com/cosmos/evm/x/vm/keeper.(*Keeper).GetAccount()
      /home/runner/work/evm/evm/x/vm/keeper/statedb.go:28 +0x144
  github.com/cosmos/evm/x/vm/statedb.(*StateDB).getStateObject()
      /home/runner/work/evm/evm/x/vm/statedb/statedb.go:374 +0x1d8
  github.com/cosmos/evm/x/vm/statedb.(*StateDB).GetNonce()
      /home/runner/work/evm/evm/x/vm/statedb/statedb.go:274 +0x95
  github.com/cosmos/evm/mempool/txpool/legacypool.(*LegacyPool).demoteUnexecutables()
      /home/runner/work/evm/evm/mempool/txpool/legacypool/legacypool.go:1618 +0x24a
  github.com/cosmos/evm/mempool/txpool/legacypool.(*LegacyPool).runReorg()
      /home/runner/work/evm/evm/mempool/txpool/legacypool/legacypool.go:1326 +0x889
  github.com/cosmos/evm/mempool/txpool/legacypool.(*LegacyPool).scheduleReorgLoop.gowrap2()
      /home/runner/work/evm/evm/mempool/txpool/legacypool/legacypool.go:1229 +0x6b

Goroutine 20845 (running) created at:
  testing.(*T).Run()
      /opt/hostedtoolcache/go/1.25.5/x64/src/testing/testing.go:1997 +0x9d2
  github.com/stretchr/testify/suite.(*Suite).Run()
      /home/runner/go/pkg/mod/github.com/stretchr/testify@v1.11.1/suite/suite.go:101 +0x12b
  github.com/cosmos/evm/tests/integration/mempool.(*IntegrationTestSuite).TestTransactionOrderingWithABCIMethodCalls()
      /home/runner/work/evm/evm/tests/integration/mempool/test_mempool_integration_abci.go:168 +0x578
  runtime.call16()
      /opt/hostedtoolcache/go/1.25.5/x64/src/runtime/asm_amd64.s:774 +0x42
  reflect.Value.Call()
      /opt/hostedtoolcache/go/1.25.5/x64/src/reflect/value.go:365 +0xb5
  github.com/stretchr/testify/suite.Run.func1()
      /home/runner/go/pkg/mod/github.com/stretchr/testify@v1.11.1/suite/suite.go:196 +0x68d
  github.com/cosmos/evm/tests/integration/mempool.(*IntegrationTestSuite).SetupTestWithChainID()
      /home/runner/work/evm/evm/tests/integration/mempool/test_setup.go:104 +0xaa4
  github.com/cosmos/evm/evmd.(*EVMD).FinalizeBlock()
      /home/runner/work/evm/evm/evmd/app.go:856 +0x44
  github.com/cosmos/evm/testutil/app.(*EvmAppAdapter).FinalizeBlock()
      <autogenerated>:1 +0x51
  github.com/cosmos/evm/testutil/integration/evm/network.(*IntegrationNetwork).finalizeBlockAndCommit()
      /home/runner/work/evm/evm/testutil/integration/evm/network/abci.go:71 +0x8b0
  github.com/cosmos/evm/testutil/integration/evm/network.(*IntegrationNetwork).NextBlockAfter()
      /home/runner/work/evm/evm/testutil/integration/evm/network/abci.go:24 +0x8f1
  github.com/cosmos/evm/testutil/integration/evm/network.(*IntegrationNetwork).NextBlock()
      /home/runner/work/evm/evm/testutil/integration/evm/network/abci.go:18 +0x887
  github.com/cosmos/evm/tests/integration/mempool.(*IntegrationTestSuite).SetupTestWithChainID()
      /home/runner/work/evm/evm/tests/integration/mempool/test_setup.go:91 +0x838
  github.com/cosmos/evm/evmd.(*EVMD).FinalizeBlock()
      /home/runner/work/evm/evm/evmd/app.go:856 +0x44
  github.com/cosmos/evm/testutil/app.(*EvmAppAdapter).FinalizeBlock()
      <autogenerated>:1 +0x51
  github.com/cosmos/evm/testutil/integration/evm/network.(*IntegrationNetwork).finalizeBlockAndCommit()
      /home/runner/work/evm/evm/testutil/integration/evm/network/abci.go:71 +0x8b0
  github.com/cosmos/evm/testutil/integration/evm/network.(*IntegrationNetwork).NextBlockAfter()
      /home/runner/work/evm/evm/testutil/integration/evm/network/abci.go:24 +0x804
  github.com/cosmos/evm/testutil/integration/evm/network.(*IntegrationNetwork).NextBlock()
      /home/runner/work/evm/evm/testutil/integration/evm/network/abci.go:18 +0x797
  github.com/cosmos/evm/tests/integration/mempool.(*IntegrationTestSuite).SetupTestWithChainID()
      /home/runner/work/evm/evm/tests/integration/mempool/test_setup.go:89 +0x748
  github.com/cosmos/evm/testutil/integration/evm/network.New()
      /home/runner/work/evm/evm/testutil/integration/evm/network/network.go:96 +0x7e6
  github.com/cosmos/evm/testutil/integration/evm/network.NewUnitTestNetwork()
      /home/runner/work/evm/evm/testutil/integration/evm/network/unit_network.go:28 +0x3f9
  github.com/cosmos/evm/tests/integration/mempool.(*IntegrationTestSuite).SetupTestWithChainID()
      /home/runner/work/evm/evm/tests/integration/mempool/test_setup.go:83 +0x365
  github.com/cosmos/evm/tests/integration/mempool.(*IntegrationTestSuite).SetupTest()
      /home/runner/work/evm/evm/tests/integration/mempool/test_setup.go:43 +0xa8
  github.com/stretchr/testify/suite.Run.func1()
      /home/runner/go/pkg/mod/github.com/stretchr/testify@v1.11.1/suite/suite.go:188 +0x2d7
  testing.tRunner()
      /opt/hostedtoolcache/go/1.25.5/x64/src/testing/testing.go:1934 +0x21c
  testing.(*T).Run.gowrap1()
      /opt/hostedtoolcache/go/1.25.5/x64/src/testing/testing.go:1997 +0x44

Goroutine 21179 (finished) created at:
  github.com/cosmos/evm/mempool/txpool/legacypool.(*LegacyPool).scheduleReorgLoop()
      /home/runner/work/evm/evm/mempool/txpool/legacypool/legacypool.go:1229 +0x3b2
  github.com/cosmos/evm/mempool/txpool/legacypool.(*LegacyPool).Init.gowrap1()
      /home/runner/work/evm/evm/mempool/txpool/legacypool/legacypool.go:344 +0x33
```