### PR TITLE
fix: align local node mempool and browser access settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@
 
 ### BUG FIXES
 
-- [\#1110](https://github.com/cosmos/evm/pull/1110) Fix `local_node.sh` app mempool startup flags and local RPC browser access defaults.
+- [\#1121](https://github.com/cosmos/evm/pull/1121) Fix `local_node.sh` app mempool startup flags and local RPC browser access defaults.
  [\#965](https://github.com/cosmos/evm/pull/965) Fix gas double charging on EVM calls in IBCOnTimeoutPacketCallback.
 - [\#869](https://github.com/cosmos/evm/pull/869) Fix erc20 IBC callbacks to check for native token transfer before parsing recipient.
 - [\#860](https://github.com/cosmos/evm/pull/860) Fix EIP-712 signature verification to use configured EVM chain ID instead of parsing cosmos chain ID string and replace legacytx.StdSignBytes with the aminojson sign mode handler.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 
 ### BUG FIXES
 
+- [\#1110](https://github.com/cosmos/evm/pull/1110) Fix `local_node.sh` app mempool startup flags and local RPC browser access defaults.
  [\#965](https://github.com/cosmos/evm/pull/965) Fix gas double charging on EVM calls in IBCOnTimeoutPacketCallback.
 - [\#869](https://github.com/cosmos/evm/pull/869) Fix erc20 IBC callbacks to check for native token transfer before parsing recipient.
 - [\#860](https://github.com/cosmos/evm/pull/860) Fix EIP-712 signature verification to use configured EVM chain ID instead of parsing cosmos chain ID string and replace legacytx.StdSignBytes with the aminojson sign mode handler.

--- a/local_node.sh
+++ b/local_node.sh
@@ -267,7 +267,8 @@ if [[ $overwrite == "y" || $overwrite == "Y" ]]; then
   sed -i.bak 's/timeout_commit = "5s"/timeout_commit = "1s"/g' "$CONFIG_TOML"
   sed -i.bak 's/timeout_broadcast_tx_commit = "10s"/timeout_broadcast_tx_commit = "5s"/g' "$CONFIG_TOML"
   sed -i.bak 's/type = "flood"/type = "app"/g' "$CONFIG_TOML"
-
+  sed -i.bak 's/laddr = "tcp:\/\/127.0.0.1:26657"/laddr = "tcp:\/\/0.0.0.0:26657"/g' "$CONFIG_TOML"
+  sed -i.bak 's/cors_allowed_origins = \[\]/cors_allowed_origins = ["*"]/g' "$CONFIG_TOML"
   # enable prometheus metrics and all APIs for dev node
   sed -i.bak 's/prometheus = false/prometheus = true/' "$CONFIG_TOML"
   sed -i.bak 's/prometheus-retention-time  = "0"/prometheus-retention-time  = "1000000000000"/g' "$APP_TOML"
@@ -343,8 +344,11 @@ fi
 evmd start "$TRACE" \
 	--pruning nothing \
 	--log_level $LOGLEVEL \
+	--mempool.max-txs=0 \
 	--minimum-gas-prices=0atest \
 	--evm.min-tip=0 \
+	--evm.mempool.operate-exclusively=true \
 	--home "$CHAINDIR" \
 	--json-rpc.api eth,txpool,personal,net,debug,web3 \
+	--api.enabled-unsafe-cors true \
 	--chain-id "$CHAINID"


### PR DESCRIPTION
## Summary
- enable the app-side mempool flags required when `local_node.sh` switches CometBFT to app mempool mode
- update the generated CometBFT RPC config to bind on `0.0.0.0` and allow browser-origin requests during local development
- keep the local node startup flow consistent for browser-based debugging against local endpoints

## Problem
Running `local_node.sh` was repeatedly logging this startup error:

```text
10:42AM ERR AppMempool.reapTxs: error reaping txs error="ReapTxs handler not set" module=mempool server=node
```

The script switched CometBFT from flood mempool mode to app mode, but it did not also enable the app-side mempool flags required for the exclusive Krakatoa path.

## Testing
- `bash -n local_node.sh`
