### PR TITLE
fix(mempool): Add `RemoveWithReason` to `RecheckPool`

### DIFF
--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -35,7 +35,7 @@ import (
 var (
 	meter = otel.Meter("github.com/cosmos/evm/mempool")
 
-	_ sdkmempool.ExtMempool = &ExperimentalEVMMempool{}
+	_ sdkmempool.ExtMempool = (*ExperimentalEVMMempool)(nil)
 )
 
 const (

--- a/mempool/recheck_pool.go
+++ b/mempool/recheck_pool.go
@@ -128,7 +128,7 @@ func (m *RecheckMempool) Insert(goCtx context.Context, tx sdk.Tx) error {
 		return err
 	}
 	if err := m.reserver.Hold(addrs...); err != nil {
-		return err
+		return fmt.Errorf("reserving %d addresses for cosmos recheck pool: %w", len(addrs), err)
 	}
 
 	m.mu.Lock()
@@ -152,6 +152,19 @@ func (m *RecheckMempool) Remove(tx sdk.Tx) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
+	return m.removeLocked(tx)
+}
+
+// RemoveWithReason removes a transaction from the pool. This must be
+// explicitly defined to prevent Go from promoting the embedded ExtMempool's
+// RemoveWithReason, which would bypass the reserver release logic.
+func (m *RecheckMempool) RemoveWithReason(_ context.Context, tx sdk.Tx, _ sdkmempool.RemoveReason) error {
+	return m.Remove(tx)
+}
+
+// removeLocked removes a tx from the underlying pool and releases the
+// reserver. Caller must hold m.mu.
+func (m *RecheckMempool) removeLocked(tx sdk.Tx) error {
 	if err := m.ExtMempool.Remove(tx); err != nil {
 		return err
 	}


### PR DESCRIPTION
# Description

We are calling `RemoveWithReason` on the `RecheckPool` after txs are included in a block. Previously the `RecheckPool` did not implement this, so releasing the `Reserver` addresses were bypassed. This would block the same address from sending evm txs after cosmos txs were removed from the mempool.

Closes: STACK-2376

---

## Author Checklist

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.

I have...

- [ ] tackled an existing issue or discussed with a team member
- [ ] left instructions on how to review the changes
- [ ] targeted the `main` branch
