### PR TITLE
fix: code scanning alert no. 702: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr_title.yml
+++ b/.github/workflows/pr_title.yml
@@ -6,6 +6,9 @@ on:
 
 jobs:
   validate-pr-title:
+    permissions:
+      contents: read
+      pull-requests: read
     runs-on: ubuntu-latest
     steps:
       - name: PR Conventional Commit Validation


### PR DESCRIPTION
Potential fix for [https://github.com/cosmos/evm/security/code-scanning/702](https://github.com/cosmos/evm/security/code-scanning/702)

In general, this problem is fixed by explicitly specifying a minimal `permissions` block for the workflow or for each job, so that the automatically provided `GITHUB_TOKEN` does not inherit broader repository/organization defaults. For a simple validation workflow that only needs to inspect pull requests and code, read-only permissions are usually enough.

For this specific workflow in `.github/workflows/pr_title.yml`, the safest minimal change that preserves existing behavior is to add a `permissions` block at the job level under `validate-pr-title`. Since the action validates the PR title and `add_label` is set to `'false'`, it does not need to write to pull requests. To allow it to read PR metadata and repository contents if needed, we can grant `contents: read` and `pull-requests: read`. We add this block between `validate-pr-title:` and `runs-on: ubuntu-latest`. No imports or additional methods are required, as this is purely a YAML configuration change within the workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
