### PR TITLE
chore(tests): fix ibc tests failing with different balances

### DIFF
--- a/evmd/tests/ibc/ibc_middleware_test.go
+++ b/evmd/tests/ibc/ibc_middleware_test.go
@@ -386,7 +386,6 @@ func (suite *MiddlewareTestSuite) TestOnRecvPacketWithCallback() {
 			path = suite.path
 
 			ctxB := suite.chainB.GetContext()
-			evmCtx := suite.evmChainA.GetContext()
 			bondDenom, err := suite.chainB.GetSimApp().StakingKeeper.BondDenom(ctxB)
 			suite.Require().NoError(err)
 
@@ -447,12 +446,12 @@ func (suite *MiddlewareTestSuite) TestOnRecvPacketWithCallback() {
 			transferStack, ok := suite.evmChainA.App.GetIBCKeeper().PortKeeper.Route(transfertypes.ModuleName)
 			suite.Require().True(ok)
 
-			_, found := suite.evmChainA.App.GetIBCKeeper().ChannelKeeper.GetChannel(evmCtx, path.EndpointA.ChannelConfig.PortID, path.EndpointA.ChannelID)
+			_, found := suite.evmChainA.App.GetIBCKeeper().ChannelKeeper.GetChannel(suite.evmChainA.GetContext(), path.EndpointA.ChannelConfig.PortID, path.EndpointA.ChannelID)
 			suite.Require().True(found)
 
 			// Execute the packet
 			ack := transferStack.OnRecvPacket(
-				evmCtx,
+				suite.evmChainA.GetContext(),
 				sourceChan.Version,
 				packet,
 				suite.evmChainA.SenderAccount.GetAddress(),
@@ -468,19 +467,19 @@ func (suite *MiddlewareTestSuite) TestOnRecvPacketWithCallback() {
 			if tc.expError == "" {
 				suite.Require().True(ack.Success(), "Expected success but got failure")
 
-				balAfterCallback := evmApp.Erc20Keeper.BalanceOf(evmCtx, contracts.ERC20MinterBurnerDecimalsContract.ABI, erc20Contract, contractAddr)
+				balAfterCallback := evmApp.Erc20Keeper.BalanceOf(suite.evmChainA.GetContext(), contracts.ERC20MinterBurnerDecimalsContract.ABI, erc20Contract, contractAddr)
 				suite.Require().Equal(sendAmt.String(), balAfterCallback.String())
 
-				tokenPair, found := evmApp.Erc20Keeper.GetTokenPair(evmCtx, singleTokenRepresentation.GetID())
+				tokenPair, found := evmApp.Erc20Keeper.GetTokenPair(suite.evmChainA.GetContext(), singleTokenRepresentation.GetID())
 				suite.Require().True(found)
 				suite.Require().Equal(voucherDenom, tokenPair.Denom)
 
-				available := evmApp.Erc20Keeper.IsDynamicPrecompileAvailable(evmCtx, common.HexToAddress(tokenPair.Erc20Address))
+				available := evmApp.Erc20Keeper.IsDynamicPrecompileAvailable(suite.evmChainA.GetContext(), common.HexToAddress(tokenPair.Erc20Address))
 				suite.Require().True(available)
 			} else {
 				suite.Require().False(ack.Success(), "Expected failure but got success")
 
-				balAfterCallback := evmApp.Erc20Keeper.BalanceOf(evmCtx, contracts.ERC20MinterBurnerDecimalsContract.ABI, erc20Contract, contractAddr)
+				balAfterCallback := evmApp.Erc20Keeper.BalanceOf(suite.evmChainA.GetContext(), contracts.ERC20MinterBurnerDecimalsContract.ABI, erc20Contract, contractAddr)
 				suite.Require().Equal("0", balAfterCallback.String())
 
 				ackObj, ok := ack.(channeltypes.Acknowledgement)
@@ -601,11 +600,10 @@ func (suite *MiddlewareTestSuite) TestOnRecvPacket() {
 			transferStack, ok := suite.evmChainA.App.GetIBCKeeper().PortKeeper.Route(transfertypes.ModuleName)
 			suite.Require().True(ok)
 
-			ctxA := suite.evmChainA.GetContext()
 			sourceChan := path.EndpointB.GetChannel()
 
 			ack := transferStack.OnRecvPacket(
-				ctxA,
+				suite.evmChainA.GetContext(),
 				sourceChan.Version,
 				packet,
 				suite.evmChainA.SenderAccount.GetAddress(),
@@ -621,17 +619,17 @@ func (suite *MiddlewareTestSuite) TestOnRecvPacket() {
 				voucherDenom := testutil.GetVoucherDenomFromPacketData(data, packet.GetDestPort(), packet.GetDestChannel())
 
 				evmApp := suite.evmChainA.App.(*evmd.EVMD)
-				voucherCoin := evmApp.BankKeeper.GetBalance(ctxA, receiver, voucherDenom)
+				voucherCoin := evmApp.BankKeeper.GetBalance(suite.evmChainA.GetContext(), receiver, voucherDenom)
 				suite.Require().Equal(sendAmt.String(), voucherCoin.Amount.String())
 
 				// Make sure token pair is registered
 				singleTokenRepresentation, err := types.NewTokenPairSTRv2(voucherDenom)
 				suite.Require().NoError(err)
-				tokenPair, found := evmApp.Erc20Keeper.GetTokenPair(ctxA, singleTokenRepresentation.GetID())
+				tokenPair, found := evmApp.Erc20Keeper.GetTokenPair(suite.evmChainA.GetContext(), singleTokenRepresentation.GetID())
 				suite.Require().True(found)
 				suite.Require().Equal(voucherDenom, tokenPair.Denom)
 				// Make sure dynamic precompile is registered
-				available := evmApp.Erc20Keeper.IsDynamicPrecompileAvailable(ctxA, common.HexToAddress(tokenPair.Erc20Address))
+				available := evmApp.Erc20Keeper.IsDynamicPrecompileAvailable(suite.evmChainA.GetContext(), common.HexToAddress(tokenPair.Erc20Address))
 				suite.Require().True(available)
 			} else {
 				suite.Require().False(ack.Success())
@@ -682,7 +680,6 @@ func (suite *MiddlewareTestSuite) TestOnRecvPacketNativeErc20() {
 			suite.SetupTest()
 			nativeErc20 := SetupNativeErc20(suite.T(), suite.evmChainA, suite.evmChainA.SenderAccounts[0])
 
-			evmCtx := suite.evmChainA.GetContext()
 			evmApp := suite.evmChainA.App.(*evmd.EVMD)
 
 			// Scenario: Native ERC20 token transfer from evmChainA to chainB
@@ -697,7 +694,7 @@ func (suite *MiddlewareTestSuite) TestOnRecvPacketNativeErc20() {
 			// Transfer half the initial balance out using the precompile
 			// Sender transfers 50 out (escrowed)
 			_, err := suite.transferViaPrecompile(
-				evmCtx,
+				suite.evmChainA.GetContext(),
 				path.EndpointA.ChannelConfig.PortID,
 				path.EndpointA.ChannelID,
 				sdk.NewCoin(nativeErc20.Denom, sendAmt),
@@ -709,10 +706,9 @@ func (suite *MiddlewareTestSuite) TestOnRecvPacketNativeErc20() {
 			)
 			suite.Require().NoError(err) // message committed
 			suite.evmChainA.NextBlock()
-			evmCtx = suite.evmChainA.GetContext()
 
 			// Balance after transfer should be initial balance - sendAmt
-			balAfterTransfer := evmApp.Erc20Keeper.BalanceOf(evmCtx, nativeErc20.ContractAbi, nativeErc20.ContractAddr, senderEthAddr)
+			balAfterTransfer := evmApp.Erc20Keeper.BalanceOf(suite.evmChainA.GetContext(), nativeErc20.ContractAbi, nativeErc20.ContractAddr, senderEthAddr)
 			suite.Require().Equal(
 				new(big.Int).Sub(nativeErc20.InitialBal, sendAmt.BigInt()).String(),
 				balAfterTransfer.String(),
@@ -732,7 +728,7 @@ func (suite *MiddlewareTestSuite) TestOnRecvPacketNativeErc20() {
 			// Check native erc20 token is escrowed on evmChainA for sending to chainB.
 			// Conversion of remaining 50 tokens to Bank token
 			escrowAddr := transfertypes.GetEscrowAddress(path.EndpointA.ChannelConfig.PortID, path.EndpointA.ChannelID)
-			escrowedBal := evmApp.BankKeeper.GetBalance(evmCtx, escrowAddr, nativeErc20.Denom)
+			escrowedBal := evmApp.BankKeeper.GetBalance(suite.evmChainA.GetContext(), escrowAddr, nativeErc20.Denom)
 			suite.Require().Equal(sendAmt.String(), escrowedBal.Amount.String())
 
 			// chainBNativeErc20Denom is the native erc20 token denom on chainB from evmChainA through IBC.
@@ -812,8 +808,8 @@ func (suite *MiddlewareTestSuite) TestOnRecvPacketNativeErc20() {
 
 				// SendEnabled=false will cause the conversion of bank tokens to erc20 tokens to fail,
 				// but not send them back to escrow
-				evmApp.BankKeeper.SetSendEnabled(evmCtx, nativeErc20.Denom, false)
-				isSendEnabled := evmApp.BankKeeper.IsSendEnabledDenom(evmCtx, nativeErc20.Denom)
+				evmApp.BankKeeper.SetSendEnabled(suite.evmChainA.GetContext(), nativeErc20.Denom, false)
+				isSendEnabled := evmApp.BankKeeper.IsSendEnabledDenom(suite.evmChainA.GetContext(), nativeErc20.Denom)
 				suite.Require().False(isSendEnabled)
 
 				packet1 := channeltypes.Packet{
@@ -828,18 +824,17 @@ func (suite *MiddlewareTestSuite) TestOnRecvPacketNativeErc20() {
 				}
 
 				errAck := transferStack.OnRecvPacket(
-					evmCtx,
+					suite.evmChainA.GetContext(),
 					sourceChan.Version,
 					packet1,
 					suite.evmChainA.SenderAccount.GetAddress(),
 				)
 				suite.Require().False(errAck.Success())
 
-				evmCtx = suite.evmChainA.GetContext()
 
 				// SendEnabled=true causes our callback to succeed
-				evmApp.BankKeeper.SetSendEnabled(evmCtx, nativeErc20.Denom, true)
-				isSendEnabled = evmApp.BankKeeper.IsSendEnabledDenom(evmCtx, nativeErc20.Denom)
+				evmApp.BankKeeper.SetSendEnabled(suite.evmChainA.GetContext(), nativeErc20.Denom, true)
+				isSendEnabled = evmApp.BankKeeper.IsSendEnabledDenom(suite.evmChainA.GetContext(), nativeErc20.Denom)
 				suite.Require().True(isSendEnabled)
 
 				packet2 := channeltypes.Packet{
@@ -854,7 +849,7 @@ func (suite *MiddlewareTestSuite) TestOnRecvPacketNativeErc20() {
 				}
 
 				ack := transferStack.OnRecvPacket(
-					evmCtx,
+					suite.evmChainA.GetContext(),
 					sourceChan.Version,
 					packet2,
 					suite.evmChainA.SenderAccount.GetAddress(),
@@ -862,7 +857,7 @@ func (suite *MiddlewareTestSuite) TestOnRecvPacketNativeErc20() {
 				suite.Require().True(ack.Success())
 
 				// Check un-escrowed balance on evmChainA after receiving the packet.
-				escrowedBal = evmApp.BankKeeper.GetBalance(evmCtx, escrowAddr, nativeErc20.Denom)
+				escrowedBal = evmApp.BankKeeper.GetBalance(suite.evmChainA.GetContext(), escrowAddr, nativeErc20.Denom)
 				suite.Require().True(escrowedBal.IsZero(), "escrowed balance should be un-escrowed after receiving the packet")
 
 				// recvAmt should be in the contractAddr upon successful recv callback
@@ -875,10 +870,10 @@ func (suite *MiddlewareTestSuite) TestOnRecvPacketNativeErc20() {
 				contractAddrStr := destCallback["address"].(string)
 				contractAddr = common.HexToAddress(contractAddrStr)
 
-				balAfterUnescrow := evmApp.Erc20Keeper.BalanceOf(evmCtx, nativeErc20.ContractAbi, nativeErc20.ContractAddr, contractAddr)
+				balAfterUnescrow := evmApp.Erc20Keeper.BalanceOf(suite.evmChainA.GetContext(), nativeErc20.ContractAbi, nativeErc20.ContractAddr, contractAddr)
 				suite.Require().Equal(recvAmt.String(), balAfterUnescrow.String())
 
-				bankBalAfterUnescrow := evmApp.BankKeeper.GetBalance(evmCtx, sender, nativeErc20.Denom)
+				bankBalAfterUnescrow := evmApp.BankKeeper.GetBalance(suite.evmChainA.GetContext(), sender, nativeErc20.Denom)
 				// InitialBalance half which was converted but not sent will be in the sending account's balance
 				suite.Require().Equal(sendAmt.String(), bankBalAfterUnescrow.Amount.String())
 
@@ -886,7 +881,7 @@ func (suite *MiddlewareTestSuite) TestOnRecvPacketNativeErc20() {
 				// and will be in the isolated address used to invoke the callback
 				isolatedAddr := callbacktypes.GenerateIsolatedAddress(path.EndpointA.ChannelID,
 					suite.chainB.SenderAccount.GetAddress().String())
-				trappedBal := evmApp.BankKeeper.GetBalance(evmCtx, isolatedAddr, nativeErc20.Denom)
+				trappedBal := evmApp.BankKeeper.GetBalance(suite.evmChainA.GetContext(), isolatedAddr, nativeErc20.Denom)
 				suite.Require().Equal(recvAmt.String(), trappedBal.Amount.String())
 			} else {
 				// Simple case: no callback, just verify hex recipient receives ERC20
@@ -902,7 +897,7 @@ func (suite *MiddlewareTestSuite) TestOnRecvPacketNativeErc20() {
 				}
 
 				ack := transferStack.OnRecvPacket(
-					evmCtx,
+					suite.evmChainA.GetContext(),
 					sourceChan.Version,
 					packet,
 					suite.evmChainA.SenderAccount.GetAddress(),
@@ -911,7 +906,7 @@ func (suite *MiddlewareTestSuite) TestOnRecvPacketNativeErc20() {
 
 				// Verify ERC20 was minted to the hex recipient
 				bal := evmApp.Erc20Keeper.BalanceOf(
-					evmCtx,
+					suite.evmChainA.GetContext(),
 					nativeErc20.ContractAbi,
 					nativeErc20.ContractAddr,
 					tc.expectedRecipientEVM,
@@ -1173,10 +1168,9 @@ func (suite *MiddlewareTestSuite) TestOnAcknowledgementPacketWithCallback() {
 		suite.Run(tc.name, func() {
 			suite.SetupTest()
 
-			ctxA := suite.evmChainA.GetContext()
 			evmApp := suite.evmChainA.App.(*evmd.EVMD)
 
-			bondDenom, err := evmApp.StakingKeeper.BondDenom(ctxA)
+			bondDenom, err := evmApp.StakingKeeper.BondDenom(suite.evmChainA.GetContext())
 			suite.Require().NoError(err)
 
 			sendAmt := ibctesting.DefaultCoinAmount
@@ -1234,7 +1228,7 @@ func (suite *MiddlewareTestSuite) TestOnAcknowledgementPacketWithCallback() {
 
 			sourceChan := suite.path.EndpointA.GetChannel()
 
-			balBeforeTransfer := evmApp.BankKeeper.GetBalance(ctxA, sender, bondDenom)
+			balBeforeTransfer := evmApp.BankKeeper.GetBalance(suite.evmChainA.GetContext(), sender, bondDenom)
 			// Execute send if required (for proper escrow setup)
 			if tc.onSendRequired {
 				timeoutHeight := clienttypes.NewHeight(1, 110)
@@ -1252,7 +1246,7 @@ func (suite *MiddlewareTestSuite) TestOnAcknowledgementPacketWithCallback() {
 				suite.Require().NoError(err) // message committed
 
 				feeAmt := evmibctesting.FeeCoins().AmountOf(bondDenom)
-				balAfterTransfer := evmApp.BankKeeper.GetBalance(ctxA, sender, bondDenom)
+				balAfterTransfer := evmApp.BankKeeper.GetBalance(suite.evmChainA.GetContext(), sender, bondDenom)
 				suite.Require().Equal(
 					balBeforeTransfer.Amount.Sub(sendAmt).Sub(feeAmt).String(),
 					balAfterTransfer.Amount.String(),
@@ -1270,13 +1264,13 @@ func (suite *MiddlewareTestSuite) TestOnAcknowledgementPacketWithCallback() {
 					// One for UpdateClient() and one for AcknowledgePacket()
 					relayPacketFeeAmt := feeAmt.Mul(math.NewInt(2))
 
-					balAfterRelayPacket := evmApp.BankKeeper.GetBalance(ctxA, sender, bondDenom)
+					balAfterRelayPacket := evmApp.BankKeeper.GetBalance(suite.evmChainA.GetContext(), sender, bondDenom)
 					suite.Require().Equal(
 						balAfterTransfer.Amount.Sub(relayPacketFeeAmt).String(),
 						balAfterRelayPacket.Amount.String(),
 					)
 					escrowAddr := transfertypes.GetEscrowAddress(path.EndpointA.ChannelConfig.PortID, path.EndpointA.ChannelID)
-					escrowedBal := evmApp.BankKeeper.GetBalance(ctxA, escrowAddr, bondDenom)
+					escrowedBal := evmApp.BankKeeper.GetBalance(suite.evmChainA.GetContext(), escrowAddr, bondDenom)
 					suite.Require().Equal(sendAmt.String(), escrowedBal.Amount.String())
 				}
 
@@ -1284,10 +1278,10 @@ func (suite *MiddlewareTestSuite) TestOnAcknowledgementPacketWithCallback() {
 				packet = sentPacket
 			}
 
-			beforeAckBal := evmApp.BankKeeper.GetBalance(ctxA, sender, bondDenom)
+			beforeAckBal := evmApp.BankKeeper.GetBalance(suite.evmChainA.GetContext(), sender, bondDenom)
 			// Execute acknowledgement
 			err = transferStack.OnAcknowledgementPacket(
-				ctxA,
+				suite.evmChainA.GetContext(),
 				sourceChan.Version,
 				packet,
 				ack,
@@ -1303,7 +1297,7 @@ func (suite *MiddlewareTestSuite) TestOnAcknowledgementPacketWithCallback() {
 					senderEVM := common.BytesToAddress(sender)
 					expectsCallbackExec := contractAddr == senderEVM
 					counterRes, err := evmApp.EVMKeeper.CallEVM(
-						ctxA,
+						suite.evmChainA.GetContext(),
 						stateDB,
 						contractData.ABI,
 						common.BytesToAddress(suite.evmChainA.SenderAccount.GetAddress()),
@@ -1328,8 +1322,8 @@ func (suite *MiddlewareTestSuite) TestOnAcknowledgementPacketWithCallback() {
 				// Verify refund for error acknowledgements
 				if tc.ackType == "error" && tc.onSendRequired {
 					escrowAddr := transfertypes.GetEscrowAddress(path.EndpointA.ChannelConfig.PortID, path.EndpointA.ChannelID)
-					escrowedBal := evmApp.BankKeeper.GetBalance(ctxA, escrowAddr, bondDenom)
-					finalSenderBal := evmApp.BankKeeper.GetBalance(ctxA, sender, bondDenom)
+					escrowedBal := evmApp.BankKeeper.GetBalance(suite.evmChainA.GetContext(), escrowAddr, bondDenom)
+					finalSenderBal := evmApp.BankKeeper.GetBalance(suite.evmChainA.GetContext(), sender, bondDenom)
 
 					// For error acks, tokens should be refunded
 					suite.Require().True(escrowedBal.IsZero(), "Escrowed balance should be zero after refund")
@@ -1339,7 +1333,7 @@ func (suite *MiddlewareTestSuite) TestOnAcknowledgementPacketWithCallback() {
 				// For ack failures, verify that counter was NOT incremented
 
 				counterRes, err := evmApp.EVMKeeper.CallEVM(
-					ctxA,
+					suite.evmChainA.GetContext(),
 					stateDB,
 					contractData.ABI,
 					common.BytesToAddress(suite.evmChainA.SenderAccount.GetAddress()),
@@ -1411,10 +1405,9 @@ func (suite *MiddlewareTestSuite) TestOnAcknowledgementPacket() {
 		suite.Run(tc.name, func() {
 			suite.SetupTest()
 
-			ctxA := suite.evmChainA.GetContext()
 			evmApp := suite.evmChainA.App.(*evmd.EVMD)
 
-			bondDenom, err := evmApp.StakingKeeper.BondDenom(ctxA)
+			bondDenom, err := evmApp.StakingKeeper.BondDenom(suite.evmChainA.GetContext())
 			suite.Require().NoError(err)
 
 			sendAmt := ibctesting.DefaultCoinAmount
@@ -1452,7 +1445,7 @@ func (suite *MiddlewareTestSuite) TestOnAcknowledgementPacket() {
 			sourceChan := suite.path.EndpointA.GetChannel()
 			onAck := func() error {
 				return transferStack.OnAcknowledgementPacket(
-					ctxA,
+					suite.evmChainA.GetContext(),
 					sourceChan.Version,
 					packet,
 					ack,
@@ -1469,12 +1462,12 @@ func (suite *MiddlewareTestSuite) TestOnAcknowledgementPacket() {
 					receiver.String(),
 					timeoutHeight, 0, "",
 				)
-				balBeforeTransfer := evmApp.BankKeeper.GetBalance(ctxA, sender, bondDenom)
+				balBeforeTransfer := evmApp.BankKeeper.GetBalance(suite.evmChainA.GetContext(), sender, bondDenom)
 				res, err := suite.evmChainA.SendMsgs(msg)
 				suite.Require().NoError(err) // message committed
 
 				feeAmt := evmibctesting.FeeCoins().AmountOf(bondDenom)
-				balAfterTransfer := evmApp.BankKeeper.GetBalance(ctxA, sender, bondDenom)
+				balAfterTransfer := evmApp.BankKeeper.GetBalance(suite.evmChainA.GetContext(), sender, bondDenom)
 				suite.Require().Equal(
 					balBeforeTransfer.Amount.Sub(sendAmt).Sub(feeAmt).String(),
 					balAfterTransfer.Amount.String(),
@@ -1491,13 +1484,13 @@ func (suite *MiddlewareTestSuite) TestOnAcknowledgementPacket() {
 				relayPacketFeeAmt := feeAmt.Mul(math.NewInt(2))
 
 				// ensure the ibc token is escrowed.
-				balAfterRelayPacket := evmApp.BankKeeper.GetBalance(ctxA, sender, bondDenom)
+				balAfterRelayPacket := evmApp.BankKeeper.GetBalance(suite.evmChainA.GetContext(), sender, bondDenom)
 				suite.Require().Equal(
 					balAfterTransfer.Amount.Sub(relayPacketFeeAmt).String(),
 					balAfterRelayPacket.Amount.String(),
 				)
 				escrowAddr := transfertypes.GetEscrowAddress(path.EndpointA.ChannelConfig.PortID, path.EndpointA.ChannelID)
-				escrowedBal := evmApp.BankKeeper.GetBalance(ctxA, escrowAddr, bondDenom)
+				escrowedBal := evmApp.BankKeeper.GetBalance(suite.evmChainA.GetContext(), escrowAddr, bondDenom)
 				suite.Require().Equal(sendAmt.String(), escrowedBal.Amount.String())
 			}
 
@@ -1563,7 +1556,6 @@ func (suite *MiddlewareTestSuite) TestOnAcknowledgementPacketNativeErc20() {
 			suite.SetupTest()
 			nativeErc20 := SetupNativeErc20(suite.T(), suite.evmChainA, suite.evmChainA.SenderAccounts[0])
 
-			evmCtx := suite.evmChainA.GetContext()
 			evmApp := suite.evmChainA.App.(*evmd.EVMD)
 
 			timeoutHeight := clienttypes.NewHeight(1, 110)
@@ -1578,28 +1570,28 @@ func (suite *MiddlewareTestSuite) TestOnAcknowledgementPacketNativeErc20() {
 			escrowAddr := transfertypes.GetEscrowAddress(path.EndpointA.ChannelConfig.PortID, path.EndpointA.ChannelID)
 			// checkEscrow is a check function to ensure the native erc20 token is escrowed.
 			checkEscrow := func() {
-				erc20BalAfterIbcTransfer := evmApp.Erc20Keeper.BalanceOf(evmCtx, nativeErc20.ContractAbi, nativeErc20.ContractAddr, senderEthAddr)
+				erc20BalAfterIbcTransfer := evmApp.Erc20Keeper.BalanceOf(suite.evmChainA.GetContext(), nativeErc20.ContractAbi, nativeErc20.ContractAddr, senderEthAddr)
 				suite.Require().Equal(
 					new(big.Int).Sub(nativeErc20.InitialBal, sendAmt.BigInt()).String(),
 					erc20BalAfterIbcTransfer.String(),
 				)
-				escrowedBal := evmApp.BankKeeper.GetBalance(evmCtx, escrowAddr, nativeErc20.Denom)
+				escrowedBal := evmApp.BankKeeper.GetBalance(suite.evmChainA.GetContext(), escrowAddr, nativeErc20.Denom)
 				suite.Require().Equal(sendAmt.String(), escrowedBal.Amount.String())
 			}
 
 			// checkRefund is a check function to ensure refund is processed.
 			checkRefund := func() {
-				escrowedBal := evmApp.BankKeeper.GetBalance(evmCtx, escrowAddr, nativeErc20.Denom)
+				escrowedBal := evmApp.BankKeeper.GetBalance(suite.evmChainA.GetContext(), escrowAddr, nativeErc20.Denom)
 				suite.Require().True(escrowedBal.IsZero())
 
 				// Check erc20 balance is same as initial balance after refund.
-				erc20BalAfterIbcTransfer := evmApp.Erc20Keeper.BalanceOf(evmCtx, nativeErc20.ContractAbi, nativeErc20.ContractAddr, senderEthAddr)
+				erc20BalAfterIbcTransfer := evmApp.Erc20Keeper.BalanceOf(suite.evmChainA.GetContext(), nativeErc20.ContractAbi, nativeErc20.ContractAddr, senderEthAddr)
 				suite.Require().Equal(nativeErc20.InitialBal.String(), erc20BalAfterIbcTransfer.String())
 			}
 
 			// Send the native erc20 token from evmChainA to chainB using the precompile.
 			_, err := suite.transferViaPrecompile(
-				evmCtx,
+				suite.evmChainA.GetContext(),
 				path.EndpointA.ChannelConfig.PortID,
 				path.EndpointA.ChannelID,
 				sdk.NewCoin(nativeErc20.Denom, sendAmt),
@@ -1611,7 +1603,6 @@ func (suite *MiddlewareTestSuite) TestOnAcknowledgementPacketNativeErc20() {
 			)
 			suite.Require().NoError(err) // message committed
 			suite.evmChainA.NextBlock()
-			evmCtx = suite.evmChainA.GetContext()
 			checkEscrow()
 
 			transferStack, ok := suite.evmChainA.App.GetIBCKeeper().PortKeeper.Route(transfertypes.ModuleName)
@@ -1643,7 +1634,7 @@ func (suite *MiddlewareTestSuite) TestOnAcknowledgementPacketNativeErc20() {
 			sourceChan := path.EndpointA.GetChannel()
 			onAck := func() error {
 				return transferStack.OnAcknowledgementPacket(
-					evmCtx,
+					suite.evmChainA.GetContext(),
 					sourceChan.Version,
 					packet,
 					ack,
@@ -1698,9 +1689,8 @@ func (suite *MiddlewareTestSuite) TestOnTimeoutPacket() {
 		suite.Run(tc.name, func() {
 			suite.SetupTest()
 
-			ctxA := suite.evmChainA.GetContext()
 			evmApp := suite.evmChainA.App.(*evmd.EVMD)
-			bondDenom, err := evmApp.StakingKeeper.BondDenom(ctxA)
+			bondDenom, err := evmApp.StakingKeeper.BondDenom(suite.evmChainA.GetContext())
 			suite.Require().NoError(err)
 
 			sendAmt := ibctesting.DefaultCoinAmount
@@ -1737,14 +1727,14 @@ func (suite *MiddlewareTestSuite) TestOnTimeoutPacket() {
 			sourceChan := suite.path.EndpointA.GetChannel()
 			onTimeout := func() error {
 				return transferStack.OnTimeoutPacket(
-					ctxA,
+					suite.evmChainA.GetContext(),
 					sourceChan.Version,
 					packet,
 					sender,
 				)
 			}
 
-			balBeforeTransfer := evmApp.BankKeeper.GetBalance(ctxA, sender, bondDenom)
+			balBeforeTransfer := evmApp.BankKeeper.GetBalance(suite.evmChainA.GetContext(), sender, bondDenom)
 			var balAfterRelayPacket sdk.Coin
 			feeAmt := evmibctesting.FeeCoins().AmountOf(bondDenom)
 			if tc.onSendRequired {
@@ -1761,7 +1751,7 @@ func (suite *MiddlewareTestSuite) TestOnTimeoutPacket() {
 				res, err := suite.evmChainA.SendMsgs(msg)
 				suite.Require().NoError(err) // message committed
 
-				balAfterTransfer := evmApp.BankKeeper.GetBalance(ctxA, sender, bondDenom)
+				balAfterTransfer := evmApp.BankKeeper.GetBalance(suite.evmChainA.GetContext(), sender, bondDenom)
 				suite.Require().Equal(
 					balBeforeTransfer.Amount.Sub(sendAmt).Sub(feeAmt).String(),
 					balAfterTransfer.Amount.String(),
@@ -1776,7 +1766,7 @@ func (suite *MiddlewareTestSuite) TestOnTimeoutPacket() {
 				// One for UpdateClient() and one for AcknowledgePacket()
 				relayPacketFeeAmt := feeAmt.Mul(math.NewInt(2))
 
-				balAfterRelayPacket = evmApp.BankKeeper.GetBalance(ctxA, sender, bondDenom)
+				balAfterRelayPacket = evmApp.BankKeeper.GetBalance(suite.evmChainA.GetContext(), sender, bondDenom)
 				suite.Require().Equal(
 					balAfterTransfer.Amount.Sub(relayPacketFeeAmt).String(),
 					balAfterRelayPacket.Amount.String(),
@@ -1784,7 +1774,7 @@ func (suite *MiddlewareTestSuite) TestOnTimeoutPacket() {
 			}
 			err = onTimeout()
 
-			balAfterTimeout := evmApp.BankKeeper.GetBalance(ctxA, sender, bondDenom)
+			balAfterTimeout := evmApp.BankKeeper.GetBalance(suite.evmChainA.GetContext(), sender, bondDenom)
 			if tc.onSendRequired {
 				suite.Require().Equal(
 					balAfterRelayPacket.Amount.Add(sendAmt).String(),
@@ -1799,7 +1789,7 @@ func (suite *MiddlewareTestSuite) TestOnTimeoutPacket() {
 
 			// ensure that the escrowed coins were refunded on timeout.
 			escrowAddr := transfertypes.GetEscrowAddress(path.EndpointA.ChannelConfig.PortID, path.EndpointA.ChannelID)
-			escrowedBal := evmApp.BankKeeper.GetBalance(ctxA, escrowAddr, bondDenom)
+			escrowedBal := evmApp.BankKeeper.GetBalance(suite.evmChainA.GetContext(), escrowAddr, bondDenom)
 			suite.Require().Equal(escrowedBal.Amount.String(), math.ZeroInt().String())
 
 			if tc.expError == "" {
@@ -2016,10 +2006,9 @@ func (suite *MiddlewareTestSuite) TestOnTimeoutPacketWithCallback() {
 		suite.Run(tc.name, func() {
 			suite.SetupTest()
 
-			ctxA := suite.evmChainA.GetContext()
 			evmApp := suite.evmChainA.App.(*evmd.EVMD)
 
-			bondDenom, err := evmApp.StakingKeeper.BondDenom(ctxA)
+			bondDenom, err := evmApp.StakingKeeper.BondDenom(suite.evmChainA.GetContext())
 			suite.Require().NoError(err)
 
 			sendAmt := ibctesting.DefaultCoinAmount
@@ -2067,7 +2056,7 @@ func (suite *MiddlewareTestSuite) TestOnTimeoutPacketWithCallback() {
 			transferStack, ok := evmApp.GetIBCKeeper().PortKeeper.Route(transfertypes.ModuleName)
 			suite.Require().True(ok)
 
-			balBeforeTransfer := evmApp.BankKeeper.GetBalance(ctxA, sender, bondDenom)
+			balBeforeTransfer := evmApp.BankKeeper.GetBalance(suite.evmChainA.GetContext(), sender, bondDenom)
 			balAfterTransfer := balBeforeTransfer
 			feeAmt := evmibctesting.FeeCoins().AmountOf(bondDenom)
 			// Execute send if required (for proper escrow setup)
@@ -2089,13 +2078,13 @@ func (suite *MiddlewareTestSuite) TestOnTimeoutPacketWithCallback() {
 				sentPacket, err := ibctesting.ParseV1PacketFromEvents(res.Events)
 				suite.Require().NoError(err)
 
-				balAfterTransfer = evmApp.BankKeeper.GetBalance(ctxA, sender, bondDenom)
+				balAfterTransfer = evmApp.BankKeeper.GetBalance(suite.evmChainA.GetContext(), sender, bondDenom)
 				suite.Require().Equal(
 					balBeforeTransfer.Amount.Sub(sendAmt).Sub(feeAmt).String(),
 					balAfterTransfer.Amount.String(),
 				)
 				escrowAddr := transfertypes.GetEscrowAddress(path.EndpointA.ChannelConfig.PortID, path.EndpointA.ChannelID)
-				escrowedBal := evmApp.BankKeeper.GetBalance(ctxA, escrowAddr, bondDenom)
+				escrowedBal := evmApp.BankKeeper.GetBalance(suite.evmChainA.GetContext(), escrowAddr, bondDenom)
 				suite.Require().Equal(sendAmt.String(), escrowedBal.Amount.String())
 
 				// Use the actually sent packet for timeout
@@ -2104,12 +2093,12 @@ func (suite *MiddlewareTestSuite) TestOnTimeoutPacketWithCallback() {
 
 			sourceChan := path.EndpointA.GetChannel()
 			err = transferStack.OnTimeoutPacket(
-				ctxA,
+				suite.evmChainA.GetContext(),
 				sourceChan.Version,
 				packet,
 				receiver,
 			)
-			balAfterTimeout := evmApp.BankKeeper.GetBalance(ctxA, sender, bondDenom)
+			balAfterTimeout := evmApp.BankKeeper.GetBalance(suite.evmChainA.GetContext(), sender, bondDenom)
 			stateDB := statedb.New(suite.evmChainA.GetContext(), evmApp.GetEVMKeeper(), statedb.NewEmptyTxConfig())
 
 			// Validate results
@@ -2123,7 +2112,7 @@ func (suite *MiddlewareTestSuite) TestOnTimeoutPacketWithCallback() {
 					senderEVM := common.BytesToAddress(sender)
 					expectsCallbackExec := contractAddr == senderEVM
 					counterRes, err := evmApp.EVMKeeper.CallEVM(
-						ctxA,
+						suite.evmChainA.GetContext(),
 						stateDB,
 						contractData.ABI,
 						common.BytesToAddress(suite.evmChainA.SenderAccount.GetAddress()),
@@ -2151,7 +2140,7 @@ func (suite *MiddlewareTestSuite) TestOnTimeoutPacketWithCallback() {
 				// Verify refund for timeouts (tokens should always be refunded on timeout)
 				if tc.onSendRequired {
 					escrowAddr := transfertypes.GetEscrowAddress(path.EndpointA.ChannelConfig.PortID, path.EndpointA.ChannelID)
-					escrowedBal := evmApp.BankKeeper.GetBalance(ctxA, escrowAddr, bondDenom)
+					escrowedBal := evmApp.BankKeeper.GetBalance(suite.evmChainA.GetContext(), escrowAddr, bondDenom)
 
 					// For timeouts, tokens should always be refunded
 					suite.Require().True(escrowedBal.IsZero(), "Escrowed balance should be zero after timeout refund")
@@ -2161,7 +2150,7 @@ func (suite *MiddlewareTestSuite) TestOnTimeoutPacketWithCallback() {
 				// For timeout callback failures, verify that counter was NOT changed
 				if strings.Contains(tc.memo(), "src_callback") && strings.Contains(tc.expError, "ABCI code") {
 					counterRes, err := evmApp.EVMKeeper.CallEVM(
-						ctxA,
+						suite.evmChainA.GetContext(),
 						stateDB,
 						contractData.ABI,
 						common.BytesToAddress(suite.evmChainA.SenderAccount.GetAddress()),
@@ -2186,7 +2175,7 @@ func (suite *MiddlewareTestSuite) TestOnTimeoutPacketWithCallback() {
 				if tc.onSendRequired && !strings.Contains(tc.expError, "cannot unmarshal") {
 					// Even if callback fails, the timeout refund should still happen
 					escrowAddr := transfertypes.GetEscrowAddress(path.EndpointA.ChannelConfig.PortID, path.EndpointA.ChannelID)
-					escrowedBal := evmApp.BankKeeper.GetBalance(ctxA, escrowAddr, bondDenom)
+					escrowedBal := evmApp.BankKeeper.GetBalance(suite.evmChainA.GetContext(), escrowAddr, bondDenom)
 
 					suite.Require().True(escrowedBal.IsZero(), "Escrowed balance should be zero after timeout refund even with callback failure")
 					suite.Require().Equal(balAfterTransfer.Amount.Add(sendAmt).String(), balAfterTimeout.Amount.String(), "Sender balance should be refunded on timeout")
@@ -2227,7 +2216,6 @@ func (suite *MiddlewareTestSuite) TestOnTimeoutPacketNativeErc20() {
 			suite.SetupTest()
 			nativeErc20 := SetupNativeErc20(suite.T(), suite.evmChainA, suite.evmChainA.SenderAccounts[0])
 
-			evmCtx := suite.evmChainA.GetContext()
 			evmApp := suite.evmChainA.App.(*evmd.EVMD)
 
 			timeoutHeight := clienttypes.NewHeight(1, 110)
@@ -2242,28 +2230,28 @@ func (suite *MiddlewareTestSuite) TestOnTimeoutPacketNativeErc20() {
 			escrowAddr := transfertypes.GetEscrowAddress(path.EndpointA.ChannelConfig.PortID, path.EndpointA.ChannelID)
 			// checkEscrow is a check function to ensure the native erc20 token is escrowed.
 			checkEscrow := func() {
-				erc20BalAfterIbcTransfer := evmApp.Erc20Keeper.BalanceOf(evmCtx, nativeErc20.ContractAbi, nativeErc20.ContractAddr, senderEthAddr)
+				erc20BalAfterIbcTransfer := evmApp.Erc20Keeper.BalanceOf(suite.evmChainA.GetContext(), nativeErc20.ContractAbi, nativeErc20.ContractAddr, senderEthAddr)
 				suite.Require().Equal(
 					new(big.Int).Sub(nativeErc20.InitialBal, sendAmt.BigInt()).String(),
 					erc20BalAfterIbcTransfer.String(),
 				)
-				escrowedBal := evmApp.BankKeeper.GetBalance(evmCtx, escrowAddr, nativeErc20.Denom)
+				escrowedBal := evmApp.BankKeeper.GetBalance(suite.evmChainA.GetContext(), escrowAddr, nativeErc20.Denom)
 				suite.Require().Equal(sendAmt.String(), escrowedBal.Amount.String())
 			}
 
 			// checkRefund is a check function to ensure refund is processed.
 			checkRefund := func() {
-				escrowedBal := evmApp.BankKeeper.GetBalance(evmCtx, escrowAddr, nativeErc20.Denom)
+				escrowedBal := evmApp.BankKeeper.GetBalance(suite.evmChainA.GetContext(), escrowAddr, nativeErc20.Denom)
 				suite.Require().True(escrowedBal.IsZero())
 
 				// Check erc20 balance is same as initial balance after refund.
-				erc20BalAfterIbcTransfer := evmApp.Erc20Keeper.BalanceOf(evmCtx, nativeErc20.ContractAbi, nativeErc20.ContractAddr, senderEthAddr)
+				erc20BalAfterIbcTransfer := evmApp.Erc20Keeper.BalanceOf(suite.evmChainA.GetContext(), nativeErc20.ContractAbi, nativeErc20.ContractAddr, senderEthAddr)
 				suite.Require().Equal(nativeErc20.InitialBal.String(), erc20BalAfterIbcTransfer.String())
 			}
 
 			// Send the native erc20 token from evmChainA to chainB using the precompile.
 			_, err := suite.transferViaPrecompile(
-				evmCtx,
+				suite.evmChainA.GetContext(),
 				path.EndpointA.ChannelConfig.PortID,
 				path.EndpointA.ChannelID,
 				sdk.NewCoin(nativeErc20.Denom, sendAmt),
@@ -2275,7 +2263,6 @@ func (suite *MiddlewareTestSuite) TestOnTimeoutPacketNativeErc20() {
 			)
 			suite.Require().NoError(err) // message committed
 			suite.evmChainA.NextBlock()
-			evmCtx = suite.evmChainA.GetContext()
 			checkEscrow()
 
 			transferStack, ok := suite.evmChainA.App.GetIBCKeeper().PortKeeper.Route(transfertypes.ModuleName)
@@ -2305,7 +2292,7 @@ func (suite *MiddlewareTestSuite) TestOnTimeoutPacketNativeErc20() {
 
 			sourceChan := path.EndpointA.GetChannel()
 			err = transferStack.OnTimeoutPacket(
-				evmCtx,
+				suite.evmChainA.GetContext(),
 				sourceChan.Version,
 				packet,
 				receiver,

--- a/evmd/tests/ibc/ibc_middleware_test.go
+++ b/evmd/tests/ibc/ibc_middleware_test.go
@@ -145,7 +145,6 @@ func (suite *MiddlewareTestSuite) transferViaPrecompile(
 }
 
 func TestMiddlewareTestSuite(t *testing.T) {
-	t.Skip("STACK-2601: fix IBC tests")
 	testifysuite.Run(t, new(MiddlewareTestSuite))
 }
 

--- a/evmd/tests/ibc/ics20_erc20_conversion_test.go
+++ b/evmd/tests/ibc/ics20_erc20_conversion_test.go
@@ -58,7 +58,6 @@ func (suite *ICS20ERC20ConversionTestSuite) SetupTest() {
 }
 
 func TestICS20ERC20ConversionTestSuite(t *testing.T) {
-	t.Skip("STACK-2601: fix IBC tests")
 	suite.Run(t, new(ICS20ERC20ConversionTestSuite))
 }
 

--- a/evmd/tests/ibc/ics20_recursive_precompile_calls_test.go
+++ b/evmd/tests/ibc/ics20_recursive_precompile_calls_test.go
@@ -113,13 +113,12 @@ func (suite *ICS20RecursivePrecompileCallsTestSuite) setupContractForTesting(
 	senderAcc evmibctesting.SenderAccount,
 ) {
 	evmAppA := suite.chainA.App.(*evmd.EVMD)
-	ctxA := suite.chainA.GetContext()
 	senderAddr := senderAcc.SenderAccount.GetAddress()
 	senderEVMAddr := common.BytesToAddress(senderAddr.Bytes())
 	deployerAddr := common.BytesToAddress(suite.chainA.SenderPrivKey.PubKey().Address().Bytes())
 
 	// Register ERC20 contract
-	_, err := evmAppA.Erc20Keeper.RegisterERC20(ctxA, &erc20types.MsgRegisterERC20{
+	_, err := evmAppA.Erc20Keeper.RegisterERC20(suite.chainA.GetContext(), &erc20types.MsgRegisterERC20{
 		Signer:         evmAppA.AccountKeeper.GetModuleAddress("gov").String(),
 		Erc20Addresses: []string{contractAddr.Hex()},
 	})
@@ -127,14 +126,14 @@ func (suite *ICS20RecursivePrecompileCallsTestSuite) setupContractForTesting(
 	suite.chainA.NextBlock()
 
 	// Send native tokens to contract for delegation
-	bondDenom, err := evmAppA.StakingKeeper.BondDenom(ctxA)
+	bondDenom, err := evmAppA.StakingKeeper.BondDenom(suite.chainA.GetContext())
 	suite.Require().NoError(err)
 
 	contractAddrBech32, err := sdk.AccAddressFromHexUnsafe(contractAddr.Hex()[2:])
 	suite.Require().NoError(err)
 
 	deployerAddrBech32 := sdk.AccAddress(deployerAddr.Bytes())
-	deployerBalance := evmAppA.BankKeeper.GetBalance(ctxA, deployerAddrBech32, bondDenom)
+	deployerBalance := evmAppA.BankKeeper.GetBalance(suite.chainA.GetContext(), deployerAddrBech32, bondDenom)
 
 	// Send delegation amount to contract
 	sendAmount := sdkmath.NewInt(DelegationAmount)
@@ -143,7 +142,7 @@ func (suite *ICS20RecursivePrecompileCallsTestSuite) setupContractForTesting(
 	}
 
 	err = evmAppA.BankKeeper.SendCoins(
-		ctxA,
+		suite.chainA.GetContext(),
 		deployerAddrBech32,
 		contractAddrBech32,
 		sdk.NewCoins(sdk.NewCoin(bondDenom, sendAmount)),
@@ -174,7 +173,7 @@ func (suite *ICS20RecursivePrecompileCallsTestSuite) setupContractForTesting(
 
 	stateDB = statedb.New(suite.chainA.GetContext(), evmAppA.GetEVMKeeper(), statedb.NewEmptyTxConfig())
 	_, err = evmAppA.GetEVMKeeper().CallEVM(
-		ctxA,
+		suite.chainA.GetContext(),
 		stateDB,
 		contractData.ABI,
 		deployerAddr,
@@ -211,7 +210,7 @@ func (suite *ICS20RecursivePrecompileCallsTestSuite) setupContractForTesting(
 	// Verify minted balance
 	stateDB = statedb.New(suite.chainA.GetContext(), evmAppA.GetEVMKeeper(), statedb.NewEmptyTxConfig())
 	ethRes, err := evmAppA.GetEVMKeeper().CallEVM(
-		ctxA,
+		suite.chainA.GetContext(),
 		stateDB,
 		contractData.ABI,
 		common.BytesToAddress(senderAddr),
@@ -561,10 +560,9 @@ func (suite *ICS20RecursivePrecompileCallsTestSuite) TestContractICS20TransferWi
 	suite.Require().NoError(err)
 
 	evmAppA := suite.chainA.App.(*evmd.EVMD)
-	ctxA := suite.chainA.GetContext()
 
 	// Register both ERC20 contracts
-	_, err = evmAppA.Erc20Keeper.RegisterERC20(ctxA, &erc20types.MsgRegisterERC20{
+	_, err = evmAppA.Erc20Keeper.RegisterERC20(suite.chainA.GetContext(), &erc20types.MsgRegisterERC20{
 		Signer:         evmAppA.AccountKeeper.GetModuleAddress("gov").String(),
 		Erc20Addresses: []string{hookTokenAddr.Hex()},
 	})
@@ -576,18 +574,17 @@ func (suite *ICS20RecursivePrecompileCallsTestSuite) TestContractICS20TransferWi
 	mintData, err := hookTokenData.ABI.Pack("mint", testerAddr, hookTokenAmount)
 	suite.Require().NoError(err)
 
-	stateDB := statedb.New(ctxA, evmAppA.GetEVMKeeper(), statedb.NewEmptyTxConfig())
+	stateDB := statedb.New(suite.chainA.GetContext(), evmAppA.GetEVMKeeper(), statedb.NewEmptyTxConfig())
 	deployer := common.BytesToAddress(suite.chainA.SenderPrivKey.PubKey().Address().Bytes())
-	_, err = evmAppA.GetEVMKeeper().CallEVMWithData(ctxA, stateDB, deployer, &hookTokenAddr, mintData, true, false, nil)
+	_, err = evmAppA.GetEVMKeeper().CallEVMWithData(suite.chainA.GetContext(), stateDB, deployer, &hookTokenAddr, mintData, true, false, nil)
 	suite.Require().NoError(err)
 	suite.chainA.NextBlock()
 
 	// Mint regular tokens to tester for the dummy transfer
 	regularTokenAmount := big.NewInt(1000)
-	ctxA = suite.chainA.GetContext()
-	stateDB = statedb.New(ctxA, evmAppA.GetEVMKeeper(), statedb.NewEmptyTxConfig())
+	stateDB = statedb.New(suite.chainA.GetContext(), evmAppA.GetEVMKeeper(), statedb.NewEmptyTxConfig())
 	_, err = evmAppA.GetEVMKeeper().CallEVM(
-		ctxA,
+		suite.chainA.GetContext(),
 		stateDB,
 		regularTokenData.ABI,
 		deployer,
@@ -603,10 +600,10 @@ func (suite *ICS20RecursivePrecompileCallsTestSuite) TestContractICS20TransferWi
 	suite.chainA.NextBlock()
 
 	// Configure hook to perform delegation
-	bondDenom, err := evmAppA.StakingKeeper.BondDenom(ctxA)
+	bondDenom, err := evmAppA.StakingKeeper.BondDenom(suite.chainA.GetContext())
 	suite.Require().NoError(err)
 
-	vals, err := evmAppA.StakingKeeper.GetAllValidators(ctxA)
+	vals, err := evmAppA.StakingKeeper.GetAllValidators(suite.chainA.GetContext())
 	suite.Require().NoError(err)
 	validatorAddr := vals[0].OperatorAddress
 
@@ -646,9 +643,8 @@ func (suite *ICS20RecursivePrecompileCallsTestSuite) TestContractICS20TransferWi
 	suite.Require().NoError(err)
 
 	// Use CallEVM for configuration (setup function)
-	ctxA = suite.chainA.GetContext()
-	stateDB = statedb.New(ctxA, evmAppA.GetEVMKeeper(), statedb.NewEmptyTxConfig())
-	_, err = evmAppA.GetEVMKeeper().CallEVMWithData(ctxA, stateDB, deployer, &hookTokenAddr, configData, true, false, nil)
+	stateDB = statedb.New(suite.chainA.GetContext(), evmAppA.GetEVMKeeper(), statedb.NewEmptyTxConfig())
+	_, err = evmAppA.GetEVMKeeper().CallEVMWithData(suite.chainA.GetContext(), stateDB, deployer, &hookTokenAddr, configData, true, false, nil)
 	suite.Require().NoError(err)
 	suite.chainA.NextBlock()
 
@@ -658,11 +654,10 @@ func (suite *ICS20RecursivePrecompileCallsTestSuite) TestContractICS20TransferWi
 	transferTokenAmount := sdkmath.NewIntFromBigInt(big.NewInt(InitialTokenAmount / 2))
 
 	// Get balances before
-	ctxA = suite.chainA.GetContext()
-	testerHookBalBefore := evmAppA.Erc20Keeper.BalanceOf(ctxA, hookTokenData.ABI, hookTokenAddr, testerAddr)
-	hookTokenNativeBalBefore := evmAppA.GetBankKeeper().GetBalance(ctxA, hookTokenAddrSDK, bondDenom)
+	testerHookBalBefore := evmAppA.Erc20Keeper.BalanceOf(suite.chainA.GetContext(), hookTokenData.ABI, hookTokenAddr, testerAddr)
+	hookTokenNativeBalBefore := evmAppA.GetBankKeeper().GetBalance(suite.chainA.GetContext(), hookTokenAddrSDK, bondDenom)
 	recipientAddrSDK := senderAccount.SenderAccount.GetAddress()
-	recipientNativeBalBefore := evmAppA.GetBankKeeper().GetBalance(ctxA, recipientAddrSDK, bondDenom)
+	recipientNativeBalBefore := evmAppA.GetBankKeeper().GetBalance(suite.chainA.GetContext(), recipientAddrSDK, bondDenom)
 
 	// Call scenario9_transferICS20Transfer from tester contract
 	callData, err := testerData.ABI.Pack(
@@ -685,10 +680,9 @@ func (suite *ICS20RecursivePrecompileCallsTestSuite) TestContractICS20TransferWi
 	suite.Require().NoError(err)
 
 	// Get balances after
-	ctxA = suite.chainA.GetContext()
-	testerHookBalAfter := evmAppA.Erc20Keeper.BalanceOf(ctxA, hookTokenData.ABI, hookTokenAddr, testerAddr)
-	hookTokenNativeBalAfter := evmAppA.GetBankKeeper().GetBalance(ctxA, hookTokenAddrSDK, bondDenom)
-	recipientNativeBalAfter := evmAppA.GetBankKeeper().GetBalance(ctxA, recipientAddrSDK, bondDenom)
+	testerHookBalAfter := evmAppA.Erc20Keeper.BalanceOf(suite.chainA.GetContext(), hookTokenData.ABI, hookTokenAddr, testerAddr)
+	hookTokenNativeBalAfter := evmAppA.GetBankKeeper().GetBalance(suite.chainA.GetContext(), hookTokenAddrSDK, bondDenom)
+	recipientNativeBalAfter := evmAppA.GetBankKeeper().GetBalance(suite.chainA.GetContext(), recipientAddrSDK, bondDenom)
 
 	// Verify ERC20 balance changes
 	expectedERC20Delta := transferTokenAmount.BigInt()
@@ -711,12 +705,12 @@ func (suite *ICS20RecursivePrecompileCallsTestSuite) TestContractICS20TransferWi
 		"recipient should receive 2 native transfers")
 
 	// Verify delegation occurred
-	delegations, err := evmAppA.StakingKeeper.GetAllDelegatorDelegations(ctxA, hookTokenAddrSDK)
+	delegations, err := evmAppA.StakingKeeper.GetAllDelegatorDelegations(suite.chainA.GetContext(), hookTokenAddrSDK)
 	suite.Require().NoError(err)
 	suite.Require().Equal(1, len(delegations), "should have 1 delegation from beforeTransfer hook")
 
 	// Verify total bonded amount
-	bondedTokens, err := evmAppA.StakingKeeper.GetDelegatorBonded(ctxA, hookTokenAddrSDK)
+	bondedTokens, err := evmAppA.StakingKeeper.GetDelegatorBonded(suite.chainA.GetContext(), hookTokenAddrSDK)
 	suite.Require().NoError(err)
 	expectedBondedAmount := DelegationAmount // Convert wei to base denom
 	suite.Require().Equal(int64(expectedBondedAmount), bondedTokens.Int64(),
@@ -775,13 +769,12 @@ func (suite *ICS20RecursivePrecompileCallsTestSuite) TestContractICS20TransferRe
 	suite.Require().NoError(err)
 
 	evmAppA := suite.chainA.App.(*evmd.EVMD)
-	ctxA := suite.chainA.GetContext()
 
 	// Get deployer address for CallEVM
 	deployer := common.BytesToAddress(suite.chainA.SenderPrivKey.PubKey().Address().Bytes())
 
 	// Register both ERC20 contracts
-	_, err = evmAppA.Erc20Keeper.RegisterERC20(ctxA, &erc20types.MsgRegisterERC20{
+	_, err = evmAppA.Erc20Keeper.RegisterERC20(suite.chainA.GetContext(), &erc20types.MsgRegisterERC20{
 		Signer:         evmAppA.AccountKeeper.GetModuleAddress("gov").String(),
 		Erc20Addresses: []string{regularTokenAddr.Hex(), hookTokenAddr.Hex()},
 	})
@@ -793,8 +786,8 @@ func (suite *ICS20RecursivePrecompileCallsTestSuite) TestContractICS20TransferRe
 	mintRegularData, err := regularTokenData.ABI.Pack("mint", testerAddr, regularTokenAmount)
 	suite.Require().NoError(err)
 
-	stateDB := statedb.New(ctxA, evmAppA.GetEVMKeeper(), statedb.NewEmptyTxConfig())
-	_, err = evmAppA.GetEVMKeeper().CallEVMWithData(ctxA, stateDB, deployer, &regularTokenAddr, mintRegularData, true, false, nil)
+	stateDB := statedb.New(suite.chainA.GetContext(), evmAppA.GetEVMKeeper(), statedb.NewEmptyTxConfig())
+	_, err = evmAppA.GetEVMKeeper().CallEVMWithData(suite.chainA.GetContext(), stateDB, deployer, &regularTokenAddr, mintRegularData, true, false, nil)
 	suite.Require().NoError(err)
 	suite.chainA.NextBlock()
 
@@ -803,13 +796,12 @@ func (suite *ICS20RecursivePrecompileCallsTestSuite) TestContractICS20TransferRe
 	mintHookData, err := hookTokenData.ABI.Pack("mint", testerAddr, hookTokenAmount)
 	suite.Require().NoError(err)
 
-	ctxA = suite.chainA.GetContext()
-	stateDB = statedb.New(ctxA, evmAppA.GetEVMKeeper(), statedb.NewEmptyTxConfig())
-	_, err = evmAppA.GetEVMKeeper().CallEVMWithData(ctxA, stateDB, deployer, &hookTokenAddr, mintHookData, true, false, nil)
+	stateDB = statedb.New(suite.chainA.GetContext(), evmAppA.GetEVMKeeper(), statedb.NewEmptyTxConfig())
+	_, err = evmAppA.GetEVMKeeper().CallEVMWithData(suite.chainA.GetContext(), stateDB, deployer, &hookTokenAddr, mintHookData, true, false, nil)
 	suite.Require().NoError(err)
 	suite.chainA.NextBlock()
 
-	vals, err := evmAppA.StakingKeeper.GetAllValidators(ctxA)
+	vals, err := evmAppA.StakingKeeper.GetAllValidators(suite.chainA.GetContext())
 	suite.Require().NoError(err)
 	validatorAddr := vals[0].OperatorAddress
 
@@ -849,9 +841,8 @@ func (suite *ICS20RecursivePrecompileCallsTestSuite) TestContractICS20TransferRe
 	suite.Require().NoError(err)
 
 	// Use CallEVM for configuration (setup function)
-	ctxA = suite.chainA.GetContext()
-	stateDB = statedb.New(ctxA, evmAppA.GetEVMKeeper(), statedb.NewEmptyTxConfig())
-	_, err = evmAppA.GetEVMKeeper().CallEVMWithData(ctxA, stateDB, deployer, &hookTokenAddr, configData, true, false, nil)
+	stateDB = statedb.New(suite.chainA.GetContext(), evmAppA.GetEVMKeeper(), statedb.NewEmptyTxConfig())
+	_, err = evmAppA.GetEVMKeeper().CallEVMWithData(suite.chainA.GetContext(), stateDB, deployer, &hookTokenAddr, configData, true, false, nil)
 	suite.Require().NoError(err)
 	suite.chainA.NextBlock()
 
@@ -861,14 +852,13 @@ func (suite *ICS20RecursivePrecompileCallsTestSuite) TestContractICS20TransferRe
 	transferTokenAmount := sdkmath.NewIntFromBigInt(big.NewInt(InitialTokenAmount / 2))
 
 	// Get balances before
-	ctxA = suite.chainA.GetContext()
-	bondDenom, err := evmAppA.StakingKeeper.BondDenom(ctxA)
+	bondDenom, err := evmAppA.StakingKeeper.BondDenom(suite.chainA.GetContext())
 	suite.Require().NoError(err)
-	regularTokenBalBefore := evmAppA.Erc20Keeper.BalanceOf(ctxA, regularTokenData.ABI, regularTokenAddr, testerAddr)
-	testerHookBalBefore := evmAppA.Erc20Keeper.BalanceOf(ctxA, hookTokenData.ABI, hookTokenAddr, testerAddr)
-	hookTokenNativeBalBefore := evmAppA.GetBankKeeper().GetBalance(ctxA, hookTokenAddrSDK, bondDenom)
+	regularTokenBalBefore := evmAppA.Erc20Keeper.BalanceOf(suite.chainA.GetContext(), regularTokenData.ABI, regularTokenAddr, testerAddr)
+	testerHookBalBefore := evmAppA.Erc20Keeper.BalanceOf(suite.chainA.GetContext(), hookTokenData.ABI, hookTokenAddr, testerAddr)
+	hookTokenNativeBalBefore := evmAppA.GetBankKeeper().GetBalance(suite.chainA.GetContext(), hookTokenAddrSDK, bondDenom)
 	recipientAddrSDK := senderAccount.SenderAccount.GetAddress()
-	recipientNativeBalBefore := evmAppA.GetBankKeeper().GetBalance(ctxA, recipientAddrSDK, bondDenom)
+	recipientNativeBalBefore := evmAppA.GetBankKeeper().GetBalance(suite.chainA.GetContext(), recipientAddrSDK, bondDenom)
 
 	// Call scenario10_transferICS20TransferRevert from tester contract
 	// First transfer will revert due to excessive amount
@@ -893,11 +883,10 @@ func (suite *ICS20RecursivePrecompileCallsTestSuite) TestContractICS20TransferRe
 	suite.Require().NoError(err)
 
 	// Get balances after
-	ctxA = suite.chainA.GetContext()
-	regularTokenBalAfter := evmAppA.Erc20Keeper.BalanceOf(ctxA, regularTokenData.ABI, regularTokenAddr, testerAddr)
-	testerHookBalAfter := evmAppA.Erc20Keeper.BalanceOf(ctxA, hookTokenData.ABI, hookTokenAddr, testerAddr)
-	hookTokenNativeBalAfter := evmAppA.GetBankKeeper().GetBalance(ctxA, hookTokenAddrSDK, bondDenom)
-	recipientNativeBalAfter := evmAppA.GetBankKeeper().GetBalance(ctxA, recipientAddrSDK, bondDenom)
+	regularTokenBalAfter := evmAppA.Erc20Keeper.BalanceOf(suite.chainA.GetContext(), regularTokenData.ABI, regularTokenAddr, testerAddr)
+	testerHookBalAfter := evmAppA.Erc20Keeper.BalanceOf(suite.chainA.GetContext(), hookTokenData.ABI, hookTokenAddr, testerAddr)
+	hookTokenNativeBalAfter := evmAppA.GetBankKeeper().GetBalance(suite.chainA.GetContext(), hookTokenAddrSDK, bondDenom)
+	recipientNativeBalAfter := evmAppA.GetBankKeeper().GetBalance(suite.chainA.GetContext(), recipientAddrSDK, bondDenom)
 
 	// Verify regular token balance unchanged (transfer reverted)
 	suite.Require().Equal(regularTokenBalBefore.String(), regularTokenBalAfter.String(),
@@ -925,12 +914,12 @@ func (suite *ICS20RecursivePrecompileCallsTestSuite) TestContractICS20TransferRe
 		"recipient should receive 2 native transfers")
 
 	// Verify delegation occurred (from beforeTransfer hook)
-	delegations, err := evmAppA.StakingKeeper.GetAllDelegatorDelegations(ctxA, hookTokenAddrSDK)
+	delegations, err := evmAppA.StakingKeeper.GetAllDelegatorDelegations(suite.chainA.GetContext(), hookTokenAddrSDK)
 	suite.Require().NoError(err)
 	suite.Require().Equal(1, len(delegations), "should have 1 delegation from beforeTransfer hook")
 
 	// Verify total bonded amount
-	bondedTokens, err := evmAppA.StakingKeeper.GetDelegatorBonded(ctxA, hookTokenAddrSDK)
+	bondedTokens, err := evmAppA.StakingKeeper.GetDelegatorBonded(suite.chainA.GetContext(), hookTokenAddrSDK)
 	suite.Require().NoError(err)
 	expectedBondedAmount := DelegationAmount // Convert wei to base denom
 	suite.Require().Equal(int64(expectedBondedAmount), bondedTokens.Int64(),

--- a/evmd/tests/ibc/ics20_recursive_precompile_calls_test.go
+++ b/evmd/tests/ibc/ics20_recursive_precompile_calls_test.go
@@ -942,6 +942,5 @@ func (suite *ICS20RecursivePrecompileCallsTestSuite) TestContractICS20TransferRe
 }
 
 func TestICS20RecursivePrecompileCallsTestSuite(t *testing.T) {
-	t.Skip("STACK-2601: fix IBC tests")
 	suite.Run(t, new(ICS20RecursivePrecompileCallsTestSuite))
 }

--- a/evmd/tests/ibc/v2_ibc_middleware_test.go
+++ b/evmd/tests/ibc/v2_ibc_middleware_test.go
@@ -65,7 +65,6 @@ func (suite *MiddlewareV2TestSuite) SetupTest() {
 }
 
 func TestMiddlewareV2TestSuite(t *testing.T) {
-	t.Skip("STACK-2601: fix IBC tests")
 	testifysuite.Run(t, new(MiddlewareV2TestSuite))
 }
 

--- a/evmd/tests/ibc/v2_transfer_test.go
+++ b/evmd/tests/ibc/v2_transfer_test.go
@@ -82,7 +82,6 @@ func (suite *TransferTestSuiteV2) SetupTest() {
 }
 
 func TestTransferTestSuiteV2(t *testing.T) {
-	t.Skip("STACK-2601: fix IBC tests")
 	testifysuite.Run(t, new(TransferTestSuiteV2))
 }
 

--- a/tests/integration/precompiles/ics20/test_integration.go
+++ b/tests/integration/precompiles/ics20/test_integration.go
@@ -30,8 +30,6 @@ import (
 )
 
 func TestPrecompileIntegrationTestSuite(t *testing.T, evmAppCreator ibctesting.AppCreator) {
-	t.Skip("STACK-2601: fix IBC tests")
-
 	isContractDeployed := func(ctx sdk.Context, evmApp evm.EvmApp, contractAddr common.Address) bool {
 		codeHash := evmApp.GetEVMKeeper().GetCodeHash(ctx, contractAddr)
 		code := evmApp.GetEVMKeeper().GetCode(ctx, codeHash)

--- a/testutil/ibc/chain.go
+++ b/testutil/ibc/chain.go
@@ -95,6 +95,13 @@ type TestChain struct {
 	// Short-term solution to override the logic of the standard SendMsgs function.
 	// See issue https://github.com/cosmos/ibc-go/issues/3123 for more information.
 	SendMsgsOverride func(msgs ...sdk.Msg) (*abci.ExecTxResult, error)
+
+	// nextBlockContextInitialized tracks whether NewNextBlockContext has been
+	// called for the current block. Calling it again would reset the finalize
+	// state and discard any writes made since the last call. GetContext uses
+	// this to initialize lazily and then return NewContextLegacy on subsequent
+	// calls so direct keeper writes accumulate across a single test body.
+	nextBlockContextInitialized bool
 }
 
 // NewTestChainWithValSet initializes a new TestChain instance with the given validator set
@@ -235,8 +242,32 @@ func NewTestChain(t *testing.T, isEVM bool, coord *Coordinator, chainID string) 
 }
 
 // GetContext returns the current context for the application.
+// If called between blocks (after Commit, before FinalizeBlock), it lazily
+// initializes the finalize state via NewNextBlockContext so that direct keeper
+// writes target the state that will be committed in the next block.
+// If called during FinalizeBlock (e.g. inside a contract callback), it returns
+// the already-active finalize state without replacing it.
 func (chain *TestChain) GetContext() sdk.Context {
-	return chain.App.GetBaseApp().NewNextBlockContext(chain.ProposedHeader)
+	if !chain.nextBlockContextInitialized {
+		// Try to get the existing finalize state first. If FinalizeBlock is
+		// in progress, the state already exists and we must not replace it
+		// with NewNextBlockContext.
+		if ctx, ok := chain.tryGetContextLegacy(); ok {
+			return ctx
+		}
+		chain.App.GetBaseApp().NewNextBlockContext(chain.ProposedHeader)
+		chain.nextBlockContextInitialized = true
+	}
+
+	return chain.App.GetBaseApp().NewContextLegacy(false, chain.ProposedHeader)
+}
+
+// tryGetContextLegacy attempts to get a context from the finalize state.
+// Returns false if the finalize state is not initialized (e.g. between blocks).
+func (chain *TestChain) tryGetContextLegacy() (sdk.Context, bool) {
+	defer func() { recover() }() //nolint:errcheck // catch nil pointer panic
+	ctx := chain.App.GetBaseApp().NewContextLegacy(false, chain.ProposedHeader)
+	return ctx, true
 }
 
 // GetSimApp returns the SimApp to allow usage ofnon-interface fields.
@@ -347,6 +378,7 @@ func (chain *TestChain) NextBlock() {
 func (chain *TestChain) commitBlock(res *abci.ResponseFinalizeBlock) {
 	_, err := chain.App.Commit()
 	require.NoError(chain.TB, err)
+	chain.nextBlockContextInitialized = false
 
 	// set the last header to the current header
 	// use nil trusted fields


### PR DESCRIPTION
closes: STACK-2601

Fixes IBC tests by copying the [upstream](https://github.com/cosmos/ibc-go/blob/v11.0.0/testing/chain.go#L219-L245) context getters to avoid wiping context between calls.

Also fixes ctx reuse by refreshing context every time a value is changed by keepers to reflect the use of cached contexts rather than the deprecated `NewUncachedContext()`.