### PR TITLE
fix(eip-712)!: encoding was using default evm chain id instead of actual chain idVlad/eip712 chainid fix

### DIFF
--- a/ethereum/eip712/encoding.go
+++ b/ethereum/eip712/encoding.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"regexp"
 	"strconv"
 
 	apitypes "github.com/ethereum/go-ethereum/signer/core/apitypes"
@@ -242,9 +243,27 @@ func validateCodecInit() error {
 	return nil
 }
 
-// parseChainID attempts to parse the chain ID string as a uint64.
-// The chain ID in the sign doc should be the EIP-155 chain ID.
+// cosmosEVMChainIDRegex matches the canonical cosmos-evm chain id format
+// "<name>_<eip155>-<revision>", e.g. "cosmos_9001-1" or "cosmos_262144-1",
+// and captures the EIP-155 numeric portion.
+var cosmosEVMChainIDRegex = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9]*_([1-9][0-9]*)-[1-9][0-9]*$`)
+
+// parseChainID extracts the EIP-155 numeric chain id from a Cosmos sign-doc
+// chain id string. It supports both:
+//
+//   - the canonical cosmos-evm form "<name>_<eip155>-<revision>"
+//     (e.g. "cosmos_9001-1"), and
+//   - a bare decimal string (e.g. "9001"), which is what the CLI emits when
+//     a chain is configured to use its EVM chain id directly as its
+//     Cosmos chain id.
+//
+// Cosmos chain ids that don't encode an EVM chain id (e.g. "cosmoshub-4",
+// "cosmos-1") return an error; callers should fall back to the configured
+// global eip155ChainID for those.
 func parseChainID(chainIDStr string) (uint64, error) {
+	if m := cosmosEVMChainIDRegex.FindStringSubmatch(chainIDStr); len(m) == 2 {
+		return strconv.ParseUint(m[1], 10, 64)
+	}
 	return strconv.ParseUint(chainIDStr, 10, 64)
 }
 

--- a/ethereum/eip712/encoding.go
+++ b/ethereum/eip712/encoding.go
@@ -110,8 +110,8 @@ func decodeAminoSignDoc(signDocBytes []byte) (apitypes.TypedData, error) {
 		return apitypes.TypedData{}, err
 	}
 
-	// Extract the chain ID from the sign doc itself for EIP-712 domain
-	// This ensures we use the same chain ID that was used during signing
+	// Prefer the sign-doc's chain id so verification can't drift from signing
+	// when the global eip155ChainID is stale (see #918).
 	chainID := eip155ChainID
 	if aminoDoc.ChainID != "" {
 		if parsedChainID, err := parseChainID(aminoDoc.ChainID); err == nil {
@@ -213,8 +213,7 @@ func decodeProtobufSignDoc(signDocBytes []byte) (apitypes.TypedData, error) {
 		return apitypes.TypedData{}, errorsmod.Wrap(err, "failed to get sign bytes using aminojson")
 	}
 
-	// Extract the chain ID from the sign doc itself for EIP-712 domain
-	// This ensures we use the same chain ID that was used during signing
+	// See decodeAminoSignDoc: prefer the sign-doc's chain id over the global.
 	chainID := eip155ChainID
 	if signDoc.ChainId != "" {
 		if parsedChainID, err := parseChainID(signDoc.ChainId); err == nil {
@@ -243,23 +242,14 @@ func validateCodecInit() error {
 	return nil
 }
 
-// cosmosEVMChainIDRegex matches the canonical cosmos-evm chain id format
-// "<name>_<eip155>-<revision>", e.g. "cosmos_9001-1" or "cosmos_262144-1",
-// and captures the EIP-155 numeric portion.
+// cosmosEVMChainIDRegex captures the EIP-155 id from the canonical
+// "<name>_<eip155>-<revision>" form (e.g. "cosmos_9001-1").
 var cosmosEVMChainIDRegex = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9]*_([1-9][0-9]*)-[1-9][0-9]*$`)
 
-// parseChainID extracts the EIP-155 numeric chain id from a Cosmos sign-doc
-// chain id string. It supports both:
-//
-//   - the canonical cosmos-evm form "<name>_<eip155>-<revision>"
-//     (e.g. "cosmos_9001-1"), and
-//   - a bare decimal string (e.g. "9001"), which is what the CLI emits when
-//     a chain is configured to use its EVM chain id directly as its
-//     Cosmos chain id.
-//
-// Cosmos chain ids that don't encode an EVM chain id (e.g. "cosmoshub-4",
-// "cosmos-1") return an error; callers should fall back to the configured
-// global eip155ChainID for those.
+// parseChainID extracts the EIP-155 chain id from a sign-doc chain id,
+// supporting both the canonical "<name>_<eip155>-<revision>" form and a
+// bare decimal. Returns an error for chain ids that don't encode one
+// (e.g. "cosmoshub-4"); callers fall back to the global eip155ChainID.
 func parseChainID(chainIDStr string) (uint64, error) {
 	if m := cosmosEVMChainIDRegex.FindStringSubmatch(chainIDStr); len(m) == 2 {
 		return strconv.ParseUint(m[1], 10, 64)

--- a/ethereum/eip712/encoding.go
+++ b/ethereum/eip712/encoding.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strconv"
 
 	apitypes "github.com/ethereum/go-ethereum/signer/core/apitypes"
 
@@ -108,8 +109,17 @@ func decodeAminoSignDoc(signDocBytes []byte) (apitypes.TypedData, error) {
 		return apitypes.TypedData{}, err
 	}
 
+	// Extract the chain ID from the sign doc itself for EIP-712 domain
+	// This ensures we use the same chain ID that was used during signing
+	chainID := eip155ChainID
+	if aminoDoc.ChainID != "" {
+		if parsedChainID, err := parseChainID(aminoDoc.ChainID); err == nil {
+			chainID = parsedChainID
+		}
+	}
+
 	typedData, err := WrapTxToTypedData(
-		eip155ChainID,
+		chainID,
 		signDocBytes,
 	)
 	if err != nil {
@@ -202,8 +212,17 @@ func decodeProtobufSignDoc(signDocBytes []byte) (apitypes.TypedData, error) {
 		return apitypes.TypedData{}, errorsmod.Wrap(err, "failed to get sign bytes using aminojson")
 	}
 
+	// Extract the chain ID from the sign doc itself for EIP-712 domain
+	// This ensures we use the same chain ID that was used during signing
+	chainID := eip155ChainID
+	if signDoc.ChainId != "" {
+		if parsedChainID, err := parseChainID(signDoc.ChainId); err == nil {
+			chainID = parsedChainID
+		}
+	}
+
 	typedData, err := WrapTxToTypedData(
-		eip155ChainID,
+		chainID,
 		signBytes,
 	)
 	if err != nil {
@@ -221,6 +240,12 @@ func validateCodecInit() error {
 	}
 
 	return nil
+}
+
+// parseChainID attempts to parse the chain ID string as a uint64.
+// The chain ID in the sign doc should be the EIP-155 chain ID.
+func parseChainID(chainIDStr string) (uint64, error) {
+	return strconv.ParseUint(chainIDStr, 10, 64)
 }
 
 // validatePayloadMessages ensures that the transaction messages can be represented in an EIP-712

--- a/ethereum/eip712/encoding_internal_test.go
+++ b/ethereum/eip712/encoding_internal_test.go
@@ -6,11 +6,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestParseChainID exercises `parseChainID` against the chain-id shapes
-// that actually appear in this repo and in real cosmos-evm deployments.
-// These formats are linked to the fix for https://github.com/cosmos/evm/pull/918
-// so we need to be explicit about which ones recover a numeric EVM chain id
-// and which ones legitimately fall back to the configured global.
 func TestParseChainID(t *testing.T) {
 	testCases := []struct {
 		name    string
@@ -18,73 +13,27 @@ func TestParseChainID(t *testing.T) {
 		want    uint64
 		wantErr bool
 	}{
-		{
-			name:  "canonical cosmos-evm chain id (evmd default)",
-			input: "cosmos_262144-1",
-			want:  262144,
-		},
-		{
-			name:  "canonical cosmos-evm chain id (18-decimal example)",
-			input: "cosmos_9001-1",
-			want:  9001,
-		},
-		{
-			name:  "canonical chain id with larger EVM chain id",
-			input: "interval_1230263908-1",
-			want:  1230263908,
-		},
-		{
-			name:  "canonical chain id with alphanumeric name",
-			input: "evmos2_9001-42",
-			want:  9001,
-		},
-		{
-			name:  "bare decimal chain id (PR #918 reproduction)",
-			input: "1230263908",
-			want:  1230263908,
-		},
-		{
-			name:    "name-revision without EVM chain id (ExampleChainID)",
-			input:   "cosmos-1",
-			wantErr: true,
-		},
-		{
-			name:    "classic cosmos chain id",
-			input:   "cosmoshub-4",
-			wantErr: true,
-		},
-		{
-			name:    "empty string",
-			input:   "",
-			wantErr: true,
-		},
-		{
-			name:    "name-only, no revision",
-			input:   "cosmos_9001",
-			wantErr: true,
-		},
-		{
-			name:    "EVM chain id cannot start with 0",
-			input:   "cosmos_0-1",
-			wantErr: true,
-		},
-		{
-			name:    "revision cannot start with 0",
-			input:   "cosmos_9001-0",
-			wantErr: true,
-		},
-		{
-			name:    "name must start with a letter",
-			input:   "1cosmos_9001-1",
-			wantErr: true,
-		},
+		{name: "canonical (evmd default)", input: "cosmos_262144-1", want: 262144},
+		{name: "canonical (ExampleChainID shape)", input: "cosmos_9001-1", want: 9001},
+		{name: "canonical with large EVM id", input: "interval_1230263908-1", want: 1230263908},
+		{name: "canonical with alphanumeric name", input: "evmos2_9001-42", want: 9001},
+		{name: "bare decimal (PR #918 repro)", input: "1230263908", want: 1230263908},
+
+		// Inputs below must error so callers fall back to global eip155ChainID.
+		{name: "name-revision, no EVM id", input: "cosmos-1", wantErr: true},
+		{name: "classic cosmos chain id", input: "cosmoshub-4", wantErr: true},
+		{name: "empty", input: "", wantErr: true},
+		{name: "missing revision", input: "cosmos_9001", wantErr: true},
+		{name: "EVM id leading zero", input: "cosmos_0-1", wantErr: true},
+		{name: "revision leading zero", input: "cosmos_9001-0", wantErr: true},
+		{name: "name must start with letter", input: "1cosmos_9001-1", wantErr: true},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			got, err := parseChainID(tc.input)
 			if tc.wantErr {
-				require.Error(t, err, "expected parseChainID(%q) to fail so callers fall back to the global eip155ChainID", tc.input)
+				require.Error(t, err)
 				return
 			}
 			require.NoError(t, err)

--- a/ethereum/eip712/encoding_internal_test.go
+++ b/ethereum/eip712/encoding_internal_test.go
@@ -1,0 +1,94 @@
+package eip712
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestParseChainID exercises `parseChainID` against the chain-id shapes
+// that actually appear in this repo and in real cosmos-evm deployments.
+// These formats are linked to the fix for https://github.com/cosmos/evm/pull/918
+// so we need to be explicit about which ones recover a numeric EVM chain id
+// and which ones legitimately fall back to the configured global.
+func TestParseChainID(t *testing.T) {
+	testCases := []struct {
+		name    string
+		input   string
+		want    uint64
+		wantErr bool
+	}{
+		{
+			name:  "canonical cosmos-evm chain id (evmd default)",
+			input: "cosmos_262144-1",
+			want:  262144,
+		},
+		{
+			name:  "canonical cosmos-evm chain id (18-decimal example)",
+			input: "cosmos_9001-1",
+			want:  9001,
+		},
+		{
+			name:  "canonical chain id with larger EVM chain id",
+			input: "interval_1230263908-1",
+			want:  1230263908,
+		},
+		{
+			name:  "canonical chain id with alphanumeric name",
+			input: "evmos2_9001-42",
+			want:  9001,
+		},
+		{
+			name:  "bare decimal chain id (PR #918 reproduction)",
+			input: "1230263908",
+			want:  1230263908,
+		},
+		{
+			name:    "name-revision without EVM chain id (ExampleChainID)",
+			input:   "cosmos-1",
+			wantErr: true,
+		},
+		{
+			name:    "classic cosmos chain id",
+			input:   "cosmoshub-4",
+			wantErr: true,
+		},
+		{
+			name:    "empty string",
+			input:   "",
+			wantErr: true,
+		},
+		{
+			name:    "name-only, no revision",
+			input:   "cosmos_9001",
+			wantErr: true,
+		},
+		{
+			name:    "EVM chain id cannot start with 0",
+			input:   "cosmos_0-1",
+			wantErr: true,
+		},
+		{
+			name:    "revision cannot start with 0",
+			input:   "cosmos_9001-0",
+			wantErr: true,
+		},
+		{
+			name:    "name must start with a letter",
+			input:   "1cosmos_9001-1",
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseChainID(tc.input)
+			if tc.wantErr {
+				require.Error(t, err, "expected parseChainID(%q) to fail so callers fall back to the global eip155ChainID", tc.input)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/ethereum/eip712/encoding_test.go
+++ b/ethereum/eip712/encoding_test.go
@@ -9,6 +9,10 @@ import (
 	ethmath "github.com/ethereum/go-ethereum/common/math"
 	"github.com/stretchr/testify/require"
 
+	"github.com/cosmos/evm/crypto/ethsecp256k1"
+	"github.com/cosmos/evm/encoding"
+	"github.com/cosmos/evm/ethereum/eip712"
+
 	sdkmath "cosmossdk.io/math"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -16,10 +20,6 @@ import (
 	authsigning "github.com/cosmos/cosmos-sdk/x/auth/signing"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
-
-	"github.com/cosmos/evm/crypto/ethsecp256k1"
-	"github.com/cosmos/evm/encoding"
-	"github.com/cosmos/evm/ethereum/eip712"
 )
 
 // setupEIP712Test initializes the EIP-712 encoding codec with the given

--- a/ethereum/eip712/encoding_test.go
+++ b/ethereum/eip712/encoding_test.go
@@ -25,9 +25,8 @@ import (
 )
 
 // setupEIP712Test initializes the EIP-712 encoding codec with the given
-// evmChainID registered globally (mirroring what `SetEncodingConfig` does at
-// app boot). Bank and auth types are registered so we can sign `MsgSend`
-// payloads.
+// evmChainID set as the global eip155ChainID (as SetEncodingConfig does at
+// app boot), plus bank/auth types so MsgSend sign docs round-trip.
 func setupEIP712Test(t *testing.T, globalEVMChainID uint64) encoding.Config {
 	t.Helper()
 
@@ -36,16 +35,14 @@ func setupEIP712Test(t *testing.T, globalEVMChainID uint64) encoding.Config {
 	banktypes.RegisterInterfaces(cfg.InterfaceRegistry)
 	banktypes.RegisterLegacyAminoCodec(cfg.Amino)
 
-	// Re-point the eip712 globals to the freshly populated codec / registry so
-	// any interface registrations above are visible to the encoding layer.
+	// Re-register so the eip712 globals see the bank/auth interfaces above.
 	eip712.SetEncodingConfig(cfg.Amino, cfg.InterfaceRegistry, globalEVMChainID)
 
 	return cfg
 }
 
-// generateBankSendSignBytes builds sign-doc bytes for a MsgSend transaction
-// using the provided sign mode and Cosmos chain-id string. The chain-id is the
-// value a signer would see through their `--chain-id` flag at sign time.
+// generateBankSendSignBytes builds MsgSend sign-doc bytes for the given sign
+// mode, using chainIDStr as the signer's --chain-id.
 func generateBankSendSignBytes(
 	t *testing.T,
 	cfg encoding.Config,
@@ -104,35 +101,14 @@ func generateBankSendSignBytes(
 	return signBytes
 }
 
-// Regression test for https://github.com/cosmos/evm/pull/918.
-//
-// Ledger multisig (and `tx validate-signatures` / `tx multi-sign`) flows create
-// a temporary app with `simtestutil.EmptyAppOptions{}`, which leaves the global
-// `eip155ChainID` at its default (262144) instead of the chain's actual EVM
-// chain id. That meant EIP-712 reconstruction during verification used a
-// different domain chain id than the one used at sign time, producing the
-// "signature verification failed: unauthorized" error.
-//
-// The fix extracts the chain id straight from the sign doc so domain hashes
-// match regardless of the process-global EVM chain id. These tests lock in
-// that contract across the three chain-id shapes a cosmos-evm chain might
-// use: the canonical "<name>_<eip155>-<revision>" form, a bare decimal
-// string, and a purely alphanumeric "<name>-<revision>" form that must fall
-// back to the global.
-//
-// The canonical `<name>_<eip155>-<revision>` form is what evmd and most
-// downstream chains emit (see `evmd/README.md` and the `cosmos_9005-1`
-// chain id used in tests/integration/ante/test_evm_ante.go). Using that
-// format here exercises the regex in `parseChainID` directly.
+// Regression tests for https://github.com/cosmos/evm/pull/918: the EIP-712
+// domain chain id must come from the sign doc, not the process-global
+// eip155ChainID (which can be stale when CLI flows build a temporary app
+// with simtestutil.EmptyAppOptions{}).
 func TestGetEIP712TypedData_UsesChainIDFromSignDoc_Amino(t *testing.T) {
-	const wrongGlobalChainID uint64 = 262144 // default evm chain id
+	const wrongGlobalChainID uint64 = 262144
 	expectedEVMChainID := constants.ExampleChainID.EVMChainID
-	// e.g. "cosmos_9001-1" built from the repo's ExampleChainID constant.
-	cosmosChainID := fmt.Sprintf(
-		"%s_%d-1",
-		constants.ExampleChainIDPrefix,
-		expectedEVMChainID,
-	)
+	cosmosChainID := fmt.Sprintf("%s_%d-1", constants.ExampleChainIDPrefix, expectedEVMChainID)
 
 	cfg := setupEIP712Test(t, wrongGlobalChainID)
 
@@ -146,17 +122,13 @@ func TestGetEIP712TypedData_UsesChainIDFromSignDoc_Amino(t *testing.T) {
 	require.NoError(t, err)
 
 	requireDomainChainID(t, expectedEVMChainID, typedData.Domain.ChainId,
-		"amino decode path: EIP-712 domain chain id must come from the sign doc, not the global eip155ChainID")
+		"amino: domain chain id must come from the sign doc")
 }
 
 func TestGetEIP712TypedData_UsesChainIDFromSignDoc_Protobuf(t *testing.T) {
 	const wrongGlobalChainID uint64 = 262144
 	expectedEVMChainID := constants.ExampleChainID.EVMChainID
-	cosmosChainID := fmt.Sprintf(
-		"%s_%d-1",
-		constants.ExampleChainIDPrefix,
-		expectedEVMChainID,
-	)
+	cosmosChainID := fmt.Sprintf("%s_%d-1", constants.ExampleChainIDPrefix, expectedEVMChainID)
 
 	cfg := setupEIP712Test(t, wrongGlobalChainID)
 
@@ -170,12 +142,11 @@ func TestGetEIP712TypedData_UsesChainIDFromSignDoc_Protobuf(t *testing.T) {
 	require.NoError(t, err)
 
 	requireDomainChainID(t, expectedEVMChainID, typedData.Domain.ChainId,
-		"protobuf decode path: EIP-712 domain chain id must come from the sign doc, not the global eip155ChainID")
+		"protobuf: domain chain id must come from the sign doc")
 }
 
-// Some chains (including the `intervald` scenario in the original PR #918
-// reproduction) configure their Cosmos chain id as the bare decimal EVM
-// chain id. Lock in that the fix still works in that shape.
+// Bare-decimal chain ids (as used in the PR #918 reproduction with intervald)
+// must also resolve via the sign doc.
 func TestGetEIP712TypedData_UsesChainIDFromSignDoc_BareNumeric(t *testing.T) {
 	const wrongGlobalChainID uint64 = 262144
 	const signDocChainID uint64 = 1230263908
@@ -192,15 +163,11 @@ func TestGetEIP712TypedData_UsesChainIDFromSignDoc_BareNumeric(t *testing.T) {
 	require.NoError(t, err)
 
 	requireDomainChainID(t, signDocChainID, typedData.Domain.ChainId,
-		"bare-numeric chain id: EIP-712 domain chain id must come from the sign doc, not the global eip155ChainID")
+		"bare numeric: domain chain id must come from the sign doc")
 }
 
-// When the sign doc's chain id does not encode an EVM chain id — e.g. the
-// `<name>-<revision>` form used by `constants.ExampleChainID.ChainID`
-// ("cosmos-1") or stock cosmos chains like "cosmoshub-4" — `parseChainID`
-// can't recover a numeric id, so the domain falls back to the configured
-// global `eip155ChainID`. This preserves the pre-fix behaviour for chains
-// that don't embed the EVM chain id in the string.
+// Chain ids that don't encode an EVM id (e.g. "cosmos-1", "cosmoshub-4")
+// fall back to the global eip155ChainID.
 func TestGetEIP712TypedData_FallsBackToGlobal_NonNumericChainID(t *testing.T) {
 	const globalEVMChainID uint64 = 9001
 
@@ -221,15 +188,13 @@ func TestGetEIP712TypedData_FallsBackToGlobal_NonNumericChainID(t *testing.T) {
 			require.NoError(t, err)
 
 			requireDomainChainID(t, globalEVMChainID, typedData.Domain.ChainId,
-				"non-evm-encoded cosmos chain id should fall back to global eip155ChainID")
+				"should fall back to global eip155ChainID")
 		})
 	}
 }
 
-// requireDomainChainID asserts that the EIP-712 domain's ChainId matches the
-// expected uint64. `apitypes.TypedDataDomain.ChainId` is a
-// `*math.HexOrDecimal256`, whose underlying type is `big.Int`, so we can
-// convert directly for comparison.
+// requireDomainChainID asserts domain.ChainId equals expected. HexOrDecimal256's
+// underlying type is big.Int, so a direct pointer conversion is safe.
 func requireDomainChainID(t *testing.T, expected uint64, actual *ethmath.HexOrDecimal256, msg string) {
 	t.Helper()
 	require.NotNil(t, actual, "%s: domain.ChainId is nil", msg)

--- a/ethereum/eip712/encoding_test.go
+++ b/ethereum/eip712/encoding_test.go
@@ -2,6 +2,7 @@ package eip712_test
 
 import (
 	"context"
+	"fmt"
 	"math/big"
 	"strconv"
 	"testing"
@@ -12,6 +13,7 @@ import (
 	"github.com/cosmos/evm/crypto/ethsecp256k1"
 	"github.com/cosmos/evm/encoding"
 	"github.com/cosmos/evm/ethereum/eip712"
+	"github.com/cosmos/evm/testutil/constants"
 
 	sdkmath "cosmossdk.io/math"
 
@@ -113,27 +115,68 @@ func generateBankSendSignBytes(
 //
 // The fix extracts the chain id straight from the sign doc so domain hashes
 // match regardless of the process-global EVM chain id. These tests lock in
-// that contract for both amino and protobuf sign docs.
+// that contract across the three chain-id shapes a cosmos-evm chain might
+// use: the canonical "<name>_<eip155>-<revision>" form, a bare decimal
+// string, and a purely alphanumeric "<name>-<revision>" form that must fall
+// back to the global.
+//
+// The canonical `<name>_<eip155>-<revision>` form is what evmd and most
+// downstream chains emit (see `evmd/README.md` and the `cosmos_9005-1`
+// chain id used in tests/integration/ante/test_evm_ante.go). Using that
+// format here exercises the regex in `parseChainID` directly.
 func TestGetEIP712TypedData_UsesChainIDFromSignDoc_Amino(t *testing.T) {
 	const wrongGlobalChainID uint64 = 262144 // default evm chain id
-	const signDocChainID uint64 = 1230263908 // what the signer's --chain-id was
+	expectedEVMChainID := constants.ExampleChainID.EVMChainID
+	// e.g. "cosmos_9001-1" built from the repo's ExampleChainID constant.
+	cosmosChainID := fmt.Sprintf(
+		"%s_%d-1",
+		constants.ExampleChainIDPrefix,
+		expectedEVMChainID,
+	)
 
 	cfg := setupEIP712Test(t, wrongGlobalChainID)
 
 	signBytes := generateBankSendSignBytes(
 		t, cfg,
 		signing.SignMode_SIGN_MODE_LEGACY_AMINO_JSON,
-		strconv.FormatUint(signDocChainID, 10),
+		cosmosChainID,
 	)
 
 	typedData, err := eip712.GetEIP712TypedDataForMsg(signBytes)
 	require.NoError(t, err)
 
-	requireDomainChainID(t, signDocChainID, typedData.Domain.ChainId,
+	requireDomainChainID(t, expectedEVMChainID, typedData.Domain.ChainId,
 		"amino decode path: EIP-712 domain chain id must come from the sign doc, not the global eip155ChainID")
 }
 
 func TestGetEIP712TypedData_UsesChainIDFromSignDoc_Protobuf(t *testing.T) {
+	const wrongGlobalChainID uint64 = 262144
+	expectedEVMChainID := constants.ExampleChainID.EVMChainID
+	cosmosChainID := fmt.Sprintf(
+		"%s_%d-1",
+		constants.ExampleChainIDPrefix,
+		expectedEVMChainID,
+	)
+
+	cfg := setupEIP712Test(t, wrongGlobalChainID)
+
+	signBytes := generateBankSendSignBytes(
+		t, cfg,
+		signing.SignMode_SIGN_MODE_DIRECT,
+		cosmosChainID,
+	)
+
+	typedData, err := eip712.GetEIP712TypedDataForMsg(signBytes)
+	require.NoError(t, err)
+
+	requireDomainChainID(t, expectedEVMChainID, typedData.Domain.ChainId,
+		"protobuf decode path: EIP-712 domain chain id must come from the sign doc, not the global eip155ChainID")
+}
+
+// Some chains (including the `intervald` scenario in the original PR #918
+// reproduction) configure their Cosmos chain id as the bare decimal EVM
+// chain id. Lock in that the fix still works in that shape.
+func TestGetEIP712TypedData_UsesChainIDFromSignDoc_BareNumeric(t *testing.T) {
 	const wrongGlobalChainID uint64 = 262144
 	const signDocChainID uint64 = 1230263908
 
@@ -141,7 +184,7 @@ func TestGetEIP712TypedData_UsesChainIDFromSignDoc_Protobuf(t *testing.T) {
 
 	signBytes := generateBankSendSignBytes(
 		t, cfg,
-		signing.SignMode_SIGN_MODE_DIRECT,
+		signing.SignMode_SIGN_MODE_LEGACY_AMINO_JSON,
 		strconv.FormatUint(signDocChainID, 10),
 	)
 
@@ -149,29 +192,38 @@ func TestGetEIP712TypedData_UsesChainIDFromSignDoc_Protobuf(t *testing.T) {
 	require.NoError(t, err)
 
 	requireDomainChainID(t, signDocChainID, typedData.Domain.ChainId,
-		"protobuf decode path: EIP-712 domain chain id must come from the sign doc, not the global eip155ChainID")
+		"bare-numeric chain id: EIP-712 domain chain id must come from the sign doc, not the global eip155ChainID")
 }
 
-// When the sign doc's chain id is not a bare numeric string (e.g. a typical
-// cosmos "name-revision" chain id like "cosmoshub-4"), `parseChainID` fails
-// and we fall back to the configured global `eip155ChainID`. This preserves
-// the pre-fix behaviour for chains that don't use a numeric chain id.
+// When the sign doc's chain id does not encode an EVM chain id — e.g. the
+// `<name>-<revision>` form used by `constants.ExampleChainID.ChainID`
+// ("cosmos-1") or stock cosmos chains like "cosmoshub-4" — `parseChainID`
+// can't recover a numeric id, so the domain falls back to the configured
+// global `eip155ChainID`. This preserves the pre-fix behaviour for chains
+// that don't embed the EVM chain id in the string.
 func TestGetEIP712TypedData_FallsBackToGlobal_NonNumericChainID(t *testing.T) {
 	const globalEVMChainID uint64 = 9001
 
 	cfg := setupEIP712Test(t, globalEVMChainID)
 
-	signBytes := generateBankSendSignBytes(
-		t, cfg,
-		signing.SignMode_SIGN_MODE_LEGACY_AMINO_JSON,
+	for _, cosmosChainID := range []string{
+		constants.ExampleChainID.ChainID, // "cosmos-1"
 		"cosmoshub-4",
-	)
+	} {
+		t.Run(cosmosChainID, func(t *testing.T) {
+			signBytes := generateBankSendSignBytes(
+				t, cfg,
+				signing.SignMode_SIGN_MODE_LEGACY_AMINO_JSON,
+				cosmosChainID,
+			)
 
-	typedData, err := eip712.GetEIP712TypedDataForMsg(signBytes)
-	require.NoError(t, err)
+			typedData, err := eip712.GetEIP712TypedDataForMsg(signBytes)
+			require.NoError(t, err)
 
-	requireDomainChainID(t, globalEVMChainID, typedData.Domain.ChainId,
-		"non-numeric cosmos chain id should fall back to global eip155ChainID")
+			requireDomainChainID(t, globalEVMChainID, typedData.Domain.ChainId,
+				"non-evm-encoded cosmos chain id should fall back to global eip155ChainID")
+		})
+	}
 }
 
 // requireDomainChainID asserts that the EIP-712 domain's ChainId matches the

--- a/ethereum/eip712/encoding_test.go
+++ b/ethereum/eip712/encoding_test.go
@@ -1,0 +1,189 @@
+package eip712_test
+
+import (
+	"context"
+	"math/big"
+	"strconv"
+	"testing"
+
+	ethmath "github.com/ethereum/go-ethereum/common/math"
+	"github.com/stretchr/testify/require"
+
+	sdkmath "cosmossdk.io/math"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/tx/signing"
+	authsigning "github.com/cosmos/cosmos-sdk/x/auth/signing"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+
+	"github.com/cosmos/evm/crypto/ethsecp256k1"
+	"github.com/cosmos/evm/encoding"
+	"github.com/cosmos/evm/ethereum/eip712"
+)
+
+// setupEIP712Test initializes the EIP-712 encoding codec with the given
+// evmChainID registered globally (mirroring what `SetEncodingConfig` does at
+// app boot). Bank and auth types are registered so we can sign `MsgSend`
+// payloads.
+func setupEIP712Test(t *testing.T, globalEVMChainID uint64) encoding.Config {
+	t.Helper()
+
+	cfg := encoding.MakeConfig(globalEVMChainID)
+	authtypes.RegisterInterfaces(cfg.InterfaceRegistry)
+	banktypes.RegisterInterfaces(cfg.InterfaceRegistry)
+	banktypes.RegisterLegacyAminoCodec(cfg.Amino)
+
+	// Re-point the eip712 globals to the freshly populated codec / registry so
+	// any interface registrations above are visible to the encoding layer.
+	eip712.SetEncodingConfig(cfg.Amino, cfg.InterfaceRegistry, globalEVMChainID)
+
+	return cfg
+}
+
+// generateBankSendSignBytes builds sign-doc bytes for a MsgSend transaction
+// using the provided sign mode and Cosmos chain-id string. The chain-id is the
+// value a signer would see through their `--chain-id` flag at sign time.
+func generateBankSendSignBytes(
+	t *testing.T,
+	cfg encoding.Config,
+	signMode signing.SignMode,
+	chainIDStr string,
+) []byte {
+	t.Helper()
+
+	privKey, err := ethsecp256k1.GenerateKey()
+	require.NoError(t, err)
+	pubKey := privKey.PubKey()
+	senderAddr := sdk.AccAddress(pubKey.Address().Bytes())
+
+	recipientPriv, err := ethsecp256k1.GenerateKey()
+	require.NoError(t, err)
+	recipientAddr := sdk.AccAddress(recipientPriv.PubKey().Address().Bytes())
+
+	msg := banktypes.NewMsgSend(
+		senderAddr,
+		recipientAddr,
+		sdk.NewCoins(sdk.NewCoin("atest", sdkmath.NewInt(1000))),
+	)
+
+	txBuilder := cfg.TxConfig.NewTxBuilder()
+	require.NoError(t, txBuilder.SetMsgs(msg))
+	txBuilder.SetGasLimit(200_000)
+	txBuilder.SetFeeAmount(sdk.NewCoins(sdk.NewCoin("atest", sdkmath.NewInt(100))))
+
+	sigV2 := signing.SignatureV2{
+		PubKey: pubKey,
+		Data: &signing.SingleSignatureData{
+			SignMode:  signMode,
+			Signature: nil,
+		},
+		Sequence: 0,
+	}
+	require.NoError(t, txBuilder.SetSignatures(sigV2))
+
+	signerData := authsigning.SignerData{
+		Address:       senderAddr.String(),
+		ChainID:       chainIDStr,
+		AccountNumber: 0,
+		Sequence:      0,
+		PubKey:        pubKey,
+	}
+
+	signBytes, err := authsigning.GetSignBytesAdapter(
+		context.Background(),
+		cfg.TxConfig.SignModeHandler(),
+		signMode,
+		signerData,
+		txBuilder.GetTx(),
+	)
+	require.NoError(t, err)
+
+	return signBytes
+}
+
+// Regression test for https://github.com/cosmos/evm/pull/918.
+//
+// Ledger multisig (and `tx validate-signatures` / `tx multi-sign`) flows create
+// a temporary app with `simtestutil.EmptyAppOptions{}`, which leaves the global
+// `eip155ChainID` at its default (262144) instead of the chain's actual EVM
+// chain id. That meant EIP-712 reconstruction during verification used a
+// different domain chain id than the one used at sign time, producing the
+// "signature verification failed: unauthorized" error.
+//
+// The fix extracts the chain id straight from the sign doc so domain hashes
+// match regardless of the process-global EVM chain id. These tests lock in
+// that contract for both amino and protobuf sign docs.
+func TestGetEIP712TypedData_UsesChainIDFromSignDoc_Amino(t *testing.T) {
+	const wrongGlobalChainID uint64 = 262144 // default evm chain id
+	const signDocChainID uint64 = 1230263908 // what the signer's --chain-id was
+
+	cfg := setupEIP712Test(t, wrongGlobalChainID)
+
+	signBytes := generateBankSendSignBytes(
+		t, cfg,
+		signing.SignMode_SIGN_MODE_LEGACY_AMINO_JSON,
+		strconv.FormatUint(signDocChainID, 10),
+	)
+
+	typedData, err := eip712.GetEIP712TypedDataForMsg(signBytes)
+	require.NoError(t, err)
+
+	requireDomainChainID(t, signDocChainID, typedData.Domain.ChainId,
+		"amino decode path: EIP-712 domain chain id must come from the sign doc, not the global eip155ChainID")
+}
+
+func TestGetEIP712TypedData_UsesChainIDFromSignDoc_Protobuf(t *testing.T) {
+	const wrongGlobalChainID uint64 = 262144
+	const signDocChainID uint64 = 1230263908
+
+	cfg := setupEIP712Test(t, wrongGlobalChainID)
+
+	signBytes := generateBankSendSignBytes(
+		t, cfg,
+		signing.SignMode_SIGN_MODE_DIRECT,
+		strconv.FormatUint(signDocChainID, 10),
+	)
+
+	typedData, err := eip712.GetEIP712TypedDataForMsg(signBytes)
+	require.NoError(t, err)
+
+	requireDomainChainID(t, signDocChainID, typedData.Domain.ChainId,
+		"protobuf decode path: EIP-712 domain chain id must come from the sign doc, not the global eip155ChainID")
+}
+
+// When the sign doc's chain id is not a bare numeric string (e.g. a typical
+// cosmos "name-revision" chain id like "cosmoshub-4"), `parseChainID` fails
+// and we fall back to the configured global `eip155ChainID`. This preserves
+// the pre-fix behaviour for chains that don't use a numeric chain id.
+func TestGetEIP712TypedData_FallsBackToGlobal_NonNumericChainID(t *testing.T) {
+	const globalEVMChainID uint64 = 9001
+
+	cfg := setupEIP712Test(t, globalEVMChainID)
+
+	signBytes := generateBankSendSignBytes(
+		t, cfg,
+		signing.SignMode_SIGN_MODE_LEGACY_AMINO_JSON,
+		"cosmoshub-4",
+	)
+
+	typedData, err := eip712.GetEIP712TypedDataForMsg(signBytes)
+	require.NoError(t, err)
+
+	requireDomainChainID(t, globalEVMChainID, typedData.Domain.ChainId,
+		"non-numeric cosmos chain id should fall back to global eip155ChainID")
+}
+
+// requireDomainChainID asserts that the EIP-712 domain's ChainId matches the
+// expected uint64. `apitypes.TypedDataDomain.ChainId` is a
+// `*math.HexOrDecimal256`, whose underlying type is `big.Int`, so we can
+// convert directly for comparison.
+func requireDomainChainID(t *testing.T, expected uint64, actual *ethmath.HexOrDecimal256, msg string) {
+	t.Helper()
+	require.NotNil(t, actual, "%s: domain.ChainId is nil", msg)
+	actualBig := (*big.Int)(actual)
+	require.Zero(t,
+		new(big.Int).SetUint64(expected).Cmp(actualBig),
+		"%s: got %s, want %d", msg, actualBig.String(), expected,
+	)
+}


### PR DESCRIPTION
Reopens #918 and adds tests.