### PR TITLE
fix(mempool): fix race in reap list

### DIFF
--- a/mempool/reap_list.go
+++ b/mempool/reap_list.go
@@ -167,12 +167,16 @@ func (rl *ReapList) PushCosmosTx(tx sdk.Tx) error {
 // push inserts a tx to the back of the reap list as the "newest" transaction
 // (last to be returned if Reap was called now). push assumes that a tx is not
 // already in the ReapList, this should be checked via exists.
+//
+// NOTE: this is not thread safe, callers should be holding the txsLock.
 func (rl *ReapList) push(hash string, tx []byte, gas uint64) {
 	rl.txs = append(rl.txs, &txWithHash{tx, hash, gas})
 	rl.txIndex[hash] = len(rl.txs) - 1
 }
 
 // exists returns true if a hash is in the index, false otherwise.
+//
+// NOTE: this is not thread safe, callers should be holding the txsLock.
 func (rl *ReapList) exists(hash string) bool {
 	_, ok := rl.txIndex[hash]
 	return ok

--- a/mempool/reap_list.go
+++ b/mempool/reap_list.go
@@ -121,6 +121,10 @@ func (rl *ReapList) Reap(maxBytes uint64, maxGas uint64) [][]byte {
 // PushEVMTx enqueues an EVM tx into the reap list.
 func (rl *ReapList) PushEVMTx(tx *ethtypes.Transaction) error {
 	hash := tx.Hash().String()
+
+	rl.txsLock.Lock()
+	defer rl.txsLock.Unlock()
+
 	if rl.exists(hash) {
 		return nil
 	}
@@ -140,8 +144,11 @@ func (rl *ReapList) PushCosmosTx(tx sdk.Tx) error {
 	if err != nil {
 		return fmt.Errorf("encoding cosmos tx to bytes: %w", err)
 	}
-
 	hash := cosmosHash(txBytes)
+
+	rl.txsLock.Lock()
+	defer rl.txsLock.Unlock()
+
 	if rl.exists(hash) {
 		return nil
 	}
@@ -161,18 +168,12 @@ func (rl *ReapList) PushCosmosTx(tx sdk.Tx) error {
 // (last to be returned if Reap was called now). push assumes that a tx is not
 // already in the ReapList, this should be checked via exists.
 func (rl *ReapList) push(hash string, tx []byte, gas uint64) {
-	rl.txsLock.Lock()
-	defer rl.txsLock.Unlock()
-
 	rl.txs = append(rl.txs, &txWithHash{tx, hash, gas})
 	rl.txIndex[hash] = len(rl.txs) - 1
 }
 
 // exists returns true if a hash is in the index, false otherwise.
 func (rl *ReapList) exists(hash string) bool {
-	rl.txsLock.RLock()
-	defer rl.txsLock.RUnlock()
-
 	_, ok := rl.txIndex[hash]
 	return ok
 }

--- a/mempool/reap_list_test.go
+++ b/mempool/reap_list_test.go
@@ -802,3 +802,39 @@ func TestReapList_MixedDrops(t *testing.T) {
 	result := rl.Reap(0, 0)
 	require.Len(t, result, 4, "should have 4 transactions after mixed drops")
 }
+
+// Regression test that verifies that racing PushEVMTx calls with the same hash
+// cannot produce a duplicate entry or an orphaned slot.
+func TestReapList_ConcurrentSameHashPush(t *testing.T) {
+	const iterations = 200
+	const workers = 32
+
+	for i := 0; i < iterations; i++ {
+		key, err := crypto.GenerateKey()
+		require.NoError(t, err)
+
+		rl := mempool.NewReapList(newDeterministicEncoder(100, 100))
+		tx := testEVMTx(t, key, 0, 21000)
+
+		var wg sync.WaitGroup
+		start := make(chan struct{})
+		for j := 0; j < workers; j++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				<-start
+				_ = rl.PushEVMTx(tx)
+			}()
+		}
+		close(start)
+		wg.Wait()
+
+		result := rl.Reap(0, 0)
+		require.Lenf(t, result, 1, "iter %d: duplicate reap from concurrent same hash push", i)
+
+		require.NotPanicsf(t, func() {
+			rl.DropEVMTx(tx)
+			_ = rl.Reap(0, 0)
+		}, "iter %d: drop after concurrent push must not orphan a slot", i)
+	}
+}


### PR DESCRIPTION
# Description

Fixes a small race condition in the reap list where we check if a tx exists, then unlock, and then push. This creates a window where we two readers can both see a tx is not in the list, leading to duplicate entries in the reap list.

Closes: #XXXX

---

## Author Checklist

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.

I have...

- [ ] tackled an existing issue or discussed with a team member
- [ ] left instructions on how to review the changes
- [ ] targeted the `main` branch
