### PR TITLE
refactor: replace sort.Slice with slices.Sort for natural ordering

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"math/big"
 	"path/filepath"
-	"sort"
+	"slices"
 	"strings"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -195,9 +195,7 @@ func GetIBCDenomAddress(denom string) (common.Address, error) {
 
 // SortSlice sorts a slice of any ordered type.
 func SortSlice[T cmp.Ordered](slice []T) {
-	sort.Slice(slice, func(i, j int) bool {
-		return slice[i] < slice[j]
-	})
+	slices.Sort(slice)
 }
 
 func Uint256FromBigInt(i *big.Int) (*uint256.Int, error) {

--- a/x/vm/keeper/keeper_test.go
+++ b/x/vm/keeper/keeper_test.go
@@ -117,3 +117,86 @@ func (suite *KeeperTestSuite) TestAddPreinstalls() {
 		})
 	}
 }
+func (suite *KeeperTestSuite) TestEnableEIPs() {
+	// Use valid EIPs from the error message: [1153 1344 1884 2200 2929 3198 3529 3855 3860 4762 5656 6780 7702 7939]
+	testCases := []struct {
+		name           string
+		initialEIPs    []int64
+		eipsToAdd      []int64
+		expectedEIPs   []int64
+		expectError    bool
+	}{
+		{
+			name:         "add EIPs to empty list",
+			initialEIPs:  []int64{},
+			eipsToAdd:    []int64{2929, 1884, 1344},
+			expectedEIPs: []int64{1344, 1884, 2929}, // should be sorted
+			expectError:  false,
+		},
+		{
+			name:         "add EIPs to existing list",
+			initialEIPs:  []int64{3198, 1153},
+			eipsToAdd:    []int64{2929, 1884},
+			expectedEIPs: []int64{1153, 1884, 2929, 3198}, // should be sorted
+			expectError:  false,
+		},
+		{
+			name:         "add single EIP",
+			initialEIPs:  []int64{3198},
+			eipsToAdd:    []int64{2929},
+			expectedEIPs: []int64{2929, 3198}, // should be sorted
+			expectError:  false,
+		},
+		{
+			name:         "add duplicate EIPs should fail",
+			initialEIPs:  []int64{3198},
+			eipsToAdd:    []int64{3198, 2929},
+			expectedEIPs: []int64{3198}, // should remain unchanged due to error
+			expectError:  true,
+		},
+		{
+			name:         "add EIPs in reverse order",
+			initialEIPs:  []int64{},
+			eipsToAdd:    []int64{7939, 3529, 1153},
+			expectedEIPs: []int64{1153, 3529, 7939}, // should be sorted
+			expectError:  false,
+		},
+		{
+			name:         "add no EIPs",
+			initialEIPs:  []int64{3198},
+			eipsToAdd:    []int64{},
+			expectedEIPs: []int64{3198}, // should remain unchanged
+			expectError:  false,
+		},
+		{
+			name:         "add invalid EIP should fail",
+			initialEIPs:  []int64{3198},
+			eipsToAdd:    []int64{1559}, // 1559 is not in the valid list
+			expectedEIPs: []int64{3198}, // should remain unchanged
+			expectError:  true,
+		},
+	}
+
+	for _, tc := range testCases {
+		suite.Run(tc.name, func() {
+			// Set initial parameters with initial EIPs
+			initialParams := vmtypes.DefaultParams()
+			initialParams.ExtraEIPs = tc.initialEIPs
+			err := suite.vmKeeper.SetParams(suite.ctx, initialParams)
+			suite.Require().NoError(err)
+
+			// Call EnableEIPs
+			err = suite.vmKeeper.EnableEIPs(suite.ctx, tc.eipsToAdd...)
+
+			if tc.expectError {
+				suite.Require().Error(err)
+			} else {
+				suite.Require().NoError(err)
+
+				// Verify the EIPs were added and sorted correctly
+				params := suite.vmKeeper.GetParams(suite.ctx)
+				suite.Require().Equal(tc.expectedEIPs, params.ExtraEIPs, "EIPs should match expected values and be sorted")
+			}
+		})
+	}
+}

--- a/x/vm/keeper/params.go
+++ b/x/vm/keeper/params.go
@@ -3,7 +3,6 @@ package keeper
 import (
 	"fmt"
 	"slices"
-	"sort"
 
 	"github.com/ethereum/go-ethereum/common"
 	"go.opentelemetry.io/otel/attribute"
@@ -104,9 +103,7 @@ func (k Keeper) EnableEIPs(ctx sdk.Context, eips ...int64) (err error) {
 	evmParams := k.GetParams(ctx)
 	evmParams.ExtraEIPs = append(evmParams.ExtraEIPs, eips...)
 
-	sort.Slice(evmParams.ExtraEIPs, func(i, j int) bool {
-		return evmParams.ExtraEIPs[i] < evmParams.ExtraEIPs[j]
-	})
+	slices.Sort(evmParams.ExtraEIPs)
 
 	return k.SetParams(ctx, evmParams)
 }


### PR DESCRIPTION
# Description

There is a [new function](https://pkg.go.dev/slices#Sort) added in the go1.21 standard library, which can make the code more concise and easy to read.

The new signed pr for https://github.com/cosmos/evm/pull/1068

---

## Author Checklist

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.

I have...

- [ ] tackled an existing issue or discussed with a team member
- [ ] left instructions on how to review the changes
- [x] targeted the `main` branch
