### PR TITLE
fix(cmd): provide home path for temp app in NewRootCmd

### DIFF
--- a/evmd/cmd/evmd/cmd/root.go
+++ b/evmd/cmd/evmd/cmd/root.go
@@ -62,7 +62,7 @@ func NewRootCmd() *cobra.Command {
 		dbm.NewMemDB(),
 		nil,
 		true,
-		simtestutil.EmptyAppOptions{},
+		simtestutil.NewAppOptionsWithFlagHome(config.MustGetDefaultNodeHome()),
 	)
 
 	encodingConfig := sdktestutil.TestEncodingConfig{


### PR DESCRIPTION
## Summary
- Fix temp app in `NewRootCmd` using `EmptyAppOptions{}` which causes the upgrade keeper to create a 'data' directory in cwd instead of the app's home directory
- Replace with `NewAppOptionsWithFlagHome()` to match the pattern used in cosmos-sdk simapp

## Problem
The temp app created for encoding config was using `EmptyAppOptions{}`, which causes failures when:
- There's already a file named 'data' in the current working directory
- The upgrade keeper tries to `mkdir data` and fails with "not a directory"

## Solution
Use `simtestutil.NewAppOptionsWithFlagHome(config.MustGetDefaultNodeHome())` instead of `simtestutil.EmptyAppOptions{}`.

## Confirmation
Traced the panic `could not create directory "data": mkdir data: not a directory` back to the upgrade keeper initialization. The empty app options caused `GetHomePath()` to return an empty string, resulting in relative path resolution against cwd. After applying this fix, the command runs without attempting to create directories in cwd.