### PR TITLE
fix(rpc): guard nil height deref in CometBlockResultByNumber

### DIFF
--- a/rpc/backend/comet.go
+++ b/rpc/backend/comet.go
@@ -68,7 +68,7 @@ func (b *Backend) CometBlockResultByNumber(ctx context.Context, height *int64) (
 	}
 	res, err := b.RPCClient.BlockResults(ctx, height)
 	if err != nil {
-		return nil, fmt.Errorf("failed to fetch block result from CometBFT %d: %w", *height, err)
+		return nil, fmt.Errorf("failed to fetch block result from CometBFT %d: %w", heightAttr, err)
 	}
 
 	return res, nil

--- a/rpc/backend/comet_test.go
+++ b/rpc/backend/comet_test.go
@@ -15,11 +15,10 @@ import (
 
 func TestCometBlockResultByNumber_NilHeightErrorPath(t *testing.T) {
 	testCases := []struct {
-		name        string
-		height      *int64
-		rpcErr      error
-		expectPanic bool
-		expectErr   bool
+		name      string
+		height    *int64
+		rpcErr    error
+		expectErr bool
 	}{
 		{
 			name:      "nil height, BlockResults succeeds",

--- a/rpc/backend/comet_test.go
+++ b/rpc/backend/comet_test.go
@@ -1,0 +1,80 @@
+package backend
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	tmrpctypes "github.com/cometbft/cometbft/rpc/core/types"
+
+	"github.com/cosmos/evm/rpc/backend/mocks"
+)
+
+func TestCometBlockResultByNumber_NilHeightErrorPath(t *testing.T) {
+	testCases := []struct {
+		name        string
+		height      *int64
+		rpcErr      error
+		expectPanic bool
+		expectErr   bool
+	}{
+		{
+			name:      "nil height, BlockResults succeeds",
+			height:    nil,
+			rpcErr:    nil,
+			expectErr: false,
+		},
+		{
+			name:      "non-zero height, BlockResults succeeds",
+			height:    func() *int64 { h := int64(5); return &h }(),
+			rpcErr:    nil,
+			expectErr: false,
+		},
+		{
+			name:      "zero height remapped to nil, BlockResults errors - must not panic",
+			height:    func() *int64 { h := int64(0); return &h }(),
+			rpcErr:    errors.New("connection timeout"),
+			expectErr: true,
+		},
+		{
+			name:      "nil height, BlockResults errors",
+			height:    nil,
+			rpcErr:    errors.New("pruned state"),
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			backend := setupMockBackend(t)
+			mockClient := backend.ClientCtx.Client.(*mocks.Client)
+
+			// The function remaps height=0 to nil before calling BlockResults,
+			// so always mock with nil when input is 0.
+			var mockHeight *int64
+			if tc.height != nil && *tc.height != 0 {
+				mockHeight = tc.height
+			}
+
+			if tc.rpcErr != nil {
+				mockClient.On("BlockResults", mock.Anything, mockHeight).
+					Return((*tmrpctypes.ResultBlockResults)(nil), tc.rpcErr).Once()
+			} else {
+				mockClient.On("BlockResults", mock.Anything, mockHeight).
+					Return(&tmrpctypes.ResultBlockResults{Height: 1}, nil).Once()
+			}
+
+			require.NotPanics(t, func() {
+				_, err := backend.CometBlockResultByNumber(context.Background(), tc.height)
+				if tc.expectErr {
+					require.Error(t, err)
+				} else {
+					require.NoError(t, err)
+				}
+			})
+		})
+	}
+}


### PR DESCRIPTION
Fixes #1066.

Was tracing an intermittent crash on a pruned node that only showed up under load. The stack trace pointed at `comet.go:71` in the error path of `CometBlockResultByNumber`. When the caller passes height=0, the pointer gets set to nil before the `BlockResults` RPC call. If that call fails (timeout, pruned state, etc), the error formatting dereferences the nil pointer and panics.

The fix captures the height value before the nil reassignment and uses it in the error message. The variable already existed for the tracing span attribute so this just reuses it in the format string.

Added a table-driven test covering the zero-height error path to confirm it no longer panics.