### PR TITLE
fix(mempool): Proper dropping from `reaplist` for cosmos txs during replacement and rechecking

### DIFF
--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -304,20 +304,6 @@ func (m *Mempool) insert(tx sdk.Tx) (<-chan error, error) {
 	}
 }
 
-// insertAndReapCosmosTx inserts a cosmos tx into the cosmos mempool and sets
-// it to be reaped.
-func (m *Mempool) insertAndReapCosmosTx(tx sdk.Tx) error {
-	m.logger.Debug("inserting Cosmos transaction")
-
-	// Insert into cosmos pool (handles locking, ante handler, and address reservation internally)
-
-	m.logger.Debug("Cosmos transaction inserted successfully")
-	if err := m.reapList.PushCosmosTx(tx); err != nil {
-		panic(fmt.Errorf("successfully inserted cosmos tx, but failed to insert into reap list: %w", err))
-	}
-	return nil
-}
-
 // ReapNewValidTxs removes and returns the oldest transactions from the reap
 // list until maxBytes or maxGas limits are reached.
 func (m *Mempool) ReapNewValidTxs(maxBytes uint64, maxGas uint64) ([][]byte, error) {

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -160,19 +160,14 @@ func NewMempool(
 		panic("tx pool should contain only legacypool")
 	}
 
-	cosmosPoolConfig := config.CosmosPoolConfig
-	if cosmosPoolConfig == nil {
-		cosmosPoolConfig = defaultCosmosPoolConfig(blockchain.GetCoinDenom)
-	}
-
-	cosmosPoolConfig.MaxTx = cosmosPoolMaxTx
-	cosmosPool := sdkmempool.NewPriorityMempool(*cosmosPoolConfig)
 	recheckPool := NewRecheckMempool(
 		logger,
-		cosmosPool,
+		config.CosmosPoolConfig,
+		cosmosPoolMaxTx,
 		reservationTracker.NewHandle(-1),
 		cosmosRechecker,
 		heightsync.New(blockchain.CurrentBlock().Number, NewCosmosTxStore, logger.With("pool", "cosmos_recheck_mempool")),
+		reapList,
 		blockchain,
 	)
 
@@ -203,12 +198,10 @@ func NewMempool(
 		func(txs []*sdk.Tx) []error {
 			errs := make([]error, len(txs))
 			for i, tx := range txs {
-				// NOTE: cosmos txs must be added to the reap list directly
-				// after insert, since recheck runs on insert, if insert
-				// completes successfully, then we know they are valid and
-				// should be added to the reap list, we do not need to wait
-				// until the next blocks recheck.
-				errs[i] = mempool.insertAndReapCosmosTx(*tx)
+				if tx == nil {
+					continue
+				}
+				errs[i] = recheckPool.Insert(context.Background(), *tx)
 			}
 			return errs
 		},
@@ -317,10 +310,6 @@ func (m *Mempool) insertAndReapCosmosTx(tx sdk.Tx) error {
 	m.logger.Debug("inserting Cosmos transaction")
 
 	// Insert into cosmos pool (handles locking, ante handler, and address reservation internally)
-	if err := m.recheckCosmosPool.Insert(context.Background(), tx); err != nil {
-		m.logger.Error("failed to insert Cosmos transaction", "error", err)
-		return err
-	}
 
 	m.logger.Debug("Cosmos transaction inserted successfully")
 	if err := m.reapList.PushCosmosTx(tx); err != nil {
@@ -431,14 +420,13 @@ func (m *Mempool) RemoveWithReason(ctx context.Context, tx sdk.Tx, reason sdkmem
 func (m *Mempool) removeCosmosTx(ctx context.Context, tx sdk.Tx, reason sdkmempool.RemoveReason) error {
 	m.logger.Debug("Removing Cosmos transaction")
 
-	// Remove from cosmos pool (handles address reservation release internally)
+	// Remove from cosmos pool (handles address reservation release  and reap
+	// list drop internally)
 	err := sdkmempool.RemoveWithReason(ctx, m.recheckCosmosPool, tx, reason)
 	if err != nil {
 		m.logger.Error("Failed to remove Cosmos transaction", "error", err)
 		return err
 	}
-
-	m.reapList.DropCosmosTx(tx)
 	m.logger.Debug("Cosmos transaction removed successfully")
 
 	return nil
@@ -601,31 +589,6 @@ func (m *Mempool) RecheckEVMTxs(newHead *ethtypes.Header) {
 // This should only used for testing.
 func (m *Mempool) RecheckCosmosTxs(newHead *ethtypes.Header) {
 	m.recheckCosmosPool.TriggerRecheckSync(newHead)
-}
-
-func defaultCosmosPoolConfig(getDenom func() string) *sdkmempool.PriorityNonceMempoolConfig[math.Int] {
-	txPriority := sdkmempool.TxPriority[math.Int]{
-		GetTxPriority: func(_ context.Context, tx sdk.Tx) math.Int {
-			cosmosTxFee, ok := tx.(sdk.FeeTx)
-			if !ok {
-				return math.ZeroInt()
-			}
-			found, coin := cosmosTxFee.GetFee().Find(getDenom())
-			if !found {
-				return math.ZeroInt()
-			}
-
-			gasPrice := coin.Amount.Quo(math.NewIntFromUint64(cosmosTxFee.GetGas()))
-
-			return gasPrice
-		},
-		Compare: func(a, b math.Int) int {
-			return a.BigInt().Cmp(b.BigInt())
-		},
-		MinValue: math.ZeroInt(),
-	}
-
-	return &sdkmempool.PriorityNonceMempoolConfig[math.Int]{TxPriority: txPriority}
 }
 
 // getEVMMessage validates that the transaction contains exactly one message and returns it if it's an EVM message.

--- a/mempool/recheck_pool.go
+++ b/mempool/recheck_pool.go
@@ -13,9 +13,11 @@ import (
 	"go.opentelemetry.io/otel/metric"
 
 	"github.com/cosmos/evm/mempool/internal/heightsync"
+	"github.com/cosmos/evm/mempool/internal/reaplist"
 	"github.com/cosmos/evm/mempool/reserver"
 
 	"cosmossdk.io/log/v2"
+	"cosmossdk.io/math"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkmempool "github.com/cosmos/cosmos-sdk/types/mempool"
@@ -97,9 +99,9 @@ type RecheckMempool struct {
 	// reserver coordinates address reservations with other pools (i.e. legacypool)
 	reserver *reserver.ReservationHandle
 
-	rechecker       Rechecker
-	contextProvider LatestContextProvider
-	logger          log.Logger
+	rechecker  Rechecker
+	blockchain *Blockchain
+	logger     log.Logger
 
 	// event channels
 	reqRecheckCh    chan *recheckRequest // channel that schedules rechecking.
@@ -112,28 +114,38 @@ type RecheckMempool struct {
 	// have been rechecked at a height, and discard of them once the chain.
 	recheckedTxs *heightsync.HeightSync[CosmosTxStore]
 
+	reapList *reaplist.ReapList
+
 	wg sync.WaitGroup
 }
 
 // NewRecheckMempool creates a new RecheckMempool wrapping the given pool.
 func NewRecheckMempool(
 	logger log.Logger,
-	pool sdkmempool.ExtMempool,
+	cosmosPoolConfig *sdkmempool.PriorityNonceMempoolConfig[math.Int],
+	maxTxs int,
 	reserver *reserver.ReservationHandle,
 	rechecker Rechecker,
 	recheckedTxs *heightsync.HeightSync[CosmosTxStore],
-	contextProvider LatestContextProvider,
+	reapList *reaplist.ReapList,
+	blockchain *Blockchain,
 ) *RecheckMempool {
+	if cosmosPoolConfig == nil {
+		cosmosPoolConfig = defaultCosmosPoolConfig(reapList, blockchain)
+	}
+	cosmosPoolConfig.MaxTx = maxTxs
+
 	return &RecheckMempool{
-		ExtMempool:      pool,
+		ExtMempool:      sdkmempool.NewPriorityMempool(*cosmosPoolConfig),
 		reserver:        reserver,
 		rechecker:       rechecker,
-		contextProvider: contextProvider,
+		blockchain:      blockchain,
 		logger:          logger.With(log.ModuleKey, "RecheckMempool"),
 		reqRecheckCh:    make(chan *recheckRequest),
 		recheckDoneCh:   make(chan chan struct{}),
 		shutdownCh:      make(chan struct{}),
 		recheckShutdown: make(chan struct{}),
+		reapList:        reapList,
 		recheckedTxs:    recheckedTxs,
 	}
 }
@@ -142,7 +154,7 @@ func NewRecheckMempool(
 // context to the latest chain state. The initialHead is used for the first
 // Rechecker.Update call before any recheck has been triggered.
 func (m *RecheckMempool) Start(initialHead *ethtypes.Header) {
-	ctx, err := m.contextProvider.GetLatestContext()
+	ctx, err := m.blockchain.GetLatestContext()
 	if err != nil {
 		m.logger.Error("failed to initialize rechecker context", "err", err)
 	} else {
@@ -184,12 +196,12 @@ func (m *RecheckMempool) Insert(_ context.Context, tx sdk.Tx) error {
 		m.logger.Warn("no context found in rechecker on insert, updating to latest")
 		// if this happens, we have not rechecked any txs yet, so this is safe
 		// to update
-		newCtx, err := m.contextProvider.GetLatestContext()
+		newCtx, err := m.blockchain.GetLatestContext()
 		if err != nil {
 			return fmt.Errorf("fetching latest context since rechecker has none: %w", err)
 		}
 
-		m.rechecker.Update(newCtx, m.contextProvider.CurrentBlock())
+		m.rechecker.Update(newCtx, m.blockchain.CurrentBlock())
 		ctx, write = m.rechecker.GetContext()
 	}
 
@@ -201,6 +213,13 @@ func (m *RecheckMempool) Insert(_ context.Context, tx sdk.Tx) error {
 	if err := m.ExtMempool.Insert(ctx, tx); err != nil {
 		_ = m.reserver.Release(addrs...) // best effort cleanup
 		return err
+	}
+
+	// since we have rechecked the tx via `rechecker.RecheckCosmos`, and this
+	// rechecks the tx on top of the state of all txs already rechecked in the
+	// mempool, this tx is valid and we can include it in the reaplist
+	if err := m.reapList.PushCosmosTx(tx); err != nil {
+		m.logger.Error("successfully inserted cosmos tx, but failed to insert into reap list", "err", err)
 	}
 
 	write()
@@ -235,6 +254,7 @@ func (m *RecheckMempool) removeLocked(tx sdk.Tx) error {
 		panic("failed to extract signer addresses from tx during Remove")
 	}
 	m.reserver.Release(addrs...) //nolint:errcheck // best effort cleanup
+	m.reapList.DropCosmosTx(tx)
 
 	return nil
 }
@@ -381,7 +401,7 @@ func (m *RecheckMempool) runRecheck(done chan struct{}, newHead *ethtypes.Header
 	m.recheckedTxs.StartNewHeight(newHead.Number)
 	defer m.recheckedTxs.EndCurrentHeight()
 
-	latestCtx, err := m.contextProvider.GetLatestContext()
+	latestCtx, err := m.blockchain.GetLatestContext()
 	if err != nil {
 		m.logger.Error("failed to get context for recheck", "err", err)
 		return
@@ -454,6 +474,8 @@ func (m *RecheckMempool) runRecheck(done chan struct{}, newHead *ethtypes.Header
 			m.logger.Error("failed to remove tx during recheck", "err", err)
 			continue
 		}
+		m.reapList.DropCosmosTx(txn)
+
 		addrs, err := signerAddressesFromTx(txn)
 		if err != nil {
 			m.logger.Error("failed to extract signer addresses for release", "err", err)
@@ -544,4 +566,40 @@ func signerAddressesFromTx(tx sdk.Tx) ([]common.Address, error) {
 	}
 
 	return addrs, nil
+}
+
+func defaultCosmosPoolConfig(reapList *reaplist.ReapList, blockchain *Blockchain) *sdkmempool.PriorityNonceMempoolConfig[math.Int] {
+	txPriority := sdkmempool.TxPriority[math.Int]{
+		GetTxPriority: func(_ context.Context, tx sdk.Tx) math.Int {
+			cosmosTxFee, ok := tx.(sdk.FeeTx)
+			if !ok {
+				return math.ZeroInt()
+			}
+			found, coin := cosmosTxFee.GetFee().Find(blockchain.GetCoinDenom())
+			if !found {
+				return math.ZeroInt()
+			}
+
+			gasPrice := coin.Amount.Quo(math.NewIntFromUint64(cosmosTxFee.GetGas()))
+
+			return gasPrice
+		},
+		Compare: func(a, b math.Int) int {
+			return a.BigInt().Cmp(b.BigInt())
+		},
+		MinValue: math.ZeroInt(),
+	}
+
+	txReplacement := func(oldPriority, newPriority math.Int, oldTx, newTx sdk.Tx) bool {
+		// tx is being replaced, we need to drop the tx that is going to be removed
+		// from the reap list. we assume that the tx doing the replacing has
+		// already been inserted into the reaplist via the insert.
+		reapList.DropCosmosTx(oldTx)
+		return true
+	}
+
+	return &sdkmempool.PriorityNonceMempoolConfig[math.Int]{
+		TxPriority:    txPriority,
+		TxReplacement: txReplacement,
+	}
 }

--- a/mempool/recheck_pool.go
+++ b/mempool/recheck_pool.go
@@ -75,13 +75,6 @@ type Rechecker interface {
 	Update(ctx sdk.Context, header *ethtypes.Header)
 }
 
-// LatestContextProvider provides the minimal methods needed by RecheckMempool
-// for context management during rechecks.
-type LatestContextProvider interface {
-	GetLatestContext() (sdk.Context, error)
-	CurrentBlock() *ethtypes.Header
-}
-
 // RecheckMempool wraps an ExtMempool and provides block-driven rechecking
 // of transactions when new blocks are committed. It mirrors the legacypool
 // pattern but simplified for Cosmos mempool behavior (no reorgs, no queued/pending management).

--- a/mempool/recheck_pool.go
+++ b/mempool/recheck_pool.go
@@ -607,7 +607,7 @@ func cosmosPoolConfig(
 			// already been inserted into the reaplist via the insert.
 			reapList.DropCosmosTx(oldTx)
 		}
-		return true
+		return shouldReplace
 	}
 	config.TxReplacement = txReplacement
 

--- a/mempool/recheck_pool.go
+++ b/mempool/recheck_pool.go
@@ -119,10 +119,10 @@ type RecheckMempool struct {
 	wg sync.WaitGroup
 }
 
-// NewRecheckMempool creates a new RecheckMempool wrapping the given pool.
+// NewRecheckMempool creates a new RecheckMempool.
 func NewRecheckMempool(
 	logger log.Logger,
-	cosmosPoolConfig *sdkmempool.PriorityNonceMempoolConfig[math.Int],
+	defaultCosmosPoolConfig *sdkmempool.PriorityNonceMempoolConfig[math.Int],
 	maxTxs int,
 	reserver *reserver.ReservationHandle,
 	rechecker Rechecker,
@@ -130,13 +130,9 @@ func NewRecheckMempool(
 	reapList *reaplist.ReapList,
 	blockchain *Blockchain,
 ) *RecheckMempool {
-	if cosmosPoolConfig == nil {
-		cosmosPoolConfig = defaultCosmosPoolConfig(reapList, blockchain)
-	}
-	cosmosPoolConfig.MaxTx = maxTxs
-
+	priorityMempoolConfg := cosmosPoolConfig(reapList, blockchain, defaultCosmosPoolConfig, maxTxs)
 	return &RecheckMempool{
-		ExtMempool:      sdkmempool.NewPriorityMempool(*cosmosPoolConfig),
+		ExtMempool:      sdkmempool.NewPriorityMempool(priorityMempoolConfg),
 		reserver:        reserver,
 		rechecker:       rechecker,
 		blockchain:      blockchain,
@@ -568,38 +564,60 @@ func signerAddressesFromTx(tx sdk.Tx) ([]common.Address, error) {
 	return addrs, nil
 }
 
-func defaultCosmosPoolConfig(reapList *reaplist.ReapList, blockchain *Blockchain) *sdkmempool.PriorityNonceMempoolConfig[math.Int] {
-	txPriority := sdkmempool.TxPriority[math.Int]{
-		GetTxPriority: func(_ context.Context, tx sdk.Tx) math.Int {
-			cosmosTxFee, ok := tx.(sdk.FeeTx)
-			if !ok {
-				return math.ZeroInt()
-			}
-			found, coin := cosmosTxFee.GetFee().Find(blockchain.GetCoinDenom())
-			if !found {
-				return math.ZeroInt()
-			}
+func cosmosPoolConfig(
+	reapList *reaplist.ReapList,
+	blockchain *Blockchain,
+	defaultConfig *sdkmempool.PriorityNonceMempoolConfig[math.Int],
+	maxTxs int,
+) sdkmempool.PriorityNonceMempoolConfig[math.Int] {
+	var config sdkmempool.PriorityNonceMempoolConfig[math.Int]
 
-			gasPrice := coin.Amount.Quo(math.NewIntFromUint64(cosmosTxFee.GetGas()))
+	if defaultConfig != nil {
+		// prioritize the default configs TxPriority struct if defined
+		config.TxPriority = defaultConfig.TxPriority
+	} else {
+		config.TxPriority = sdkmempool.TxPriority[math.Int]{
+			GetTxPriority: func(_ context.Context, tx sdk.Tx) math.Int {
+				cosmosTxFee, ok := tx.(sdk.FeeTx)
+				if !ok {
+					return math.ZeroInt()
+				}
+				found, coin := cosmosTxFee.GetFee().Find(blockchain.GetCoinDenom())
+				if !found {
+					return math.ZeroInt()
+				}
 
-			return gasPrice
-		},
-		Compare: func(a, b math.Int) int {
-			return a.BigInt().Cmp(b.BigInt())
-		},
-		MinValue: math.ZeroInt(),
+				gasPrice := coin.Amount.Quo(math.NewIntFromUint64(cosmosTxFee.GetGas()))
+
+				return gasPrice
+			},
+			Compare: func(a, b math.Int) int {
+				return a.BigInt().Cmp(b.BigInt())
+			},
+			MinValue: math.ZeroInt(),
+		}
 	}
 
 	txReplacement := func(oldPriority, newPriority math.Int, oldTx, newTx sdk.Tx) bool {
-		// tx is being replaced, we need to drop the tx that is going to be removed
-		// from the reap list. we assume that the tx doing the replacing has
-		// already been inserted into the reaplist via the insert.
-		reapList.DropCosmosTx(oldTx)
+		// start by assuming we are going to replace oldTx with newTx
+		shouldReplace := true
+
+		if defaultConfig != nil && defaultConfig.TxReplacement != nil {
+			// if the default config has a custom TxReplacement function, call
+			// that to determine if we should replace oldTx for newTx
+			shouldReplace = defaultConfig.TxReplacement(oldPriority, newPriority, oldTx, newTx)
+		}
+
+		if shouldReplace {
+			// tx is being replaced, we need to drop the tx that is going to be removed
+			// from the reap list. we assume that the tx doing the replacing has
+			// already been inserted into the reaplist via the insert.
+			reapList.DropCosmosTx(oldTx)
+		}
 		return true
 	}
+	config.TxReplacement = txReplacement
 
-	return &sdkmempool.PriorityNonceMempoolConfig[math.Int]{
-		TxPriority:    txPriority,
-		TxReplacement: txReplacement,
-	}
+	config.MaxTx = maxTxs
+	return config
 }

--- a/mempool/recheck_pool.go
+++ b/mempool/recheck_pool.go
@@ -123,9 +123,9 @@ func NewRecheckMempool(
 	reapList *reaplist.ReapList,
 	blockchain *Blockchain,
 ) *RecheckMempool {
-	priorityMempoolConfg := cosmosPoolConfig(reapList, blockchain, defaultCosmosPoolConfig, maxTxs)
+	priorityMempoolConfig := cosmosPoolConfig(reapList, blockchain, defaultCosmosPoolConfig, maxTxs)
 	return &RecheckMempool{
-		ExtMempool:      sdkmempool.NewPriorityMempool(priorityMempoolConfg),
+		ExtMempool:      sdkmempool.NewPriorityMempool(priorityMempoolConfig),
 		reserver:        reserver,
 		rechecker:       rechecker,
 		blockchain:      blockchain,
@@ -591,8 +591,7 @@ func cosmosPoolConfig(
 		}
 	}
 
-	txReplacement := func(oldPriority, newPriority math.Int, oldTx, newTx sdk.Tx) bool {
-		// start by assuming we are going to replace oldTx with newTx
+	config.TxReplacement = func(oldPriority, newPriority math.Int, oldTx, newTx sdk.Tx) bool {
 		shouldReplace := true
 
 		if defaultConfig != nil && defaultConfig.TxReplacement != nil {
@@ -609,7 +608,6 @@ func cosmosPoolConfig(
 		}
 		return shouldReplace
 	}
-	config.TxReplacement = txReplacement
 
 	config.MaxTx = maxTxs
 	return config

--- a/mempool/recheck_pool_test.go
+++ b/mempool/recheck_pool_test.go
@@ -117,13 +117,6 @@ func newTestReapList() *reaplist.ReapList {
 	return reaplist.New(testTxEncoder{})
 }
 
-// ensureEVMChainConfig initializes the global EVM chain config / coin info
-// needed by *Blockchain.CurrentBlock() when a test exercises that path.
-// Safe to call from multiple tests (ResetTestConfig clears prior state).
-func ensureEVMChainConfig(t *testing.T) {
-	t.Helper()
-}
-
 // testHeader creates a minimal header for testing with the given height.
 func testHeader(height int64) *ethtypes.Header {
 	return &ethtypes.Header{

--- a/mempool/recheck_pool_test.go
+++ b/mempool/recheck_pool_test.go
@@ -14,13 +14,18 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
 
 	"github.com/cosmos/evm/crypto/ethsecp256k1"
 	"github.com/cosmos/evm/mempool"
 	"github.com/cosmos/evm/mempool/internal/heightsync"
+	"github.com/cosmos/evm/mempool/internal/reaplist"
+	"github.com/cosmos/evm/mempool/mocks"
 	"github.com/cosmos/evm/mempool/reserver"
+	"github.com/cosmos/evm/testutil/constants"
+	vmtypes "github.com/cosmos/evm/x/vm/types"
 
 	"cosmossdk.io/log/v2"
 	sdkmath "cosmossdk.io/math"
@@ -68,33 +73,55 @@ func (m *mockRechecker) Update(ctx sdk.Context, _ *ethtypes.Header) {
 }
 
 // ----------------------------------------------------------------------------
-// Mock ContextProvider
+// Test Blockchain
 // ----------------------------------------------------------------------------
 
-// mockContextProvider implements ContextProvider for unit tests.
-type mockContextProvider struct {
-	ctx          sdk.Context
-	getContextFn func() (sdk.Context, error)
-	ctxErr       error
+// newTestBlockchain creates a minimal *mempool.Blockchain for recheck-pool
+// tests. GetLatestContext() returns the supplied ctx.
+func newTestBlockchain(t *testing.T, ctx sdk.Context) *mempool.Blockchain {
+	t.Helper()
+	return newTestBlockchainWithGetter(t, func(_ int64, _ bool) (sdk.Context, error) {
+		return ctx, nil
+	})
 }
 
-func newMockContextProvider(ctx sdk.Context) *mockContextProvider {
-	return &mockContextProvider{ctx: ctx}
+// newTestBlockchainWithGetter lets a test control the behavior of the ctx
+// callback (e.g., to simulate failures or return different contexts over
+// time).
+func newTestBlockchainWithGetter(t *testing.T, getCtx func(int64, bool) (sdk.Context, error)) *mempool.Blockchain {
+	t.Helper()
+	vmKeeper := mocks.NewVMKeeperI(t)
+	feeMarketKeeper := mocks.NewFeeMarketKeeper(t)
+	vmKeeper.On("GetBaseFee", mock.Anything).Return(big.NewInt(0)).Maybe()
+	vmKeeper.On("GetEvmCoinInfo", mock.Anything).
+		Return(vmtypes.EvmCoinInfo{Denom: recheckTestFeeDenom}).Maybe()
+	feeMarketKeeper.On("GetBlockGasWanted", mock.Anything).Return(uint64(0)).Maybe()
+	return mempool.NewBlockchain(getCtx, log.NewNopLogger(), vmKeeper, feeMarketKeeper, 30_000_000)
 }
 
-func (m *mockContextProvider) GetLatestContext() (sdk.Context, error) {
-	if m.ctxErr != nil {
-		return sdk.Context{}, m.ctxErr
-	}
-	if m.getContextFn != nil {
-		return m.getContextFn()
-	}
-	ctx, _ := m.ctx.CacheContext()
-	return ctx, nil
+// ----------------------------------------------------------------------------
+// Test ReapList + Encoder
+// ----------------------------------------------------------------------------
+
+type testTxEncoder struct{}
+
+func (testTxEncoder) EVMTx(tx *ethtypes.Transaction) ([]byte, error) {
+	return tx.Hash().Bytes(), nil
 }
 
-func (m *mockContextProvider) CurrentBlock() *ethtypes.Header {
-	return &ethtypes.Header{Number: big.NewInt(10)}
+func (testTxEncoder) CosmosTx(tx sdk.Tx) ([]byte, error) {
+	return []byte(fmt.Sprintf("%p", tx)), nil
+}
+
+func newTestReapList() *reaplist.ReapList {
+	return reaplist.New(testTxEncoder{})
+}
+
+// ensureEVMChainConfig initializes the global EVM chain config / coin info
+// needed by *Blockchain.CurrentBlock() when a test exercises that path.
+// Safe to call from multiple tests (ResetTestConfig clears prior state).
+func ensureEVMChainConfig(t *testing.T) {
+	t.Helper()
 }
 
 // testHeader creates a minimal header for testing with the given height.
@@ -114,7 +141,6 @@ func TestRecheckMempool_Insert(t *testing.T) {
 		name          string
 		setupReserver func(*reserver.ReservationTracker, common.Address)
 		anteErr       error
-		poolInsertErr error
 		expectErr     error
 		expectCount   int
 		expectHeld    bool
@@ -142,13 +168,6 @@ func TestRecheckMempool_Insert(t *testing.T) {
 			expectCount: 0,
 			expectHeld:  false,
 		},
-		{
-			name:          "pool insert failure releases reservation",
-			poolInsertErr: errors.New("pool full"),
-			expectErr:     errors.New("pool full"),
-			expectCount:   0,
-			expectHeld:    false,
-		},
 	}
 
 	for _, tc := range tests {
@@ -161,8 +180,6 @@ func TestRecheckMempool_Insert(t *testing.T) {
 				tc.setupReserver(tracker, acc.address)
 			}
 
-			pool := &recheckMockPool{insertErr: tc.poolInsertErr}
-
 			anteHandler := func(ctx sdk.Context, tx sdk.Tx, _ bool) (sdk.Context, error) {
 				if tc.anteErr != nil {
 					return sdk.Context{}, tc.anteErr
@@ -171,10 +188,13 @@ func TestRecheckMempool_Insert(t *testing.T) {
 			}
 
 			ctx := newRecheckTestContext()
-			bc := newMockContextProvider(ctx)
+			bc := newTestBlockchain(t, ctx)
 			rc := newMockRechecker(ctx, anteHandler)
 
-			mp := mempool.NewRecheckMempool(log.NewNopLogger(), pool, handle, rc, newTestRecheckedTxs(), bc)
+			mp := mempool.NewRecheckMempool(
+				log.NewNopLogger(), nil, 0, handle, rc,
+				newTestRecheckedTxs(), newTestReapList(), bc,
+			)
 
 			tx := newRecheckTestTx(t, acc.key)
 			err := mp.Insert(ctx, tx)
@@ -199,63 +219,76 @@ func TestRecheckMempool_Insert(t *testing.T) {
 	}
 }
 
+func TestRecheckMempool_Insert_PoolCapacity(t *testing.T) {
+	tracker := reserver.NewReservationTracker()
+	handle := tracker.NewHandle(1)
+
+	ctx := newRecheckTestContext()
+	bc := newTestBlockchain(t, ctx)
+	rc := newMockRechecker(ctx, noopAnteHandler)
+
+	maxTxs := 1
+	mp := mempool.NewRecheckMempool(
+		log.NewNopLogger(), nil, maxTxs, handle, rc,
+		newTestRecheckedTxs(), newTestReapList(), bc,
+	)
+
+	firstAcc := newRecheckTestAccount(t)
+	require.NoError(t, mp.Insert(ctx, newRecheckTestTx(t, firstAcc.key)))
+
+	secondAcc := newRecheckTestAccount(t)
+	err := mp.Insert(ctx, newRecheckTestTx(t, secondAcc.key))
+	require.Error(t, err)
+
+	// Second signer should not remain reserved after failed insert.
+	otherHandle := tracker.NewHandle(2)
+	require.False(t, otherHandle.Has(secondAcc.address))
+	require.True(t, otherHandle.Has(firstAcc.address))
+}
+
 func TestRecheckMempool_Remove(t *testing.T) {
-	tests := []struct {
-		name       string
-		poolErr    error
-		expectErr  bool
-		expectHeld bool
-	}{
-		{
-			name:       "success releases reservation",
-			expectErr:  false,
-			expectHeld: false,
-		},
-		{
-			name:       "pool error does not release",
-			poolErr:    errors.New("tx not found"),
-			expectErr:  true,
-			expectHeld: true,
-		},
-	}
+	acc := newRecheckTestAccount(t)
+	tracker := reserver.NewReservationTracker()
+	handle := tracker.NewHandle(1)
 
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			acc := newRecheckTestAccount(t)
-			tracker := reserver.NewReservationTracker()
-			handle := tracker.NewHandle(1)
+	ctx := newRecheckTestContext()
+	bc := newTestBlockchain(t, ctx)
+	rc := newMockRechecker(ctx, noopAnteHandler)
 
-			pool := &recheckMockPool{}
-			ctx := newRecheckTestContext()
-			bc := newMockContextProvider(ctx)
-			rc := newMockRechecker(ctx, noopAnteHandler)
+	mp := mempool.NewRecheckMempool(
+		log.NewNopLogger(), nil, 0, handle, rc,
+		newTestRecheckedTxs(), newTestReapList(), bc,
+	)
 
-			mp := mempool.NewRecheckMempool(log.NewNopLogger(), pool, handle, rc, newTestRecheckedTxs(), bc)
+	tx := newRecheckTestTx(t, acc.key)
+	require.NoError(t, mp.Insert(ctx, tx))
 
-			tx := newRecheckTestTx(t, acc.key)
-			require.NoError(t, mp.Insert(ctx, tx))
+	otherHandle := tracker.NewHandle(2)
+	require.True(t, otherHandle.Has(acc.address), "address should be reserved after insert")
 
-			otherHandle := tracker.NewHandle(2)
-			require.True(t, otherHandle.Has(acc.address), "address should be reserved after insert")
+	require.NoError(t, mp.Remove(tx))
+	require.False(t, otherHandle.Has(acc.address), "address should not be reserved after remove")
+}
 
-			if tc.poolErr != nil {
-				pool.removeErr = tc.poolErr
-			}
+func TestRecheckMempool_Remove_NotInPool(t *testing.T) {
+	acc := newRecheckTestAccount(t)
+	tracker := reserver.NewReservationTracker()
+	handle := tracker.NewHandle(1)
 
-			err := mp.Remove(tx)
-			if tc.expectErr {
-				require.Error(t, err)
-			} else {
-				require.NoError(t, err)
-			}
+	ctx := newRecheckTestContext()
+	bc := newTestBlockchain(t, ctx)
+	rc := newMockRechecker(ctx, noopAnteHandler)
 
-			if tc.expectHeld {
-				require.True(t, otherHandle.Has(acc.address))
-			} else {
-				require.False(t, otherHandle.Has(acc.address))
-			}
-		})
-	}
+	mp := mempool.NewRecheckMempool(
+		log.NewNopLogger(), nil, 0, handle, rc,
+		newTestRecheckedTxs(), newTestReapList(), bc,
+	)
+
+	err := mp.Remove(newRecheckTestTx(t, acc.key))
+	require.Error(t, err)
+
+	otherHandle := tracker.NewHandle(2)
+	require.False(t, otherHandle.Has(acc.address))
 }
 
 // ----------------------------------------------------------------------------
@@ -265,12 +298,14 @@ func TestRecheckMempool_Remove(t *testing.T) {
 func TestRecheckMempool_StartClose(t *testing.T) {
 	tracker := reserver.NewReservationTracker()
 	handle := tracker.NewHandle(1)
-	pool := &recheckMockPool{}
 	ctx := newRecheckTestContext()
-	bc := newMockContextProvider(ctx)
+	bc := newTestBlockchain(t, ctx)
 	rc := newMockRechecker(ctx, noopAnteHandler)
 
-	mp := mempool.NewRecheckMempool(log.NewNopLogger(), pool, handle, rc, newTestRecheckedTxs(), bc)
+	mp := mempool.NewRecheckMempool(
+		log.NewNopLogger(), nil, 0, handle, rc,
+		newTestRecheckedTxs(), newTestReapList(), bc,
+	)
 
 	mp.Start(testHeader(0))
 
@@ -290,12 +325,14 @@ func TestRecheckMempool_StartClose(t *testing.T) {
 func TestRecheckMempool_CloseIdempotent(t *testing.T) {
 	tracker := reserver.NewReservationTracker()
 	handle := tracker.NewHandle(1)
-	pool := &recheckMockPool{}
 	ctx := newRecheckTestContext()
-	bc := newMockContextProvider(ctx)
+	bc := newTestBlockchain(t, ctx)
 	rc := newMockRechecker(ctx, noopAnteHandler)
 
-	mp := mempool.NewRecheckMempool(log.NewNopLogger(), pool, handle, rc, newTestRecheckedTxs(), bc)
+	mp := mempool.NewRecheckMempool(
+		log.NewNopLogger(), nil, 0, handle, rc,
+		newTestRecheckedTxs(), newTestReapList(), bc,
+	)
 	mp.Start(testHeader(0))
 
 	require.NoError(t, mp.Close())
@@ -305,12 +342,14 @@ func TestRecheckMempool_CloseIdempotent(t *testing.T) {
 func TestRecheckMempool_TriggerRecheckAfterShutdown(t *testing.T) {
 	tracker := reserver.NewReservationTracker()
 	handle := tracker.NewHandle(1)
-	pool := &recheckMockPool{}
 	ctx := newRecheckTestContext()
-	bc := newMockContextProvider(ctx)
+	bc := newTestBlockchain(t, ctx)
 	rc := newMockRechecker(ctx, noopAnteHandler)
 
-	mp := mempool.NewRecheckMempool(log.NewNopLogger(), pool, handle, rc, newTestRecheckedTxs(), bc)
+	mp := mempool.NewRecheckMempool(
+		log.NewNopLogger(), nil, 0, handle, rc,
+		newTestRecheckedTxs(), newTestReapList(), bc,
+	)
 	mp.Start(testHeader(0))
 	require.NoError(t, mp.Close())
 
@@ -330,9 +369,8 @@ func TestRecheckMempool_TriggerRecheckAfterShutdown(t *testing.T) {
 func TestRecheckMempool_ShutdownDuringRecheck(t *testing.T) {
 	tracker := reserver.NewReservationTracker()
 	handle := tracker.NewHandle(1)
-	pool := &recheckMockPool{}
 	ctx := newRecheckTestContext()
-	bc := newMockContextProvider(ctx)
+	bc := newTestBlockchain(t, ctx)
 
 	gate := make(chan struct{})
 	ready := make(chan struct{}) // signals when ante handler is waiting
@@ -352,7 +390,10 @@ func TestRecheckMempool_ShutdownDuringRecheck(t *testing.T) {
 
 	rc := newMockRechecker(ctx, anteHandler)
 
-	mp := mempool.NewRecheckMempool(log.NewNopLogger(), pool, handle, rc, newTestRecheckedTxs(), bc)
+	mp := mempool.NewRecheckMempool(
+		log.NewNopLogger(), nil, 0, handle, rc,
+		newTestRecheckedTxs(), newTestReapList(), bc,
+	)
 	mp.Start(testHeader(0))
 
 	for range numTxsToInsert {
@@ -400,66 +441,35 @@ func TestRecheckMempool_ShutdownDuringRecheck(t *testing.T) {
 func TestRecheckMempool_GetCtxError(t *testing.T) {
 	tracker := reserver.NewReservationTracker()
 	handle := tracker.NewHandle(1)
-	pool := &recheckMockPool{}
 	ctx := newRecheckTestContext()
 
-	// Blockchain that returns an error from GetLatestContext
-	bc := newMockContextProvider(ctx)
-	bc.ctxErr = errors.New("context unavailable")
-
+	// Blockchain with a switchable ctx getter — healthy during insert,
+	// failing once we flip the flag before triggering recheck.
+	var getCtxFail atomic.Bool
+	bc := newTestBlockchainWithGetter(t, func(_ int64, _ bool) (sdk.Context, error) {
+		if getCtxFail.Load() {
+			return sdk.Context{}, errors.New("context unavailable")
+		}
+		return ctx, nil
+	})
 	rc := newMockRechecker(ctx, noopAnteHandler)
 
-	mp := mempool.NewRecheckMempool(log.NewNopLogger(), pool, handle, rc, newTestRecheckedTxs(), bc)
+	mp := mempool.NewRecheckMempool(
+		log.NewNopLogger(), nil, 0, handle, rc,
+		newTestRecheckedTxs(), newTestReapList(), bc,
+	)
 	mp.Start(testHeader(0))
 	defer mp.Close()
 
 	acc := newRecheckTestAccount(t)
 	tx := newRecheckTestTx(t, acc.key)
-
-	// Use a separate mempool to insert the tx (which shares the same underlying pool)
-	insertBc := newMockContextProvider(ctx)
-	insertRc := newMockRechecker(ctx, noopAnteHandler)
-	insertMp := mempool.NewRecheckMempool(log.NewNopLogger(), pool, handle, insertRc, newTestRecheckedTxs(), insertBc)
-	require.NoError(t, insertMp.Insert(ctx, tx))
-
+	require.NoError(t, mp.Insert(ctx, tx))
 	require.Equal(t, 1, mp.CountTx())
 
+	getCtxFail.Store(true)
 	mp.TriggerRecheckSync(testHeader(1))
 
 	require.Equal(t, 1, mp.CountTx(), "tx should remain when getCtx fails")
-}
-
-func TestRecheckMempool_RemoveErrorDuringRecheck(t *testing.T) {
-	acc := newRecheckTestAccount(t)
-	tracker := reserver.NewReservationTracker()
-	handle := tracker.NewHandle(1)
-	pool := &recheckMockPool{}
-	ctx := newRecheckTestContext()
-	bc := newMockContextProvider(ctx)
-
-	failOnRecheck := false
-	anteHandler := func(ctx sdk.Context, tx sdk.Tx, _ bool) (sdk.Context, error) {
-		if failOnRecheck {
-			return sdk.Context{}, errors.New("recheck failed")
-		}
-		return ctx, nil
-	}
-
-	rc := newMockRechecker(ctx, anteHandler)
-
-	mp := mempool.NewRecheckMempool(log.NewNopLogger(), pool, handle, rc, newTestRecheckedTxs(), bc)
-	mp.Start(testHeader(0))
-	defer mp.Close()
-
-	tx := newRecheckTestTx(t, acc.key)
-	require.NoError(t, mp.Insert(ctx, tx))
-
-	failOnRecheck = true
-	pool.removeErr = errors.New("remove failed")
-
-	mp.TriggerRecheckSync(testHeader(1))
-
-	require.Equal(t, 1, mp.CountTx(), "tx remains when remove fails")
 }
 
 // ----------------------------------------------------------------------------
@@ -469,12 +479,14 @@ func TestRecheckMempool_RemoveErrorDuringRecheck(t *testing.T) {
 func TestRecheckMempool_ConcurrentTriggers(t *testing.T) {
 	tracker := reserver.NewReservationTracker()
 	handle := tracker.NewHandle(1)
-	pool := &recheckMockPool{}
 	ctx := newRecheckTestContext()
-	bc := newMockContextProvider(ctx)
+	bc := newTestBlockchain(t, ctx)
 	rc := newMockRechecker(ctx, noopAnteHandler)
 
-	mp := mempool.NewRecheckMempool(log.NewNopLogger(), pool, handle, rc, newTestRecheckedTxs(), bc)
+	mp := mempool.NewRecheckMempool(
+		log.NewNopLogger(), nil, 0, handle, rc,
+		newTestRecheckedTxs(), newTestReapList(), bc,
+	)
 	mp.Start(testHeader(0))
 	defer mp.Close()
 
@@ -711,9 +723,8 @@ func TestRecheckMempool_RecheckedTxs(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			tracker := reserver.NewReservationTracker()
 			handle := tracker.NewHandle(1)
-			pool := &recheckMockPool{}
 			ctx := newRecheckTestContext()
-			bc := newMockContextProvider(ctx)
+			bc := newTestBlockchain(t, ctx)
 			recheckedTxs := newTestRecheckedTxs()
 
 			failSet := make(map[sdk.Tx]bool)
@@ -727,7 +738,10 @@ func TestRecheckMempool_RecheckedTxs(t *testing.T) {
 
 			rc := newMockRechecker(ctx, anteHandler)
 
-			mp := mempool.NewRecheckMempool(log.NewNopLogger(), pool, handle, rc, recheckedTxs, bc)
+			mp := mempool.NewRecheckMempool(
+				log.NewNopLogger(), nil, 0, handle, rc,
+				recheckedTxs, newTestReapList(), bc,
+			)
 			mp.Start(testHeader(0))
 			defer mp.Close()
 
@@ -786,13 +800,15 @@ func TestRecheckMempool_RecheckedTxsReset(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			tracker := reserver.NewReservationTracker()
 			handle := tracker.NewHandle(1)
-			pool := &recheckMockPool{}
 			ctx := newRecheckTestContext()
-			bc := newMockContextProvider(ctx)
+			bc := newTestBlockchain(t, ctx)
 			recheckedTxs := newTestRecheckedTxs()
 			rc := newMockRechecker(ctx, noopAnteHandler)
 
-			mp := mempool.NewRecheckMempool(log.NewNopLogger(), pool, handle, rc, recheckedTxs, bc)
+			mp := mempool.NewRecheckMempool(
+				log.NewNopLogger(), nil, 0, handle, rc,
+				recheckedTxs, newTestReapList(), bc,
+			)
 			mp.Start(testHeader(0))
 			defer mp.Close()
 
@@ -837,9 +853,8 @@ func TestRecheckMempool_RecheckedTxsBlocksUntilComplete(t *testing.T) {
 	acc := newRecheckTestAccount(t)
 	tracker := reserver.NewReservationTracker()
 	handle := tracker.NewHandle(1)
-	pool := &recheckMockPool{}
 	ctx := newRecheckTestContext()
-	bc := newMockContextProvider(ctx)
+	bc := newTestBlockchain(t, ctx)
 	recheckedTxs := newTestRecheckedTxs()
 
 	var callCount atomic.Int32
@@ -854,7 +869,10 @@ func TestRecheckMempool_RecheckedTxsBlocksUntilComplete(t *testing.T) {
 
 	rc := newMockRechecker(ctx, anteHandler)
 
-	mp := mempool.NewRecheckMempool(log.NewNopLogger(), pool, handle, rc, recheckedTxs, bc)
+	mp := mempool.NewRecheckMempool(
+		log.NewNopLogger(), nil, 0, handle, rc,
+		recheckedTxs, newTestReapList(), bc,
+	)
 	mp.Start(testHeader(0))
 	defer mp.Close()
 
@@ -893,19 +911,29 @@ func TestRecheckMempool_RecheckedTxsBlocksUntilComplete(t *testing.T) {
 }
 
 func TestRecheckMempool_RecheckerNoContextOnInsert(t *testing.T) {
+	// setup mocks for blockchain fetching latest block
+	vmtypes.NewEVMConfigurator().ResetTestConfig()
+	require.NoError(t, vmtypes.SetChainConfig(vmtypes.DefaultChainConfig(constants.EighteenDecimalsChainID)))
+	require.NoError(t, vmtypes.NewEVMConfigurator().
+		WithEVMCoinInfo(constants.ChainsCoinInfo[constants.EighteenDecimalsChainID]).
+		Configure())
+
 	acc := newRecheckTestAccount(t)
 	tracker := reserver.NewReservationTracker()
 	handle := tracker.NewHandle(1)
-	pool := &recheckMockPool{}
 
-	// context provided has a valid context ready
+	// blockchain has a valid context ready
 	ctx := newRecheckTestContext()
-	bc := newMockContextProvider(ctx)
+	bc := newTestBlockchain(t, ctx)
+
 	// rechecker does not have a valid context
 	rc := newMockRechecker(sdk.Context{}, noopAnteHandler)
 
 	recheckedTxs := newTestRecheckedTxs()
-	mp := mempool.NewRecheckMempool(log.NewNopLogger(), pool, handle, rc, recheckedTxs, bc)
+	mp := mempool.NewRecheckMempool(
+		log.NewNopLogger(), nil, 0, handle, rc,
+		recheckedTxs, newTestReapList(), bc,
+	)
 
 	tx := newRecheckTestTx(t, acc.key)
 	require.NoError(t, mp.Insert(ctx, tx))
@@ -967,11 +995,13 @@ func TestRecheckMempool_InsertSequentialNonces(t *testing.T) {
 	ctx := newRecheckTestContext()
 	tracker := reserver.NewReservationTracker()
 	handle := tracker.NewHandle(1)
-	pool := &recheckMockPool{}
-	bc := newMockContextProvider(ctx)
+	bc := newTestBlockchain(t, ctx)
 	rc := newMockRechecker(ctx, newNonceTrackingAnteHandler())
 
-	mp := mempool.NewRecheckMempool(log.NewNopLogger(), pool, handle, rc, newTestRecheckedTxs(), bc)
+	mp := mempool.NewRecheckMempool(
+		log.NewNopLogger(), nil, 0, handle, rc,
+		newTestRecheckedTxs(), newTestReapList(), bc,
+	)
 
 	key, err := crypto.GenerateKey()
 	require.NoError(t, err)
@@ -990,11 +1020,13 @@ func TestRecheckMempool_InsertNonceGapFails(t *testing.T) {
 	ctx := newRecheckTestContext()
 	tracker := reserver.NewReservationTracker()
 	handle := tracker.NewHandle(1)
-	pool := &recheckMockPool{}
-	bc := newMockContextProvider(ctx)
+	bc := newTestBlockchain(t, ctx)
 	rc := newMockRechecker(ctx, newNonceTrackingAnteHandler())
 
-	mp := mempool.NewRecheckMempool(log.NewNopLogger(), pool, handle, rc, newTestRecheckedTxs(), bc)
+	mp := mempool.NewRecheckMempool(
+		log.NewNopLogger(), nil, 0, handle, rc,
+		newTestRecheckedTxs(), newTestReapList(), bc,
+	)
 
 	key, err := crypto.GenerateKey()
 	require.NoError(t, err)
@@ -1014,14 +1046,16 @@ func TestRecheckMempool_InsertAfterRecheck(t *testing.T) {
 	ctx := newRecheckTestContext()
 	tracker := reserver.NewReservationTracker()
 	handle := tracker.NewHandle(1)
-	pool := &recheckMockPool{}
-	bc := newMockContextProvider(ctx)
+	bc := newTestBlockchain(t, ctx)
 
 	// The nonce tracker is shared across insert and recheck calls.
 	// After recheck re-validates nonces 0 and 1, the tracker expects 2 next.
 	rc := newMockRechecker(ctx, newNonceTrackingAnteHandler())
 
-	mp := mempool.NewRecheckMempool(log.NewNopLogger(), pool, handle, rc, newTestRecheckedTxs(), bc)
+	mp := mempool.NewRecheckMempool(
+		log.NewNopLogger(), nil, 0, handle, rc,
+		newTestRecheckedTxs(), newTestReapList(), bc,
+	)
 	mp.Start(testHeader(0))
 	defer mp.Close()
 
@@ -1048,12 +1082,14 @@ func TestRecheckMempool_InsertReplacementInvalidatesRechecked(t *testing.T) {
 	ctx := newRecheckTestContext()
 	tracker := reserver.NewReservationTracker()
 	handle := tracker.NewHandle(1)
-	pool := &recheckMockPool{}
-	bc := newMockContextProvider(ctx)
+	bc := newTestBlockchain(t, ctx)
 	rc := newMockRechecker(ctx, noopAnteHandler)
 	recheckedTxs := newTestRecheckedTxs()
 
-	mp := mempool.NewRecheckMempool(log.NewNopLogger(), pool, handle, rc, recheckedTxs, bc)
+	mp := mempool.NewRecheckMempool(
+		log.NewNopLogger(), nil, 0, handle, rc,
+		recheckedTxs, newTestReapList(), bc,
+	)
 	mp.Start(testHeader(0))
 	t.Cleanup(func() {
 		require.NoError(t, mp.Close())
@@ -1081,14 +1117,14 @@ func TestRecheckMempool_InsertReplacementInvalidatesRechecked(t *testing.T) {
 	require.Equal(t, 1, mp.CountTx())
 }
 
-func TestRecheckMempool_RecheckRebuildsSnapshotAfterReplacement(t *testing.T) {
-	ctx := newRecheckTestContext()
-	tracker := reserver.NewReservationTracker()
-	handle := tracker.NewHandle(1)
-	pool := sdkmempool.NewPriorityMempool(sdkmempool.PriorityNonceMempoolConfig[sdkmath.Int]{
+// customReplacementConfig returns a PriorityNonceMempoolConfig whose
+// TxReplacement allows replacement only when the new priority beats the old.
+// Used by tests that exercise replacement behavior without relying on the
+// default (reap-list-dropping) config.
+func customReplacementConfig() *sdkmempool.PriorityNonceMempoolConfig[sdkmath.Int] {
+	return &sdkmempool.PriorityNonceMempoolConfig[sdkmath.Int]{
 		TxPriority: sdkmempool.TxPriority[sdkmath.Int]{
-			GetTxPriority: func(goCtx context.Context, tx sdk.Tx) sdkmath.Int {
-				_ = sdk.UnwrapSDKContext(goCtx)
+			GetTxPriority: func(_ context.Context, tx sdk.Tx) sdkmath.Int {
 				cosmosTxFee, ok := tx.(sdk.FeeTx)
 				if !ok {
 					return sdkmath.ZeroInt()
@@ -1097,9 +1133,7 @@ func TestRecheckMempool_RecheckRebuildsSnapshotAfterReplacement(t *testing.T) {
 				if !found {
 					return sdkmath.ZeroInt()
 				}
-
-				gasPrice := coin.Amount.Quo(sdkmath.NewIntFromUint64(cosmosTxFee.GetGas()))
-				return gasPrice
+				return coin.Amount.Quo(sdkmath.NewIntFromUint64(cosmosTxFee.GetGas()))
 			},
 			Compare: func(a, b sdkmath.Int) int {
 				return a.BigInt().Cmp(b.BigInt())
@@ -1109,12 +1143,21 @@ func TestRecheckMempool_RecheckRebuildsSnapshotAfterReplacement(t *testing.T) {
 		TxReplacement: func(op, np sdkmath.Int, _ sdk.Tx, _ sdk.Tx) bool {
 			return np.GT(op)
 		},
-	})
-	bc := newMockContextProvider(ctx)
+	}
+}
+
+func TestRecheckMempool_RecheckRebuildsSnapshotAfterReplacement(t *testing.T) {
+	ctx := newRecheckTestContext()
+	tracker := reserver.NewReservationTracker()
+	handle := tracker.NewHandle(1)
+	bc := newTestBlockchain(t, ctx)
 	rc := newMockRechecker(ctx, noopAnteHandler)
 	recheckedTxs := newTestRecheckedTxs()
 
-	mp := mempool.NewRecheckMempool(log.NewNopLogger(), pool, handle, rc, recheckedTxs, bc)
+	mp := mempool.NewRecheckMempool(
+		log.NewNopLogger(), customReplacementConfig(), 0, handle, rc,
+		recheckedTxs, newTestReapList(), bc,
+	)
 	mp.Start(testHeader(0))
 	t.Cleanup(func() {
 		require.NoError(t, mp.Close())
@@ -1146,6 +1189,96 @@ func TestRecheckMempool_RecheckRebuildsSnapshotAfterReplacement(t *testing.T) {
 	iter = mp.RecheckedTxs(context.Background(), big.NewInt(1))
 	rechecked = collectIteratorTxs(iter)
 	require.Equal(t, []sdk.Tx{tx3, replacement, tx5, tx6}, rechecked)
+}
+
+// TestRecheckMempool_RecheckDropsFromReapList verifies that when a tx fails
+// recheck and gets removed from the pool, it is also dropped from the reap
+// list. Txs that pass recheck must remain reapable.
+func TestRecheckMempool_RecheckDropsFromReapList(t *testing.T) {
+	ctx := newRecheckTestContext()
+	tracker := reserver.NewReservationTracker()
+	handle := tracker.NewHandle(1)
+	bc := newTestBlockchain(t, ctx)
+	reapList := newTestReapList()
+
+	failSet := make(map[sdk.Tx]bool)
+	anteHandler := func(ctx sdk.Context, tx sdk.Tx, _ bool) (sdk.Context, error) {
+		if failSet[tx] {
+			return sdk.Context{}, errors.New("recheck failed")
+		}
+		return ctx, nil
+	}
+	rc := newMockRechecker(ctx, anteHandler)
+
+	mp := mempool.NewRecheckMempool(
+		log.NewNopLogger(), nil, 0, handle, rc,
+		newTestRecheckedTxs(), reapList, bc,
+	)
+	mp.Start(testHeader(0))
+	t.Cleanup(func() { require.NoError(t, mp.Close()) })
+
+	// Three txs from independent signers: keepA, doomed, keepB.
+	keepA := newRecheckTestTx(t, mustGenKey(t))
+	doomed := newRecheckTestTx(t, mustGenKey(t))
+	keepB := newRecheckTestTx(t, mustGenKey(t))
+
+	for _, tx := range []sdk.Tx{keepA, doomed, keepB} {
+		require.NoError(t, mp.Insert(ctx, tx))
+	}
+
+	// Flip the doomed tx to fail on recheck.
+	failSet[doomed] = true
+	mp.TriggerRecheckSync(testHeader(1))
+
+	require.Equal(t, 2, mp.CountTx(), "failed tx should be removed from pool")
+
+	reaped := reapList.Reap(0, 0)
+	require.Len(t, reaped, 2, "doomed tx's bytes should also be dropped from reap list")
+
+	enc := testTxEncoder{}
+	doomedBytes, _ := enc.CosmosTx(doomed)
+	for _, b := range reaped {
+		require.NotEqual(t, doomedBytes, b, "doomed tx bytes should not appear in reap list")
+	}
+}
+
+func mustGenKey(t *testing.T) *ecdsa.PrivateKey {
+	t.Helper()
+	k, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	return k
+}
+
+func TestRecheckMempool_ReplacementDropsFromReapList(t *testing.T) {
+	ctx := newRecheckTestContext()
+	tracker := reserver.NewReservationTracker()
+	handle := tracker.NewHandle(1)
+	bc := newTestBlockchain(t, ctx)
+	rc := newMockRechecker(ctx, noopAnteHandler)
+	reapList := newTestReapList()
+
+	mp := mempool.NewRecheckMempool(
+		log.NewNopLogger(), nil, 0, handle, rc,
+		newTestRecheckedTxs(), reapList, bc,
+	)
+
+	key, err := crypto.GenerateKey()
+	require.NoError(t, err)
+
+	original := newRecheckTestTxWithGasPrice(t, key, 5, 1)
+	require.NoError(t, mp.Insert(ctx, original))
+
+	// same sender + nonce, new gas price
+	replacement := newRecheckTestTxWithGasPrice(t, key, 5, 2)
+	require.NoError(t, mp.Insert(ctx, replacement))
+
+	require.Equal(t, 1, mp.CountTx(), "pool should hold exactly one tx after replacement")
+
+	reaped := reapList.Reap(0, 0)
+	require.Len(t, reaped, 1, "reap list should only hold the replacement")
+	expected, err := testTxEncoder{}.CosmosTx(replacement)
+	require.NoError(t, err)
+	require.Equal(t, expected, reaped[0])
 }
 
 // newRecheckTestTx creates a minimal sdk.Tx for unit testing RecheckMempool.
@@ -1217,94 +1350,6 @@ func (m *recheckTestTx) GetSignaturesV2() ([]signingtypes.SignatureV2, error) {
 			Sequence: m.sequence,
 		},
 	}, nil
-}
-
-// recheckMockPool is a simple in-memory ExtMempool for testing RecheckMempool in isolation.
-type recheckMockPool struct {
-	mu          sync.Mutex
-	txs         []sdk.Tx
-	insertErr   error
-	removeErr   error
-	insertDelay time.Duration
-}
-
-func (m *recheckMockPool) Insert(_ context.Context, tx sdk.Tx) error {
-	if m.insertDelay > 0 {
-		time.Sleep(m.insertDelay)
-	}
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	if m.insertErr != nil {
-		return m.insertErr
-	}
-	m.txs = append(m.txs, tx)
-	return nil
-}
-
-func (m *recheckMockPool) Remove(tx sdk.Tx) error {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	if m.removeErr != nil {
-		return m.removeErr
-	}
-	for i, t := range m.txs {
-		if t == tx {
-			m.txs = append(m.txs[:i], m.txs[i+1:]...)
-			return nil
-		}
-	}
-	return sdkmempool.ErrTxNotFound
-}
-
-func (m *recheckMockPool) RemoveWithReason(_ context.Context, tx sdk.Tx, _ sdkmempool.RemoveReason) error {
-	return m.Remove(tx)
-}
-
-func (m *recheckMockPool) Select(_ context.Context, _ [][]byte) sdkmempool.Iterator {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	if len(m.txs) == 0 {
-		return nil
-	}
-	return &recheckMockIterator{txs: append([]sdk.Tx{}, m.txs...), idx: 0}
-}
-
-func (m *recheckMockPool) SelectBy(_ context.Context, _ [][]byte, callback func(sdk.Tx) bool) {
-	m.mu.Lock()
-	txsCopy := append([]sdk.Tx{}, m.txs...)
-	m.mu.Unlock()
-
-	for _, tx := range txsCopy {
-		if !callback(tx) {
-			return
-		}
-	}
-}
-
-func (m *recheckMockPool) CountTx() int {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	return len(m.txs)
-}
-
-type recheckMockIterator struct {
-	txs []sdk.Tx
-	idx int
-}
-
-func (i *recheckMockIterator) Tx() sdk.Tx {
-	if i.idx >= len(i.txs) {
-		return nil
-	}
-	return i.txs[i.idx]
-}
-
-func (i *recheckMockIterator) Next() sdkmempool.Iterator {
-	i.idx++
-	if i.idx >= len(i.txs) {
-		return nil
-	}
-	return i
 }
 
 // recheckTestAccount holds test account data.


### PR DESCRIPTION
# Description

Addresses two places where cosmos txs would become permanently stuck in the `reaplist`.
* When they were dropped due to failing recheck during the `runRecheck` loop.
* When they were replaced by another tx with the same sender + nonce that arrived later. 
  * To do this we use the `TxReplacement` config function for the `PriorityNonceMempool` that is internal to the `RecheckPool`. Previously, the `RecheckPool` saw its internal mempool as an `ExtMempool` interface that was passed in as a dependency. However this meant that the `RecheckPool` had to rely on the caller to create it with a correct `TxReplacement` function in order for it to function properly. This felt off, so I moved the creation of the `PriorityNonceMempool` and its config into the constructor of the `RecheckPool`, only relying on the caller to pass in a default config, if any.

Closes: STACK-2450, STACK-1939

---

## Author Checklist

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.

I have...

- [ ] tackled an existing issue or discussed with a team member
- [ ] left instructions on how to review the changes
- [ ] targeted the `main` branch
