### PR TITLE
fix: code scanning alert no. 703: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/trigger-docs-update.yml
+++ b/.github/workflows/trigger-docs-update.yml
@@ -1,5 +1,7 @@
 # .github/workflows/trigger-docs-update.yml
 name: Trigger Docs Changelog Update
+permissions:
+  contents: read
 
 on:
   release:


### PR DESCRIPTION
Potential fix for [https://github.com/cosmos/evm/security/code-scanning/703](https://github.com/cosmos/evm/security/code-scanning/703)

In general, the fix is to explicitly define a minimal `permissions:` block for the workflow or for the specific job so that `GITHUB_TOKEN` has only the privileges required. This workflow only needs to read basic repository metadata (e.g., release information already provided via `github.event`) and call `repository-dispatch` using a separate token, so it can safely restrict `GITHUB_TOKEN` to `contents: read` (or even `read-all` if desired, but `contents: read` is narrower and sufficient).

The best, non‑breaking fix is to add a `permissions:` block at the workflow root level (top-level, alongside `name:` and `on:`), setting `contents: read`. This will apply to all jobs in this workflow, including `trigger-docs-update`, and will not interfere with the use of `secrets.DOCS_REPO_TOKEN`, since that secret is independent of `GITHUB_TOKEN`. Concretely, in `.github/workflows/trigger-docs-update.yml`, add a `permissions:` section after the `name:` line (line 2) and before `on:` (line 4), e.g.:

```yaml
name: Trigger Docs Changelog Update
permissions:
  contents: read

on:
  release:
    types: [published]
```

No additional imports, methods, or definitions are needed, as this is purely a GitHub Actions YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
