### PR TITLE
fix(rpc): return error from NewBackend instead of panicking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 
 ### BUG FIXES
 
+- [\#1036](https://github.com/cosmos/evm/issues/1036) Replace `panic` with error return in `NewBackend` for config and client type failures.
  [\#965](https://github.com/cosmos/evm/pull/965) Fix gas double charging on EVM calls in IBCOnTimeoutPacketCallback.
 - [\#869](https://github.com/cosmos/evm/pull/869) Fix erc20 IBC callbacks to check for native token transfer before parsing recipient.
 - [\#860](https://github.com/cosmos/evm/pull/860) Fix EIP-712 signature verification to use configured EVM chain ID instead of parsing cosmos chain ID string and replace legacytx.StdSignBytes with the aminojson sign mode handler.

--- a/rpc/apis.go
+++ b/rpc/apis.go
@@ -63,7 +63,11 @@ func init() {
 			indexer servertypes.EVMTxIndexer,
 			mempool *evmmempool.ExperimentalEVMMempool,
 		) []rpc.API {
-			evmBackend := backend.NewBackend(ctx, ctx.Logger, clientCtx, allowUnprotectedTxs, indexer, mempool)
+			evmBackend, err := backend.NewBackend(ctx, ctx.Logger, clientCtx, allowUnprotectedTxs, indexer, mempool)
+			if err != nil {
+				ctx.Logger.Error("failed to create backend", "error", err)
+				return nil
+			}
 			return []rpc.API{
 				{
 					Namespace: EthNamespace,
@@ -106,7 +110,11 @@ func init() {
 			indexer servertypes.EVMTxIndexer,
 			mempool *evmmempool.ExperimentalEVMMempool,
 		) []rpc.API {
-			evmBackend := backend.NewBackend(ctx, ctx.Logger, clientCtx, allowUnprotectedTxs, indexer, mempool)
+			evmBackend, err := backend.NewBackend(ctx, ctx.Logger, clientCtx, allowUnprotectedTxs, indexer, mempool)
+			if err != nil {
+				ctx.Logger.Error("failed to create backend", "error", err)
+				return nil
+			}
 			return []rpc.API{
 				{
 					Namespace: PersonalNamespace,
@@ -123,7 +131,11 @@ func init() {
 			indexer servertypes.EVMTxIndexer,
 			mempool *evmmempool.ExperimentalEVMMempool,
 		) []rpc.API {
-			evmBackend := backend.NewBackend(ctx, ctx.Logger, clientCtx, allowUnprotectedTxs, indexer, mempool)
+			evmBackend, err := backend.NewBackend(ctx, ctx.Logger, clientCtx, allowUnprotectedTxs, indexer, mempool)
+			if err != nil {
+				ctx.Logger.Error("failed to create backend", "error", err)
+				return nil
+			}
 			return []rpc.API{
 				{
 					Namespace: TxPoolNamespace,
@@ -140,7 +152,11 @@ func init() {
 			indexer servertypes.EVMTxIndexer,
 			mempool *evmmempool.ExperimentalEVMMempool,
 		) []rpc.API {
-			evmBackend := backend.NewBackend(ctx, ctx.Logger, clientCtx, allowUnprotectedTxs, indexer, mempool)
+			evmBackend, err := backend.NewBackend(ctx, ctx.Logger, clientCtx, allowUnprotectedTxs, indexer, mempool)
+			if err != nil {
+				ctx.Logger.Error("failed to create backend", "error", err)
+				return nil
+			}
 			return []rpc.API{
 				{
 					Namespace: DebugNamespace,
@@ -157,7 +173,11 @@ func init() {
 			indexer servertypes.EVMTxIndexer,
 			mempool *evmmempool.ExperimentalEVMMempool,
 		) []rpc.API {
-			evmBackend := backend.NewBackend(ctx, ctx.Logger, clientCtx, allowUnprotectedTxs, indexer, mempool)
+			evmBackend, err := backend.NewBackend(ctx, ctx.Logger, clientCtx, allowUnprotectedTxs, indexer, mempool)
+			if err != nil {
+				ctx.Logger.Error("failed to create backend", "error", err)
+				return nil
+			}
 			return []rpc.API{
 				{
 					Namespace: MinerNamespace,

--- a/rpc/backend/backend.go
+++ b/rpc/backend/backend.go
@@ -193,15 +193,15 @@ func NewBackend(
 	allowUnprotectedTxs bool,
 	indexer servertypes.EVMTxIndexer,
 	mempool *evmmempool.ExperimentalEVMMempool,
-) *Backend {
+) (*Backend, error) {
 	appConf, err := config.GetConfig(ctx.Viper)
 	if err != nil {
-		panic(err)
+		return nil, fmt.Errorf("failed to get EVM config: %w", err)
 	}
 
 	rpcClient, ok := clientCtx.Client.(tmrpcclient.SignClient)
 	if !ok {
-		panic(fmt.Sprintf("invalid rpc client, expected: tmrpcclient.SignClient, got: %T", clientCtx.Client))
+		return nil, fmt.Errorf("invalid rpc client, expected tmrpcclient.SignClient, got: %T", clientCtx.Client)
 	}
 
 	b := &Backend{
@@ -216,5 +216,5 @@ func NewBackend(
 		Mempool:             mempool,
 	}
 	b.ProcessBlocker = b.ProcessBlock
-	return b
+	return b, nil
 }


### PR DESCRIPTION
# Description

Closes: #1036

## Summary

`NewBackend()` calls `panic()` when `config.GetConfig()` fails or when the RPC client doesn't implement `SignClient`. These are recoverable configuration errors that should not crash the entire node process.

## Fix

- Changed `NewBackend` return type from `*Backend` to `(*Backend, error)`
- Replaced both `panic()` calls with `return nil, fmt.Errorf(...)`
- Updated all 5 callers in `rpc/apis.go` to handle the new error return

## Author Checklist

- [x] tackled an existing issue or discussed with a team member
- [x] left instructions on how to review the changes
- [x] targeted the `main` branch