### PR TITLE
chore: align upstream createObject

### DIFF
--- a/tests/integration/x/vm/test_statedb.go
+++ b/tests/integration/x/vm/test_statedb.go
@@ -40,17 +40,6 @@ func (s *KeeperTestSuite) TestCreateAccount() {
 		callback func(vm.StateDB, common.Address)
 	}{
 		{
-			"reset account (keep balance)",
-			utiltx.GenerateAddress(),
-			func(vmdb vm.StateDB, addr common.Address) {
-				vmdb.AddBalance(addr, uint256.NewInt(100), tracing.BalanceChangeUnspecified)
-				s.Require().NotZero(vmdb.GetBalance(addr).Uint64())
-			},
-			func(vmdb vm.StateDB, addr common.Address) {
-				s.Require().Equal(vmdb.GetBalance(addr).Uint64(), uint64(100))
-			},
-		},
-		{
 			"create account",
 			utiltx.GenerateAddress(),
 			func(vmdb vm.StateDB, addr common.Address) {

--- a/x/vm/statedb/journal.go
+++ b/x/vm/statedb/journal.go
@@ -98,9 +98,6 @@ type (
 	createObjectChange struct {
 		account *common.Address
 	}
-	resetObjectChange struct {
-		prev *stateObject
-	}
 	selfDestructChange struct {
 		account *common.Address
 	}
@@ -154,7 +151,6 @@ type (
 var (
 	_ JournalEntry = createContractChange{}
 	_ JournalEntry = createObjectChange{}
-	_ JournalEntry = resetObjectChange{}
 	_ JournalEntry = selfDestructChange{}
 	_ JournalEntry = balanceChange{}
 	_ JournalEntry = nonceChange{}
@@ -198,14 +194,6 @@ func (ch createObjectChange) Revert(s *StateDB) {
 
 func (ch createObjectChange) Dirtied() *common.Address {
 	return ch.account
-}
-
-func (ch resetObjectChange) Revert(s *StateDB) {
-	s.setStateObject(ch.prev)
-}
-
-func (ch resetObjectChange) Dirtied() *common.Address {
-	return nil
 }
 
 func (ch selfDestructChange) Revert(s *StateDB) {

--- a/x/vm/statedb/statedb.go
+++ b/x/vm/statedb/statedb.go
@@ -402,44 +402,31 @@ func (s *StateDB) getStateObject(addr common.Address) *stateObject {
 func (s *StateDB) getOrNewStateObject(addr common.Address) *stateObject {
 	stateObject := s.getStateObject(addr)
 	if stateObject == nil {
-		stateObject, _ = s.createObject(addr)
+		stateObject = s.createObject(addr)
 	}
 	return stateObject
 }
 
-// createObject creates a new state object. If there is an existing account with
-// the given address, it is overwritten and returned as the second return value.
-func (s *StateDB) createObject(addr common.Address) (newobj, prev *stateObject) {
-	prev = s.getStateObject(addr)
-
-	newobj = newObject(s, addr, Account{})
-	if prev == nil {
-		s.journal.append(createObjectChange{account: &addr})
-	} else {
-		s.journal.append(resetObjectChange{prev: prev})
-	}
-	s.setStateObject(newobj)
-	if prev != nil {
-		return newobj, prev
-	}
-	return newobj, nil
+// createObject creates a new state object. The assumption is held there is no
+// existing account with the given address, otherwise it will be silently overwritten.
+func (s *StateDB) createObject(addr common.Address) *stateObject {
+	obj := newObject(s, addr, Account{})
+	s.journal.append(createObjectChange{account: &addr})
+	s.setStateObject(obj)
+	return obj
 }
 
-// CreateAccount explicitly creates a state object. If a state object with the address
-// already exists the balance is carried over to the new account.
+// CreateAccount explicitly creates a new state object, assuming that the
+// account did not previously exist in the state. If the account already
+// exists, this function will silently overwrite it which might lead to a
+// consensus bug eventually.
 //
-// CreateAccount is called during the EVM CREATE operation. The situation might arise that
-// a contract does the following:
-//
-// 1. sends funds to sha(account ++ (nonce + 1))
-// 2. tx_create(sha(account ++ nonce)) (note that this gets the address of 1)
-//
-// Carrying over the balance ensures that Ether doesn't disappear.
+// The EVM only calls CreateAccount when Exist(addr) is false, immediately
+// followed by CreateContract to set the EIP-6780 newContract flag, so the
+// pre-funded-then-deployed flow is preserved without any balance carry-over
+// here. See go-ethereum PR #29520.
 func (s *StateDB) CreateAccount(addr common.Address) {
-	newObj, prev := s.createObject(addr)
-	if prev != nil {
-		newObj.setBalance(prev.account.Balance)
-	}
+	s.createObject(addr)
 }
 
 // ForEachStorage iterate the contract storage, the iteration order is not defined.

--- a/x/vm/statedb/statedb_test.go
+++ b/x/vm/statedb/statedb_test.go
@@ -115,25 +115,6 @@ func (suite *StateDBTestSuite) TestAccount() {
 	}
 }
 
-func (suite *StateDBTestSuite) TestAccountOverride() {
-	keeper := mocks.NewEVMKeeper()
-	db := statedb.New(sdk.Context{}.WithEventManager(sdk.NewEventManager()), keeper, emptyTxConfig)
-	// test balance carry over when overwritten
-	amount := uint256.NewInt(1)
-
-	// init an EOA account, account overridden only happens on EOA account.
-	db.AddBalance(address, amount, tracing.BalanceChangeUnspecified)
-	db.SetNonce(address, 1, tracing.NonceChangeUnspecified)
-
-	// override
-	db.CreateAccount(address)
-
-	// check balance is not lost
-	suite.Require().Equal(amount, db.GetBalance(address))
-	// but nonce is reset
-	suite.Require().Equal(uint64(0), db.GetNonce(address))
-}
-
 func (suite *StateDBTestSuite) TestDBError() {
 	testCases := []struct {
 		name     string


### PR DESCRIPTION
closes: STACK-2326

Aligns createObject with upstream behaviour based on https://github.com/ethereum/go-ethereum/pull/29520.

Changes:
- `resetObjectChange` removed - not used since geth 1.14.1
- Simplified `createObject` / `CreateAccount`: always install a fresh state object, no balance carry-over, no special revert path.
- No behavioural change for EVM execution / consensus.