### PR TITLE
ci: add workflow_dispatch to build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,7 @@
 name: Build
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main


### PR DESCRIPTION
## Summary
- Add `workflow_dispatch` trigger to the Build workflow, allowing it to be triggered manually from the GitHub Actions UI.

## Test plan
- [x] Verify the workflow YAML is valid
- [ ] Confirm the workflow can be triggered manually from the Actions tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)