### PR TITLE
fix(rpc): invalid message index errors in block RPCs with StateDB commit error transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 - [\#992](https://github.com/cosmos/evm/pull/992) Respect the provided `gasCap` in `CallEVMWithData` instead of always used the default cap.
 - [\#993](https://github.com/cosmos/evm/pull/993) Enforce `src_callback` contract address to match the packet sender for IBC acknowledgement and timeout callbacks to prevent arbitrary contract execution.
 - [\#1050](https://github.com/cosmos/evm/pull/1050) Align precompile gas calculation with expected EVM gas semantics.
+- [\#1107](https://github.com/cosmos/evm/pull/1107) Skip StateDB commit error transactions during receipt conversion to prevent `invalid message index` errors in block RPCs.
 
 
 ## v0.6.0

--- a/rpc/backend/comet_to_eth.go
+++ b/rpc/backend/comet_to_eth.go
@@ -117,10 +117,16 @@ func (b *Backend) EthMsgsFromCometBlock(
 	for i, tx := range block.Txs {
 		// Check if tx exists on EVM by cross checking with blockResults:
 		//  - Include unsuccessful tx that exceeds block gas limit
-		//  - Include unsuccessful tx that failed when committing changes to stateDB
+		//  - Exclude unsuccessful tx that failed when committing changes to stateDB,
+		//    because they don't carry Msg response data and can break receipt decoding
 		//  - Exclude unsuccessful tx with any other error but ExceedBlockGasLimit
 		if !rpctypes.TxSucessOrExpectedFailure(txResults[i]) {
 			b.Logger.Debug("invalid tx result code", "cosmos-hash", hexutil.Encode(tx.Hash()))
+			continue
+		}
+
+		if rpctypes.TxStateDBCommitError(txResults[i]) {
+			b.Logger.Debug("skip statedb commit failure tx", "cosmos-hash", hexutil.Encode(tx.Hash()))
 			continue
 		}
 

--- a/rpc/backend/comet_to_eth.go
+++ b/rpc/backend/comet_to_eth.go
@@ -117,16 +117,9 @@ func (b *Backend) EthMsgsFromCometBlock(
 	for i, tx := range block.Txs {
 		// Check if tx exists on EVM by cross checking with blockResults:
 		//  - Include unsuccessful tx that exceeds block gas limit
-		//  - Exclude unsuccessful tx that failed when committing changes to stateDB,
-		//    because they don't carry Msg response data and can break receipt decoding
 		//  - Exclude unsuccessful tx with any other error but ExceedBlockGasLimit
 		if !rpctypes.TxSucessOrExpectedFailure(txResults[i]) {
 			b.Logger.Debug("invalid tx result code", "cosmos-hash", hexutil.Encode(tx.Hash()))
-			continue
-		}
-
-		if rpctypes.TxStateDBCommitError(txResults[i]) {
-			b.Logger.Debug("skip statedb commit failure tx", "cosmos-hash", hexutil.Encode(tx.Hash()))
 			continue
 		}
 

--- a/rpc/backend/tx_info_test.go
+++ b/rpc/backend/tx_info_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/cosmos/evm/encoding"
 	"github.com/cosmos/evm/indexer"
 	"github.com/cosmos/evm/rpc/backend/mocks"
-	"github.com/cosmos/evm/rpc/types"
 	rpctypes "github.com/cosmos/evm/rpc/types"
 	servertypes "github.com/cosmos/evm/server/types"
 	"github.com/cosmos/evm/testutil/constants"
@@ -546,7 +545,7 @@ func TestEthMsgsFromCometBlockSkipStateDBCommitFailure(t *testing.T) {
 	blockRes := &tmrpctypes.ResultBlockResults{
 		Height: 100,
 		TxsResults: []*abcitypes.ExecTxResult{
-			{Code: 4, Log: types.StateDBCommitError},
+			{Code: 4, Log: rpctypes.StateDBCommitError},
 			{Code: 0},
 		},
 	}

--- a/rpc/backend/tx_info_test.go
+++ b/rpc/backend/tx_info_test.go
@@ -545,7 +545,7 @@ func TestEthMsgsFromCometBlockSkipStateDBCommitFailure(t *testing.T) {
 	blockRes := &tmrpctypes.ResultBlockResults{
 		Height: 100,
 		TxsResults: []*abcitypes.ExecTxResult{
-			{Code: 4, Log: rpctypes.StateDBCommitError},
+			{Code: 4, Log: "failed to commit stateDB"},
 			{Code: 0},
 		},
 	}

--- a/rpc/backend/tx_info_test.go
+++ b/rpc/backend/tx_info_test.go
@@ -13,6 +13,7 @@ import (
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	protov2 "google.golang.org/protobuf/proto"
 
 	abcitypes "github.com/cometbft/cometbft/abci/types"
 	tmrpctypes "github.com/cometbft/cometbft/rpc/core/types"
@@ -22,6 +23,7 @@ import (
 	"github.com/cosmos/evm/encoding"
 	"github.com/cosmos/evm/indexer"
 	"github.com/cosmos/evm/rpc/backend/mocks"
+	"github.com/cosmos/evm/rpc/types"
 	rpctypes "github.com/cosmos/evm/rpc/types"
 	servertypes "github.com/cosmos/evm/server/types"
 	"github.com/cosmos/evm/testutil/constants"
@@ -421,6 +423,25 @@ func buildMsgEthereumTx(t *testing.T) *evmtypes.MsgEthereumTx {
 	return msgEthereumTx
 }
 
+type mockDecodedTx struct {
+	msgs []sdk.Msg
+}
+
+func (m mockDecodedTx) GetMsgs() []sdk.Msg { return m.msgs }
+
+func (m mockDecodedTx) GetMsgsV2() ([]protov2.Message, error) { return nil, nil }
+
+func (m mockDecodedTx) ValidateBasic() error { return nil }
+
+type txConfigWithDecoder struct {
+	client.TxConfig
+	decoder sdk.TxDecoder
+}
+
+func (t txConfigWithDecoder) TxDecoder() sdk.TxDecoder {
+	return t.decoder
+}
+
 type MockIndexer struct {
 	txResults map[common.Hash]*servertypes.TxResult
 }
@@ -500,4 +521,38 @@ func TestReceiptsFromCometBlock(t *testing.T) {
 			require.Equal(t, ethtypes.ReceiptStatusSuccessful, receipts[0].Status)
 		})
 	}
+}
+
+func TestEthMsgsFromCometBlockSkipStateDBCommitFailure(t *testing.T) {
+	backend := setupMockBackend(t)
+	successMsg := buildMsgEthereumTx(t)
+	decodeCalls := 0
+
+	backend.ClientCtx = backend.ClientCtx.WithTxConfig(txConfigWithDecoder{
+		TxConfig: backend.ClientCtx.TxConfig,
+		decoder: func(_ []byte) (sdk.Tx, error) {
+			decodeCalls++
+			return mockDecodedTx{msgs: []sdk.Msg{successMsg}}, nil
+		},
+	})
+
+	resBlock := &tmrpctypes.ResultBlock{
+		Block: &tmtypes.Block{
+			Header: tmtypes.Header{Height: 100},
+			Data:   tmtypes.Data{Txs: []tmtypes.Tx{{0x01}, {0x02}}},
+		},
+	}
+
+	blockRes := &tmrpctypes.ResultBlockResults{
+		Height: 100,
+		TxsResults: []*abcitypes.ExecTxResult{
+			{Code: 4, Log: types.StateDBCommitError},
+			{Code: 0},
+		},
+	}
+
+	msgs := backend.EthMsgsFromCometBlock(rpctypes.NewContextWithHeight(100), resBlock, blockRes)
+	require.Equal(t, 1, decodeCalls)
+	require.Len(t, msgs, 1)
+	require.Same(t, successMsg, msgs[0])
 }

--- a/rpc/types/utils.go
+++ b/rpc/types/utils.go
@@ -34,11 +34,6 @@ import (
 // The tx fee is deducted in ante handler, so it shouldn't be ignored in JSON-RPC API.
 const ExceedBlockGasLimitError = "out of gas in location: block gas meter; gasWanted:"
 
-// StateDBCommitError defines the error message when commit after executing EVM transaction, for example
-// transfer native token to a distribution module account 0x93354845030274cD4bf1686Abd60AB28EC52e1a7 using an evm type transaction
-// note: the transfer amount cannot be set to 0, otherwise this problem will not be triggered
-const StateDBCommitError = "failed to commit stateDB"
-
 // RawTxToEthTx returns a evm MsgEthereum transaction from raw tx bytes.
 func RawTxToEthTx(clientCtx client.Context, txBz cmttypes.Tx) ([]*evmtypes.MsgEthereumTx, error) {
 	tx, err := clientCtx.TxConfig.TxDecoder()(txBz)
@@ -355,15 +350,10 @@ func TxExceedBlockGasLimit(res *abci.ExecTxResult) bool {
 	return strings.Contains(res.Log, ExceedBlockGasLimitError)
 }
 
-// TxStateDBCommitError returns true if the evm tx commit error.
-func TxStateDBCommitError(res *abci.ExecTxResult) bool {
-	return strings.Contains(res.Log, StateDBCommitError)
-}
-
 // TxSucessOrExpectedFailure returns true if the transaction was successful
-// or if it failed with an ExceedBlockGasLimit error or TxStateDBCommitError error
+// or if it failed with an ExceedBlockGasLimit error.
 func TxSucessOrExpectedFailure(res *abci.ExecTxResult) bool {
-	return res.Code == 0 || TxExceedBlockGasLimit(res) || TxStateDBCommitError(res)
+	return res.Code == 0 || TxExceedBlockGasLimit(res)
 }
 
 // CalcBaseFee calculates the basefee of the header.


### PR DESCRIPTION
# Description

To avoid block RPCs error like when get block https://rpc.archive.mantrachain.io/block_results?height=9329725 that contains unauthorized error tx
```
curl --location 'https://evm.archive.mantrachain.io' \
--header 'Content-Type: application/json' \
--data '{
    "jsonrpc": "2.0",
    "method": "eth_getBlockByNumber",
    "params": [
        "0x8E5C3D",
        true
    ],
    "id": 0
}'
{"jsonrpc":"2.0","id":0,"error":{"code":-32000,"message":"failed to get rpc block from comet block: failed to get receipts from comet block: failed to convert tx result to eth receipt: invalid message index: 0"}}
```

for test [info](https://github.com/MANTRA-Chain/mantrachain-e2e/commit/97201248bac44d33f5c2b5bbedacb244cd3b3a07)

---

## Author Checklist

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.

I have...

- [ ] tackled an existing issue or discussed with a team member
- [ ] left instructions on how to review the changes
- [ ] targeted the `main` branch
