### PR TITLE
fix(rpc): use latest block in eth_fillTransaction gas estimation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
 - [\#992](https://github.com/cosmos/evm/pull/992) Respect the provided `gasCap` in `CallEVMWithData` instead of always used the default cap.
 - [\#993](https://github.com/cosmos/evm/pull/993) Enforce `src_callback` contract address to match the packet sender for IBC acknowledgement and timeout callbacks to prevent arbitrary contract execution.
 - [\#1050](https://github.com/cosmos/evm/pull/1050) Align precompile gas calculation with expected EVM gas semantics.
+- [\#1106](https://github.com/cosmos/evm/pull/1106) Use `latest` block when `eth_fillTransaction` auto-estimates gas so it does not use incorrect historical state.
 
 
 ## v0.6.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@
 - [\#992](https://github.com/cosmos/evm/pull/992) Respect the provided `gasCap` in `CallEVMWithData` instead of always used the default cap.
 - [\#993](https://github.com/cosmos/evm/pull/993) Enforce `src_callback` contract address to match the packet sender for IBC acknowledgement and timeout callbacks to prevent arbitrary contract execution.
 - [\#1050](https://github.com/cosmos/evm/pull/1050) Align precompile gas calculation with expected EVM gas semantics.
-- [\#1106](https://github.com/cosmos/evm/pull/1106) Use `latest` block when `eth_fillTransaction` auto-estimates gas so it does not use incorrect historical state.
+- [\#1120](https://github.com/cosmos/evm/pull/1120) Use `latest` block when `eth_fillTransaction` auto-estimates gas so it does not use incorrect historical state.
 
 
 ## v0.6.0

--- a/rpc/backend/call_tx.go
+++ b/rpc/backend/call_tx.go
@@ -279,7 +279,7 @@ func (b *Backend) SetTxDefaults(ctx context.Context, args evmtypes.TransactionAr
 			Nonce:                args.Nonce,
 		}
 
-		blockNr := rpctypes.NewBlockNumber(big.NewInt(0))
+		blockNr := rpctypes.EthLatestBlockNumber
 		blockNrOrHash := rpctypes.BlockNumberOrHash{BlockNumber: &blockNr}
 		estimated, err := b.EstimateGas(ctx, callArgs, &blockNrOrHash, nil)
 		if err != nil {


### PR DESCRIPTION
## Summary

- use `rpctypes.EthLatestBlockNumber` when `eth_fillTransaction` auto-estimates gas
- align `SetTxDefaults` with geth behavior for transaction defaulting

## Why

geth uses `rpc.LatestBlockNumber` when it auto-estimates gas while filling transaction defaults:

Reference:
https://github.com/ethereum/go-ethereum/blob/master/internal/ethapi/transaction_args.go#L160-L161

```go
latestBlockNr := rpc.BlockNumberOrHashWithNumber(rpc.LatestBlockNumber)
estimated, err := DoEstimateGas(ctx, b, callArgs, latestBlockNr, nil, nil, b.RPCGasCap())
```

In contrast, the current implementation passes a numeric block `0`:

```go
blockNr := rpctypes.NewBlockNumber(big.NewInt(0))
```

On Cosmos EVM, numeric block `0` is not treated as `latest`, so `eth_fillTransaction` may estimate gas against the wrong historical state. This PR switches the default block selection to `latest` so the behavior matches geth.

## Testing

- `go test ./rpc/backend`
