### PR TITLE
chore: fix for Missing error check

### DIFF
--- a/tests/integration/x/ibc/test_msg_server.go
+++ b/tests/integration/x/ibc/test_msg_server.go
@@ -322,8 +322,8 @@ func (suite *KeeperTestSuite) TestTransfer() {
 				coin := sdk.NewCoin(denom, math.NewInt(10))
 
 				pair, err := suite.network.App.GetErc20Keeper().RegisterERC20Extension(suite.network.GetContext(), coinMetadata.Base)
-				suite.Require().Equal(pair.Denom, denom)
 				suite.Require().NoError(err)
+				suite.Require().Equal(pair.Denom, denom)
 
 				transferMsg := types.NewMsgTransfer(types.PortID, chan0, coin, senderAcc.String(), receiver.String(), timeoutHeight, 0, "")
 


### PR DESCRIPTION
In general, when a function returns `(ptr *T, err error)`, always check `err` before dereferencing `ptr`. If `err` is non-nil, the function may have returned `ptr == nil`, so dereferencing it can cause a panic.

For this specific code, the best minimal fix is to swap the order of the two `suite.Require` calls after `RegisterERC20Extension` so that `err` is checked before accessing `pair.Denom`. Currently, line 325 dereferences `pair` first, and line 326 checks the error. We should first assert `suite.Require().NoError(err)` and only then assert on `pair.Denom`. No imports or additional methods are needed; this is just a reordering of two existing test assertions in `tests/integration/x/ibc/test_msg_server.go`.

Concretely:
- In `TestTransfer`, inside the `"no-op - fail transfer"` test case, modify lines 325–326 so that line 326 (`NoError(err)`) appears before the equality assertion using `pair.Denom`.
- The semantics remain unchanged, but we avoid the potential nil dereference.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._