### PR TITLE
chore: fix for Missing error check

### DIFF
--- a/tests/integration/x/vm/test_state_transition.go
+++ b/tests/integration/x/vm/test_state_transition.go
@@ -1185,6 +1185,7 @@ func (s *KeeperTestSuite) TestApplyMessageWithConfig() {
 
 			err = s.Network.NextBlock()
 			if tc.expVMErr {
+				s.Require().NoError(err)
 				s.Require().NotEmpty(res.VmError)
 				return
 			}


### PR DESCRIPTION
To fix the problem, we must not dereference `res` in any path where it might be nil. Concretely, after the call to `ApplyMessageWithConfig`, we should handle the `err` result in all code paths before using `res`, or at least ensure `res` is non-nil in the path where it is used. The minimal change that preserves existing behavior is to add an error assertion for the `tc.expVMErr` case, similar to the existing assertions in the other branches, before accessing `res.VmError`.

The single best fix is: right after `err = s.Network.NextBlock()` and before `if tc.expVMErr { ... }`, assert that `err` is nil unconditionally; then in the `tc.expVMErr` branch, we can safely assume that `ApplyMessageWithConfig` completed without a Go-level error and returned a valid `res` struct with a VM-level error string. However, because there is already a `s.Require().NoError(err)` after the `if tc.expVMErr` block, the most targeted and non-disruptive fix is instead to assert `s.Require().NoError(err)` immediately after the `ApplyMessageWithConfig` call when `tc.expVMErr` is true, or more simply, add `s.Require().NoError(err)` just before using `res` in the `tc.expVMErr` block. That way all three logical scenarios (`expErr`, `!expVMErr`, `expVMErr`) now check `err` before any use of `res`. Specifically, in `tests/integration/x/vm/test_state_transition.go`, within `TestApplyMessageWithConfig`, in the section around lines 1186–1192, we will insert an `s.Require().NoError(err)` at the start of the `if tc.expVMErr { ... }` block, ensuring `res` cannot be nil due to an unhandled error.

No new imports or helper methods are needed; we simply add one additional assertion line using the existing `s.Require()` helper.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._