### PR TITLE
chore: add Ledger Nano Gen5 USB product IDs

### DIFF
--- a/wallets/usbwallet/hub.go
+++ b/wallets/usbwallet/hub.go
@@ -64,6 +64,7 @@ func NewLedgerHub() (*Hub, error) {
 		0x0005, /* Ledger Nano S Plus */
 		0x0006, /* Ledger Nano FTS */
 		0x0007, /* Ledger Flex */
+		0x0008, /* Ledger Nano Gen5 */
 
 		0x0000, /* WebUSB Ledger Blue */
 		0x1000, /* WebUSB Ledger Nano S */
@@ -71,6 +72,7 @@ func NewLedgerHub() (*Hub, error) {
 		0x5000, /* WebUSB Ledger Nano S Plus */
 		0x6000, /* WebUSB Ledger Nano FTS */
 		0x7000, /* WebUSB Ledger Flex */
+		0x8000, /* WebUSB Ledger Nano Gen5 */
 	}, 0xffa0, 0, newLedgerDriver)
 }
 


### PR DESCRIPTION
## Summary

Add missing Ledger Nano Gen5 USB (apex) product IDs to the device enumeration list:
- `0x0008` — Original product ID
- `0x8000` — WebUSB product ID

Aligns with upstream go-ethereum.

## Reference

- Upstream go-ethereum: https://github.com/ethereum/go-ethereum/blob/master/accounts/usbwallet/hub.go#L87-L101
- Ledger device registry (`productIdMM: 0x80` for Gen5): https://github.com/LedgerHQ/ledger-live/blob/main/libs/ledgerjs/packages/devices/src/index.ts#L93-L94