### PR TITLE
fix(mempool): remove unnecessary fetch of context on mempool removals

### DIFF
--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -369,19 +369,13 @@ func (m *Mempool) Remove(tx sdk.Tx) error {
 // For EVM transactions, removal is typically handled automatically by the pool
 // based on nonce progression. Cosmos transactions are removed from the Cosmos pool.
 func (m *Mempool) RemoveWithReason(ctx context.Context, tx sdk.Tx, reason sdkmempool.RemoveReason) error {
-	chainCtx, err := m.blockchain.GetLatestContext()
-	if err != nil || chainCtx.BlockHeight() == 0 {
-		m.logger.Warn("Failed to get latest context, skipping removal")
-		return nil
-	}
-
 	msgEthereumTx, err := evmTxFromCosmosTx(tx)
 	switch {
 	case errors.Is(err, ErrNoMessages):
 		return err
 	case err != nil:
 		// unable to parse evm tx -> process as cosmos tx
-		return m.removeCosmosTx(ctx, tx, reason)
+		return m.removeCosmosTx(tx)
 	}
 
 	hash := msgEthereumTx.Hash()
@@ -403,15 +397,14 @@ func (m *Mempool) RemoveWithReason(ctx context.Context, tx sdk.Tx, reason sdkmem
 
 // removeCosmosTx removes a cosmos tx from the mempool.
 // The RecheckMempool handles locking internally.
-func (m *Mempool) removeCosmosTx(ctx context.Context, tx sdk.Tx, reason sdkmempool.RemoveReason) error {
+func (m *Mempool) removeCosmosTx(tx sdk.Tx) error {
 	m.logger.Debug("Removing Cosmos transaction")
 
 	// Remove from cosmos pool (handles address reservation release  and reap
 	// list drop internally)
-	err := sdkmempool.RemoveWithReason(ctx, m.recheckCosmosPool, tx, reason)
-	if err != nil {
+	if err := m.recheckCosmosPool.Remove(tx); err != nil {
 		m.logger.Error("Failed to remove Cosmos transaction", "error", err)
-		return err
+		return fmt.Errorf("removing cosmos tx: %w", err)
 	}
 	m.logger.Debug("Cosmos transaction removed successfully")
 


### PR DESCRIPTION
# Description

Fetching the `ctx` from the mempools `blockchain` is actually not necessary here, it was unused. This was causing a warning log when we would finalize a block during blocksync or wal replay, since the blockchains `ctx` was not available yet.

Closes: STACK-2381

---

## Author Checklist

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.

I have...

- [ ] tackled an existing issue or discussed with a team member
- [ ] left instructions on how to review the changes
- [ ] targeted the `main` branch
