### PR TITLE
chore: Fix non ready

### DIFF
--- a/mempool/txpool/legacypool/legacypool.go
+++ b/mempool/txpool/legacypool/legacypool.go
@@ -1560,8 +1560,9 @@ func (pool *LegacyPool) promoteExecutables(accounts []common.Address, reset *txp
 		queuedRecheckDurationTimer.UpdateSince(recheckStart)
 
 		// Gather all executable transactions and promote them
+		listLen := list.Len()
 		readies := list.Ready(pool.pendingNonces.get(addr))
-		queuedNonReadies.Mark(int64(list.Len() - len(readies)))
+		queuedNonReadies.Mark(int64(listLen - len(readies)))
 		for _, tx := range readies {
 			hash := tx.Hash()
 			if pool.promoteTx(addr, hash, tx) {


### PR DESCRIPTION
# Description

The `list.Ready` call removes transactions from the list which are returned which means that we need to calculate the total length of the list before calling `Ready` otherwise we get massive negative numbers for our `queuedNonReadies` metric.