### PR TITLE
fix(mempool): fix race between queued tx promotion reorg and reset reorg causing stuck queued txs

### DIFF
--- a/mempool/txpool/legacypool/legacypool.go
+++ b/mempool/txpool/legacypool/legacypool.go
@@ -1510,6 +1510,49 @@ type reorgInput struct {
 	events        map[common.Address]*SortedMap
 }
 
+// computePendingTipNonces returns a mapping from account address to the next
+// expected nonce, taking the pending pool entries into account, but not the
+// queued pool entries.
+func (pool *LegacyPool) computePendingTipNonces() map[common.Address]uint64 {
+	tips := make(map[common.Address]uint64, len(pool.pending))
+	for addr, list := range pool.pending {
+		// get the next nonce that should be included on chain after last
+		// pending pool tx for this account lands
+		nextPendingNonce := list.LastElement().Nonce() + 1
+
+		// grab the latest nonce that we have observed on chain for this
+		// account if we have it cached
+		latestIncludedNonce, ok := pool.latestIncludedNonce.Get(addr)
+		if ok {
+			// if we have a cached on chain nonce for this account, it likely
+			// had a tx land in the latest block and its last pending pool
+			// element may be stale if we have not yet run demoteUnexecutables
+			// yet. thus, if the latestIncludedNonce + 1 is > nextPendingNonce,
+			// then that is actually what we should be using as the 'tip' of
+			// the pending pool for this account
+			//
+			// NOTE: latestIncludedNonce is a lru cache (lru to manage its
+			// growth). It is strongly recommended to the user to configure
+			// this cache size > the max number of unique accounts they expect
+			// to see in a block. If they do not do so, an issue could manifest
+			// here where a block has more accounts than entries in the
+			// latestIncludedNonce cache. If an entry gets evicted from
+			// latestIncludedNonce for an account that was included in H-1,
+			// then calling this function at H will use a stale
+			// nextPendingNonce value (when compared to statedb.GetNonce(addr))
+			// if this function is called before demoteUnexecutables, causing a
+			// queued contiguous nonce tx (with respect to pending txs) to not
+			// be promoted if there is a race on resetting + promoting the
+			// queued tx after insert. This is unlikely and would require a
+			// misconfiguration by the user, but this is a documented possible
+			// scenario.
+			nextPendingNonce = max(nextPendingNonce, latestIncludedNonce+1)
+		}
+		tips[addr] = nextPendingNonce
+	}
+	return tips
+}
+
 // runReorg runs reset and promoteExecutables on behalf of scheduleReorgLoop.
 func (pool *LegacyPool) runReorg(input reorgInput) {
 	defer func(t0 time.Time) {
@@ -1566,12 +1609,7 @@ func (pool *LegacyPool) runReorg(input reorgInput) {
 			}
 		}
 		// Update all accounts to the latest known pending nonce
-		nonces := make(map[common.Address]uint64, len(pool.pending))
-		for addr, list := range pool.pending {
-			highestPending := list.LastElement()
-			nonces[addr] = highestPending.Nonce() + 1
-		}
-		pool.pendingNonces.setAll(nonces)
+		pool.pendingNonces.setAll(pool.computePendingTipNonces())
 		pool.validPendingTxs.EndCurrentHeight()
 	}
 
@@ -1629,6 +1667,26 @@ func (pool *LegacyPool) resetInternalState(newHead *types.Header, reinject types
 	pool.currentHead.Store(newHead)
 	pool.currentState = statedb
 	pool.pendingNonces = newNoncer(statedb)
+
+	// a brand new noncer only knows the statedb's committed nonce, which may
+	// be behind the tip of pool.pending nonce wise. we need to reconcile
+	// the noncer with the current pending tip so that any subsequent
+	// promoteExecutables can still promote queued txs whose nonces are
+	// contiguous with pending.
+	//
+	// without this the following scenario is possible:
+	// - pool.pending = [tx0, tx1], pool.queue = [tx2].
+	// - statedb nonce for this account is 0 (nothing included on chain).
+	// - reset runs **before** the async promotion gets scheduled, or they are batched together.
+	// - pendingNonces reset = newNoncer(statedb), noncer map empty so
+	//   get(addr) falls back to nonce 0 from statedb.
+	// - promoteExecutables calls list.Ready(0) on pool.queue = [tx2], sees
+	//   lowest nonce 2 > 0, returns a gap, promotes nothing.
+	// - tx2 stays stuck in queued even though it is contiguous with pending.
+	// - tx2 must wait for another insert from this account in order to be
+	//   promoted, or the existing pending txs are included on chain.
+	pool.pendingNonces.setAll(pool.computePendingTipNonces())
+
 	ctx, err := pool.chain.GetLatestContext()
 	if err != nil {
 		panic(fmt.Errorf("failed to get latest context for rechecker: %w", err))

--- a/mempool/txpool/legacypool/legacypool_test.go
+++ b/mempool/txpool/legacypool/legacypool_test.go
@@ -2840,6 +2840,104 @@ func TestSetCodeTransactionsReorg(t *testing.T) {
 	}
 }
 
+func TestQueuedPromotionOnReset(t *testing.T) {
+	t.Parallel()
+
+	pool, _, _ := setupPool()
+	defer pool.Close()
+
+	// create transactions with sequential nonces
+	key, _ := crypto.GenerateKey()
+	addr := crypto.PubkeyToAddress(key.PublicKey)
+
+	// mock the on chain nonce for this account as 0
+	testSetNonce(pool, addr, 0)
+	testAddBalance(pool, addr, big.NewInt(1000000000000000))
+
+	// create two txs and add  both transactions to the pool synchronously, so
+	// they will both go to pending
+	tx0 := transaction(0, 100000, key)
+	tx1 := transaction(1, 100000, key)
+	require.NoError(t, pool.addRemoteSync(tx0))
+	require.NoError(t, pool.addRemoteSync(tx1))
+
+	// create another sequential tx based on the previous two, but only enqueue
+	// it
+	tx2 := transaction(2, 100000, key)
+	replaced, err := pool.enqueueTx(tx2.Hash(), tx2, true)
+	require.False(t, replaced, "enqueuing tx should not have replaced anything")
+	require.NoError(t, err)
+
+	// ensure we have 2 txs in pending and 1 in queued
+	pending, queued := pool.Stats()
+	require.Equal(t, 2, pending, "incorrect amount of txs in the pending pool after setup")
+	require.Equal(t, 1, queued, "incorrect amount of txs in queued pool after setup")
+
+	// now we reset the pool to a new height. this reset will trigger a mempool
+	// state reset, plus a promotion of our queued tx to pending
+	oldHead := pool.currentHead.Load()
+	oldHead.BaseFee = big.NewInt(100) // needed for testing
+	newHead := *oldHead
+	newHead.Number = new(big.Int).Add(oldHead.Number, big.NewInt(1))
+	pool.Reset(oldHead, &newHead)
+
+	pending, queued = pool.Stats()
+	require.Equal(t, 3, pending, "incorrect amount of txs in the pending pool after reset")
+	require.Equal(t, 0, queued, "incorrect amount of txs in queued pool after reset")
+}
+
+func TestQueuedPromotionOnResetWithStalePending(t *testing.T) {
+	t.Parallel()
+
+	pool, _, _ := setupPool()
+	defer pool.Close()
+
+	// create transactions with sequential nonces
+	key, _ := crypto.GenerateKey()
+	addr := crypto.PubkeyToAddress(key.PublicKey)
+
+	// mock the on chain nonce for this account as 0
+	testSetNonce(pool, addr, 0)
+	testAddBalance(pool, addr, big.NewInt(1000000000000000))
+
+	// create two txs and add  both transactions to the pool synchronously, so
+	// they will both go to pending
+	tx0 := transaction(0, 100000, key)
+	tx1 := transaction(1, 100000, key)
+	require.NoError(t, pool.addRemoteSync(tx0))
+	require.NoError(t, pool.addRemoteSync(tx1))
+
+	// create another tx with a nonce gap from the previous two, this will stay
+	// enqueued.
+	tx3 := transaction(3, 100000, key)
+	require.NoError(t, pool.addRemoteSync(tx3))
+
+	// ensure we have 2 txs in pending and 1 in queued
+	pending, queued := pool.Stats()
+	require.Equal(t, 2, pending, "incorrect amount of txs in the pending pool after setup")
+	require.Equal(t, 1, queued, "incorrect amount of txs in queued pool after setup")
+
+	// mock that tx0 and tx1 **AND** tx2 were included on chain (simulating
+	// that another node had tx2, and filled the nonce gap for us)
+	require.NoError(t, pool.ScheduleForRemoval(tx0))
+	require.NoError(t, pool.ScheduleForRemoval(tx1))
+	tx2 := transaction(2, 100000, key)
+	require.NoError(t, pool.ScheduleForRemoval(tx2))
+
+	// now we reset the pool to a new height. this reset will trigger a mempool
+	// state reset, plus a promotion of our queued tx to pending, and dropping
+	// the olds txs that were scheduled for removal
+	oldHead := pool.currentHead.Load()
+	oldHead.BaseFee = big.NewInt(100) // needed for testing
+	newHead := *oldHead
+	newHead.Number = new(big.Int).Add(oldHead.Number, big.NewInt(1))
+	pool.Reset(oldHead, &newHead)
+
+	pending, queued = pool.Stats()
+	require.Equal(t, 1, pending, "incorrect amount of txs in the pending pool after reset")
+	require.Equal(t, 0, queued, "incorrect amount of txs in queued pool after reset")
+}
+
 // TestRemoveTxTruncatePoolRace is a regression test for a race condition
 // between removing txs and runReorg loop. Run this with the -race flag to
 // ensure that there is no race condition between the two functions.


### PR DESCRIPTION
# Description

Fixes a race condition that was causing flakey tests (`TestMempool_ReapNewBlock` & `TestMempool_ReapPromoteDemotePromote`) that would manifest as txs being not promoted from queued -> pending. 

This race happens when an account has txs in pending, then a new tx is inserted into queued, and a promotion is scheduled. At the same time, a new block arrives, and some delay (likely an existing reorg loop running, or just scheduler delay) causes the promotion reorg loop run + the new block reset reorg loop run to be combined (they both see `currDone != nil`, so they wait and run together). Since `reset != nil`, we will run `pool.resetInternalState`, which clears `pool.pendingNonces` to be the on chain nonce (every `.Get(addr)` will fall back to `statedb.GetNonce(addr)`) at the height we are resetting on top of. Now, we will then run `promoteExecutables`, which attempt to promote our queued tx to pending. This tx is ready based on the on chain state and the pending state (lets say the tx in queued has nonce 3, and in pending currently there is nonce 1 and 2). However, `promoteExecutables` will check `pool.pendingNonces` to get the latest nonce for this account based on the pending state, but we have just reset it, and it will show the on chain nonce (`0`), not the pending nonce (`2`). Thus, it will consider this queued tx still a nonce gapped tx, and incorrectly keep it in pending.

After `demoteUnexecutables` runs, we repopulate the `pendingNonces` map with the state of the pending pool based on the state of the pending pool post demotion, so the next time a promotion for this account happens (a new tx must arrive after rebuilding the `pendingNonces` map), this tx will be properly promoted.

To fix this, we rebuild the `pendingNonces` map right after we `resetInternalState` (which clears it), based on the current state of the pending pool **AND** the current state of the `latestIncludedNonce` cache. The `latestIncludedNonce` is a LRU cache of accounts -> nonce that we have seen included on chain via `FinalizeBlock` calling `mempool.Remove`. We defer the removal of these txs by included their nonces in the cache, and removing them during `demoteUnexecutables` via `pool.removeOlds`. However this means that some pending txs in the pending pool when we are rebuilding `pendingNonces` just after `resetInternalState` may actually be stale, and we are about to drop them because they were just included in a block. Thus, we also must repopulate `pendingNonces` with the max of the pending pool greatest nonce, and the `latestIncludedNonce` nonce (if available).

Additionally, there is another subtle issue with using `latestIncludedNonce` here, since this is a LRU cache. What if we evict an account -> nonce mapping since the cache is full? This would cause us to prefer the pending pool greatest nonce, which is actually stale compared to the nonce on chain, causing the promotion to again see a nonce gap and not promote our queued tx. However, it is documented that the user should configure the size of this cache to be > the maximum number of accounts they expect to see in a single block, so if configured correctly, this should never happen, plus, you would also need this race condition to happen at the same time, which is extremely rare. Thus, I am opting to leave this as a documented limitation for now.

Closes: STACK-2546

---

## Author Checklist

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.

I have...

- [ ] tackled an existing issue or discussed with a team member
- [ ] left instructions on how to review the changes
- [ ] targeted the `main` branch
