### PR TITLE
fix(mempool): advance legacypool nonces on cosmos tx inclusion

### DIFF
--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -426,7 +426,7 @@ func (m *Mempool) removeEVMTx(tx sdk.Tx, msgEthereumTx *evmtypes.MsgEthereumTx, 
 }
 
 // recordNonceAdvances records the on chain nonce advance for every signer of
-// tx against in the legacypool.
+// tx in the legacypool.
 func (m *Mempool) recordNonceAdvances(tx sdk.Tx) {
 	signers, err := m.signerExtractor.GetSigners(tx)
 	if err != nil {

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -370,61 +370,72 @@ func (m *Mempool) Remove(tx sdk.Tx) error {
 }
 
 // RemoveWithReason removes a transaction from the appropriate sdkmempool.
-// For EVM transactions, removal is typically handled automatically by the pool
-// based on nonce progression. Cosmos transactions are removed from the Cosmos pool.
-func (m *Mempool) RemoveWithReason(ctx context.Context, tx sdk.Tx, reason sdkmempool.RemoveReason) error {
+//
+// NOTE: even if removal fails, side effects may have occurred like recording
+// nonce increments.
+func (m *Mempool) RemoveWithReason(_ context.Context, tx sdk.Tx, reason sdkmempool.RemoveReason) error {
 	msgEthereumTx, err := evmTxFromCosmosTx(tx)
 	switch {
 	case errors.Is(err, ErrNoMessages):
 		return err
 	case err != nil:
 		// unable to parse evm tx -> process as cosmos tx
-		if err := m.removeCosmosTx(tx); err != nil {
-			return err
-		}
-
-		if reason.Caller == sdkmempool.CallerRunTxFinalize {
-			signers, err := m.signerExtractor.GetSigners(tx)
-			if err != nil {
-				m.logger.Warn("could not extract cosmos signers for nonce tracking", "err", err)
-				return nil
-			}
-			for _, s := range signers {
-				m.legacyTxPool.SetLatestNonce(common.BytesToAddress(s.Signer), s.Sequence)
-			}
-		}
+		return m.removeCosmosTx(tx, reason)
 	default:
-		hash := msgEthereumTx.Hash()
-		if m.shouldRemoveFromEVMPool(hash, reason) {
-			m.logger.Debug("Manually removing EVM transaction", "tx_hash", hash)
-			m.legacyTxPool.RemoveTx(hash, false, true, convertRemovalReason(reason.Caller))
-		}
-
-		if reason.Caller == sdkmempool.CallerRunTxFinalize {
-			_ = m.txTracker.IncludedInBlock(hash)
-			if err := m.legacyTxPool.SetLatestNonceForTx(msgEthereumTx.AsTransaction()); err != nil {
-				m.logger.Warn("could not update latest nonce from tx", "tx_hash", hash, "err", err)
-			}
-		}
+		return m.removeEVMTx(tx, msgEthereumTx, reason)
 	}
-
-	return nil
 }
 
 // removeCosmosTx removes a cosmos tx from the mempool.
 // The RecheckMempool handles locking internally.
-func (m *Mempool) removeCosmosTx(tx sdk.Tx) error {
+func (m *Mempool) removeCosmosTx(tx sdk.Tx, reason sdkmempool.RemoveReason) error {
 	m.logger.Debug("Removing Cosmos transaction")
 
-	// Remove from cosmos pool (handles address reservation release  and reap
-	// list drop internally)
+	if reason.Caller == sdkmempool.CallerRunTxFinalize {
+		m.recordNonceAdvances(tx)
+	}
+
 	if err := m.recheckCosmosPool.Remove(tx); err != nil {
 		m.logger.Error("Failed to remove Cosmos transaction", "error", err)
 		return fmt.Errorf("removing cosmos tx: %w", err)
 	}
+
 	m.logger.Debug("Cosmos transaction removed successfully")
 
 	return nil
+}
+
+// removeEVMTx removes a evm tx from the mempool.
+func (m *Mempool) removeEVMTx(tx sdk.Tx, msgEthereumTx *evmtypes.MsgEthereumTx, reason sdkmempool.RemoveReason) error {
+	m.logger.Debug("Removing EVM transaction")
+
+	hash := msgEthereumTx.Hash()
+	if reason.Caller == sdkmempool.CallerRunTxFinalize {
+		_ = m.txTracker.IncludedInBlock(hash)
+		m.recordNonceAdvances(tx)
+	}
+
+	if m.shouldRemoveFromEVMPool(hash, reason) {
+		m.logger.Debug("Manually removing EVM transaction", "tx_hash", hash)
+		m.legacyTxPool.RemoveTx(hash, false, true, convertRemovalReason(reason.Caller))
+	}
+
+	m.logger.Debug("EVM transaction removed successfully")
+
+	return nil
+}
+
+// recordNonceAdvances records the on chain nonce advance for every signer of
+// tx against in the legacypool.
+func (m *Mempool) recordNonceAdvances(tx sdk.Tx) {
+	signers, err := m.signerExtractor.GetSigners(tx)
+	if err != nil {
+		m.logger.Warn("could not extract signers for nonce tracking", "err", err)
+		return
+	}
+	for _, s := range signers {
+		m.legacyTxPool.SetLatestNonce(common.BytesToAddress(s.Signer), s.Sequence)
+	}
 }
 
 // shouldRemoveFromEVMPool determines whether an EVM transaction should be manually removed.

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -105,6 +105,9 @@ type Mempool struct {
 	/** Transaction Inserting **/
 	cosmosInsertQueue *queue.Queue[sdk.Tx]
 	evmInsertQueue    *queue.Queue[ethtypes.Transaction]
+
+	/** Signer extraction **/
+	signerExtractor sdkmempool.SignerExtractionAdapter
 }
 
 func NewMempool(
@@ -184,6 +187,7 @@ func NewMempool(
 		pendingTxProposalTimeout: config.PendingTxProposalTimeout,
 		reapList:                 reapList,
 		txTracker:                txTracker,
+		signerExtractor:          NewEthSignerExtractionAdapter(sdkmempool.NewDefaultSignerExtractionAdapter()),
 	}
 
 	// Setup queues
@@ -375,20 +379,32 @@ func (m *Mempool) RemoveWithReason(ctx context.Context, tx sdk.Tx, reason sdkmem
 		return err
 	case err != nil:
 		// unable to parse evm tx -> process as cosmos tx
-		return m.removeCosmosTx(tx)
-	}
+		if err := m.removeCosmosTx(tx); err != nil {
+			return err
+		}
 
-	hash := msgEthereumTx.Hash()
+		if reason.Caller == sdkmempool.CallerRunTxFinalize {
+			signers, err := m.signerExtractor.GetSigners(tx)
+			if err != nil {
+				m.logger.Warn("could not extract cosmos signers for nonce tracking", "err", err)
+				return nil
+			}
+			for _, s := range signers {
+				m.legacyTxPool.SetLatestNonce(common.BytesToAddress(s.Signer), s.Sequence)
+			}
+		}
+	default:
+		hash := msgEthereumTx.Hash()
+		if m.shouldRemoveFromEVMPool(hash, reason) {
+			m.logger.Debug("Manually removing EVM transaction", "tx_hash", hash)
+			m.legacyTxPool.RemoveTx(hash, false, true, convertRemovalReason(reason.Caller))
+		}
 
-	if m.shouldRemoveFromEVMPool(hash, reason) {
-		m.logger.Debug("Manually removing EVM transaction", "tx_hash", hash)
-		m.legacyTxPool.RemoveTx(hash, false, true, convertRemovalReason(reason.Caller))
-	}
-
-	if reason.Caller == sdkmempool.CallerRunTxFinalize {
-		_ = m.txTracker.IncludedInBlock(hash)
-		if err := m.legacyTxPool.ScheduleForRemoval(msgEthereumTx.AsTransaction()); err != nil {
-			m.logger.Error("error scheduling tx for removal from legacypool", "err", err)
+		if reason.Caller == sdkmempool.CallerRunTxFinalize {
+			_ = m.txTracker.IncludedInBlock(hash)
+			if err := m.legacyTxPool.SetLatestNonceForTx(msgEthereumTx.AsTransaction()); err != nil {
+				m.logger.Warn("could not update latest nonce from tx", "tx_hash", hash, "err", err)
+			}
 		}
 	}
 

--- a/mempool/mempool_test.go
+++ b/mempool/mempool_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cosmos/evm/mempool/reserver"
 	"github.com/cosmos/evm/mempool/txpool/legacypool"
 	"github.com/cosmos/evm/testutil/constants"
+	evmtestutiltx "github.com/cosmos/evm/testutil/tx"
 	"github.com/cosmos/evm/x/vm/statedb"
 	vmtypes "github.com/cosmos/evm/x/vm/types"
 
@@ -398,6 +399,61 @@ func TestMempool_ReapNewBlock(t *testing.T) {
 	require.GreaterOrEqual(t, getTxNonce(t, txConfig, txs[1]), uint64(1)) // 1 or 2
 }
 
+func TestMempool_CosmosNonceAdvanceDropsStaleEVM(t *testing.T) {
+	mp, s := setupMempoolWithAccounts(t, 1)
+	txConfig, bus, accounts := s.txConfig, s.eventBus, s.accounts
+	account := accounts[0]
+
+	require.NoError(t, bus.PublishEventNewBlockHeader(cmttypes.EventDataNewBlockHeader{
+		Header: cmttypes.Header{
+			Height:  1,
+			Time:    time.Now(),
+			ChainID: strconv.Itoa(constants.EighteenDecimalsChainID),
+		},
+	}))
+	require.NoError(t, mp.GetTxPool().Sync())
+
+	// seed the pool with two pending EVM txs at nonces 0 and 1
+	for nonce := uint64(0); nonce < 2; nonce++ {
+		tx := createMsgEthereumTx(t, txConfig, account.key, nonce, big.NewInt(1e8))
+		require.NoError(t, mp.Insert(context.Background(), tx))
+	}
+	require.NoError(t, mp.GetTxPool().Sync())
+
+	// ensure initial state is correct
+	legacyPool := mp.GetTxPool().Subpools[0].(*legacypool.LegacyPool)
+	pending, queued := legacyPool.ContentFrom(account.address)
+	require.Equal(t, 2, len(pending), "expected 2 txs in the pending pool after setup")
+	require.Equal(t, 0, len(queued), "expected 0 txs in the queued pool after setup")
+
+	// mock that another val had a cosmos tx with nonce 1 and included that on
+	// chain (note that this will never be our node doing this, since the
+	// reserver prevents us from having an evm tx and cosmos tx with the same
+	// signer(s) in the both pools at the same time)
+	cosmosTx := createTestCosmosTx(t, txConfig, account.key, 1)
+	err := mp.RemoveWithReason(context.Background(), cosmosTx, mempooltypes.RemoveReason{
+		Caller: mempooltypes.CallerRunTxFinalize,
+	})
+	require.ErrorIs(t, err, mempooltypes.ErrTxNotFound)
+
+	// after we finish finalizing the above block, the chain will advance and
+	// the pool will reset
+	require.NoError(t, bus.PublishEventNewBlockHeader(cmttypes.EventDataNewBlockHeader{
+		Header: cmttypes.Header{
+			Height:  2,
+			Time:    time.Now(),
+			ChainID: strconv.Itoa(constants.EighteenDecimalsChainID),
+		},
+	}))
+	require.NoError(t, mp.GetTxPool().Sync())
+
+	// using eventually here since publishing a new block happens async
+	require.Eventually(t, func() bool {
+		pending, queued := legacyPool.ContentFrom(account.address)
+		return len(pending) == 0 && len(queued) == 0
+	}, time.Second, 10*time.Millisecond, "expected pending and queued pools to drain after stale txs dropped")
+}
+
 func TestMempool_InsertMultiMsgCosmosTx(t *testing.T) {
 	mp, s := setupMempoolWithAccounts(t, 3)
 	txConfig, bus := s.txConfig, s.eventBus
@@ -721,34 +777,22 @@ func createMsgEthereumTx(
 ) sdk.Tx {
 	t.Helper()
 
-	tx := types.NewTransaction(
-		nonce,
-		common.Address{0x01}, // Send to a dummy address
-		big.NewInt(txValue),
-		txGasLimit,
-		gasPrice,
-		nil,
-	)
+	to := common.Address{0x01} // dummy recipient
+	chainID := new(big.Int).SetUint64(vmtypes.GetChainConfig().ChainId)
+	msg := vmtypes.NewTx(&vmtypes.EvmTxArgs{
+		ChainID:  chainID,
+		Nonce:    nonce,
+		To:       &to,
+		Amount:   big.NewInt(txValue),
+		GasLimit: txGasLimit,
+		GasPrice: gasPrice,
+	})
+	msg.From = crypto.PubkeyToAddress(key.PublicKey).Bytes()
 
-	chainID := vmtypes.GetChainConfig().ChainId
-	signer := types.LatestSignerForChainID(new(big.Int).SetUint64(chainID))
-	signedTx, err := types.SignTx(tx, signer, key)
+	priv := &ethsecp256k1.PrivKey{Key: crypto.FromECDSA(key)}
+	cosmosTx, err := evmtestutiltx.PrepareEthTx(txConfig, priv, msg)
 	require.NoError(t, err)
-
-	return wrapInCosmosSDKTx(t, txConfig, signedTx)
-}
-
-func wrapInCosmosSDKTx(t *testing.T, txConfig client.TxConfig, ethTx *types.Transaction) sdk.Tx {
-	t.Helper()
-
-	msg := &vmtypes.MsgEthereumTx{}
-	msg.FromEthereumTx(ethTx)
-
-	txBuilder := txConfig.NewTxBuilder()
-	err := txBuilder.SetMsgs(msg)
-	require.NoError(t, err)
-
-	return txBuilder.GetTx()
+	return cosmosTx
 }
 
 // decodeTxBytes decodes transaction bytes returned from ReapNewValidTxs back into an Ethereum transaction

--- a/mempool/recheck_pool.go
+++ b/mempool/recheck_pool.go
@@ -268,11 +268,11 @@ func (m *RecheckMempool) acquireTxReservations(tx sdk.Tx) ([]common.Address, err
 // reserver. Caller must hold m.mu.
 func (m *RecheckMempool) removeLocked(tx sdk.Tx) error {
 	if err := m.ExtMempool.Remove(tx); err != nil {
-		return err
+		return fmt.Errorf("failed to remove tx from mempool: %w", err)
 	}
 
 	if err := m.releaseTxReservations(tx); err != nil {
-		panic("failed to extract signers from tx during Remove")
+		m.logger.Error("failed to release reservations", "err", err)
 	}
 	m.reapList.DropCosmosTx(tx)
 

--- a/mempool/recheck_pool.go
+++ b/mempool/recheck_pool.go
@@ -21,7 +21,6 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkmempool "github.com/cosmos/cosmos-sdk/types/mempool"
-	authsigning "github.com/cosmos/cosmos-sdk/x/auth/signing"
 )
 
 var (
@@ -92,9 +91,10 @@ type RecheckMempool struct {
 	// reserver coordinates address reservations with other pools (i.e. legacypool)
 	reserver *reserver.ReservationHandle
 
-	rechecker  Rechecker
-	blockchain *Blockchain
-	logger     log.Logger
+	rechecker       Rechecker
+	blockchain      *Blockchain
+	signerExtractor sdkmempool.SignerExtractionAdapter
+	logger          log.Logger
 
 	// event channels
 	reqRecheckCh    chan *recheckRequest // channel that schedules rechecking.
@@ -129,6 +129,7 @@ func NewRecheckMempool(
 		reserver:        reserver,
 		rechecker:       rechecker,
 		blockchain:      blockchain,
+		signerExtractor: sdkmempool.NewDefaultSignerExtractionAdapter(),
 		logger:          logger.With(log.ModuleKey, "RecheckMempool"),
 		reqRecheckCh:    make(chan *recheckRequest),
 		recheckDoneCh:   make(chan chan struct{}),
@@ -167,12 +168,9 @@ func (m *RecheckMempool) Close() error {
 // This is the main entry point for new cosmos transactions.
 func (m *RecheckMempool) Insert(_ context.Context, tx sdk.Tx) error {
 	// Reserve addresses to prevent conflicts with EVM pool
-	addrs, err := signerAddressesFromTx(tx)
+	addrs, err := m.acquireTxReservations(tx)
 	if err != nil {
-		return err
-	}
-	if err := m.reserver.Hold(addrs...); err != nil {
-		return fmt.Errorf("reserving %d addresses for cosmos recheck pool: %w", len(addrs), err)
+		return fmt.Errorf("acquiring reservations for tx: %w", err)
 	}
 
 	m.mu.Lock()
@@ -231,6 +229,41 @@ func (m *RecheckMempool) RemoveWithReason(_ context.Context, tx sdk.Tx, _ sdkmem
 	return m.Remove(tx)
 }
 
+// releaseTxReservations extracts the signers of tx and releases their
+// reserver holds. Returns an error only if signer extraction fails; any
+// error from the reserver itself is swallowed to preserve the prior
+// best-effort cleanup semantics.
+func (m *RecheckMempool) releaseTxReservations(tx sdk.Tx) error {
+	signers, err := m.signerExtractor.GetSigners(tx)
+	if err != nil {
+		return fmt.Errorf("getting signers for tx: %w", err)
+	}
+	addrs := make([]common.Address, len(signers))
+	for i, s := range signers {
+		addrs[i] = common.BytesToAddress(s.Signer)
+	}
+	_ = m.reserver.Release(addrs...) // best-effort cleanup
+	return nil
+}
+
+// acquireTxReservations extracts the signers of tx and acquires their reserver
+// holds. Returns any addresses who are now reserved, and any errors that
+// occurred.
+func (m *RecheckMempool) acquireTxReservations(tx sdk.Tx) ([]common.Address, error) {
+	signers, err := m.signerExtractor.GetSigners(tx)
+	if err != nil {
+		return nil, err
+	}
+	addrs := make([]common.Address, len(signers))
+	for i, s := range signers {
+		addrs[i] = common.BytesToAddress(s.Signer)
+	}
+	if err := m.reserver.Hold(addrs...); err != nil {
+		return nil, fmt.Errorf("reserving %d addresses for cosmos recheck pool: %w", len(addrs), err)
+	}
+	return addrs, nil
+}
+
 // removeLocked removes a tx from the underlying pool and releases the
 // reserver. Caller must hold m.mu.
 func (m *RecheckMempool) removeLocked(tx sdk.Tx) error {
@@ -238,11 +271,9 @@ func (m *RecheckMempool) removeLocked(tx sdk.Tx) error {
 		return err
 	}
 
-	addrs, err := signerAddressesFromTx(tx)
-	if err != nil {
-		panic("failed to extract signer addresses from tx during Remove")
+	if err := m.releaseTxReservations(tx); err != nil {
+		panic("failed to extract signers from tx during Remove")
 	}
-	m.reserver.Release(addrs...) //nolint:errcheck // best effort cleanup
 	m.reapList.DropCosmosTx(tx)
 
 	return nil
@@ -418,16 +449,16 @@ func (m *RecheckMempool) runRecheck(done chan struct{}, newHead *ethtypes.Header
 		}
 
 		txsChecked++
-		signerSeqs, err := extractSignerSequences(txn)
+		signers, err := m.signerExtractor.GetSigners(txn)
 		if err != nil {
-			m.logger.Error("failed to extract signer sequences", "err", err)
+			m.logger.Error("failed to extract signers", "err", err)
 			iter = iter.Next()
 			continue
 		}
 
 		invalidTx := false
-		for _, sig := range signerSeqs {
-			if failedSeq, ok := failedAtSequence[sig.account]; ok && failedSeq < sig.seq {
+		for _, s := range signers {
+			if failedSeq, ok := failedAtSequence[string(s.Signer)]; ok && failedSeq < s.Sequence {
 				invalidTx = true
 				break
 			}
@@ -444,9 +475,10 @@ func (m *RecheckMempool) runRecheck(done chan struct{}, newHead *ethtypes.Header
 		}
 
 		removeTxs = append(removeTxs, txn)
-		for _, sig := range signerSeqs {
-			if existing, ok := failedAtSequence[sig.account]; !ok || existing > sig.seq {
-				failedAtSequence[sig.account] = sig.seq
+		for _, s := range signers {
+			key := string(s.Signer)
+			if existing, ok := failedAtSequence[key]; !ok || existing > s.Sequence {
+				failedAtSequence[key] = s.Sequence
 			}
 		}
 
@@ -465,12 +497,10 @@ func (m *RecheckMempool) runRecheck(done chan struct{}, newHead *ethtypes.Header
 		}
 		m.reapList.DropCosmosTx(txn)
 
-		addrs, err := signerAddressesFromTx(txn)
-		if err != nil {
-			m.logger.Error("failed to extract signer addresses for release", "err", err)
+		if err := m.releaseTxReservations(txn); err != nil {
+			m.logger.Error("failed to release reservations", "err", err)
 			continue
 		}
-		m.reserver.Release(addrs...) //nolint:errcheck // best effort cleanup
 	}
 	txsRemoved = len(removeTxs)
 }
@@ -492,37 +522,6 @@ func (m *RecheckMempool) markTxInserted(txn sdk.Tx) {
 	})
 }
 
-type signerSequence struct {
-	account string
-	seq     uint64
-}
-
-// extractSignerSequences extracts account addresses and sequences from a tx.
-func extractSignerSequences(txn sdk.Tx) ([]signerSequence, error) {
-	sigTx, ok := txn.(authsigning.SigVerifiableTx)
-	if !ok {
-		return nil, fmt.Errorf(
-			"tx does not implement %T",
-			(*authsigning.SigVerifiableTx)(nil),
-		)
-	}
-
-	sigs, err := sigTx.GetSignaturesV2()
-	if err != nil {
-		return nil, err
-	}
-
-	signerSeqs := make([]signerSequence, 0, len(sigs))
-	for _, sig := range sigs {
-		signerSeqs = append(signerSeqs, signerSequence{
-			account: sig.PubKey.Address().String(),
-			seq:     sig.Sequence,
-		})
-	}
-
-	return signerSeqs, nil
-}
-
 // isCancelled checks if the cancellation channel has been closed.
 func isCancelled(ch <-chan struct{}) bool {
 	select {
@@ -531,30 +530,6 @@ func isCancelled(ch <-chan struct{}) bool {
 	default:
 		return false
 	}
-}
-
-// signerAddressesFromTx extracts signer addresses from a transaction as EVM addresses.
-func signerAddressesFromTx(tx sdk.Tx) ([]common.Address, error) {
-	sigTx, ok := tx.(authsigning.SigVerifiableTx)
-	if !ok {
-		return nil, fmt.Errorf("tx does not implement GetSigners")
-	}
-
-	signers, err := sigTx.GetSigners()
-	if err != nil {
-		return nil, err
-	}
-
-	if len(signers) == 0 {
-		return nil, fmt.Errorf("tx contains no signers")
-	}
-
-	addrs := make([]common.Address, 0, len(signers))
-	for _, signer := range signers {
-		addrs = append(addrs, common.BytesToAddress(signer))
-	}
-
-	return addrs, nil
 }
 
 func cosmosPoolConfig(

--- a/mempool/tx_store.go
+++ b/mempool/tx_store.go
@@ -16,10 +16,11 @@ import (
 // CosmosTxStore is a set of cosmos transactions that can be added to or
 // removed from.
 type CosmosTxStore struct {
-	txs         map[string]cosmosTxBucket
-	nextUnkeyed uint64
-	logger      log.Logger
-	mu          sync.RWMutex
+	txs             map[string]cosmosTxBucket
+	nextUnkeyed     uint64
+	logger          log.Logger
+	signerExtractor sdkmempool.SignerExtractionAdapter
+	mu              sync.RWMutex
 }
 
 type cosmosTxBucket struct {
@@ -38,8 +39,9 @@ type cosmosTxWithMetadata struct {
 // NewCosmosTxStore creates a new CosmosTxStore.
 func NewCosmosTxStore(l log.Logger) *CosmosTxStore {
 	return &CosmosTxStore{
-		txs:    make(map[string]cosmosTxBucket),
-		logger: l,
+		txs:             make(map[string]cosmosTxBucket),
+		logger:          l,
+		signerExtractor: sdkmempool.NewDefaultSignerExtractionAdapter(),
 	}
 }
 
@@ -48,7 +50,7 @@ func (s *CosmosTxStore) AddTx(tx sdk.Tx) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	storedTx := newCosmosTxWithMetadata(tx)
+	storedTx := s.newCosmosTxWithMetadata(tx)
 	if storedTx.signerKey == "" {
 		storedTx.signerKey = unkeyedSignerKey
 	}
@@ -80,7 +82,7 @@ func (s *CosmosTxStore) InvalidateFrom(tx sdk.Tx) int {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	storedTx := newCosmosTxWithMetadata(tx)
+	storedTx := s.newCosmosTxWithMetadata(tx)
 
 	// first check if this tx is already here. If it isn't; no need to do anything. It's a fresh insert.
 	// If it is, we need to do the work of invaliding any txs from the same sender with a higher nonce.
@@ -124,10 +126,10 @@ func (s *CosmosTxStore) InvalidateFrom(tx sdk.Tx) int {
 	return removed
 }
 
-func newCosmosTxWithMetadata(tx sdk.Tx) cosmosTxWithMetadata {
+func (s *CosmosTxStore) newCosmosTxWithMetadata(tx sdk.Tx) cosmosTxWithMetadata {
 	storedTx := cosmosTxWithMetadata{tx: tx}
 
-	nonceMap, ok := cosmosTxNonceMap(tx)
+	nonceMap, ok := s.cosmosTxNonceMap(tx)
 	if !ok {
 		return storedTx
 	}
@@ -143,11 +145,11 @@ const unkeyedSignerKey = "unkeyed"
 
 func cosmosTxSignerSetKey(nonceMap map[string]uint64) string {
 	var b strings.Builder
-	for i, sig := range sortedSignerNonces(nonceMap) {
+	for i, k := range sortedSignerKeys(nonceMap) {
 		if i > 0 {
 			b.WriteByte('|')
 		}
-		b.WriteString(sig.account)
+		b.WriteString(k)
 	}
 
 	return b.String()
@@ -155,11 +157,11 @@ func cosmosTxSignerSetKey(nonceMap map[string]uint64) string {
 
 func cosmosTxKey(nonceMap map[string]uint64) string {
 	var b strings.Builder
-	for i, sig := range sortedSignerNonces(nonceMap) {
+	for i, k := range sortedSignerKeys(nonceMap) {
 		if i > 0 {
 			b.WriteByte('|')
 		}
-		fmt.Fprintf(&b, "%s/%020d", sig.account, sig.seq)
+		fmt.Fprintf(&b, "%s/%020d", k, nonceMap[k])
 	}
 
 	return b.String()
@@ -175,33 +177,33 @@ func cosmosTxNonceSum(nonceMap map[string]uint64) uint64 {
 
 // cosmosTxNonceMap extracts the signers from the transaction
 // and returns a signer -> nonce map.
-func cosmosTxNonceMap(tx sdk.Tx) (map[string]uint64, bool) {
-	signerSeqs, err := extractSignerSequences(tx)
-	if err != nil || len(signerSeqs) == 0 {
+func (s *CosmosTxStore) cosmosTxNonceMap(tx sdk.Tx) (map[string]uint64, bool) {
+	signers, err := s.signerExtractor.GetSigners(tx)
+	if err != nil || len(signers) == 0 {
 		return nil, false
 	}
 
-	nonceMap := make(map[string]uint64, len(signerSeqs))
-	for _, sig := range signerSeqs {
-		nonce, err := sdkmempool.ChooseNonce(sig.seq, tx)
+	nonceMap := make(map[string]uint64, len(signers))
+	for _, sig := range signers {
+		nonce, err := sdkmempool.ChooseNonce(sig.Sequence, tx)
 		if err != nil {
 			return nil, false
 		}
-		nonceMap[sig.account] = nonce
+		nonceMap[string(sig.Signer)] = nonce
 	}
 
 	return nonceMap, true
 }
 
-func sortedSignerNonces(nonceMap map[string]uint64) []signerSequence {
-	signerSeqs := make([]signerSequence, 0, len(nonceMap))
-	for account, seq := range nonceMap {
-		signerSeqs = append(signerSeqs, signerSequence{account: account, seq: seq})
+// sortedSignerKeys returns the signer-address keys of nonceMap in stable
+// ascending byte order, for use in deterministic signer-set / tx keys.
+func sortedSignerKeys(nonceMap map[string]uint64) []string {
+	keys := make([]string, 0, len(nonceMap))
+	for k := range nonceMap {
+		keys = append(keys, k)
 	}
-	slices.SortFunc(signerSeqs, func(a, b signerSequence) int {
-		return strings.Compare(a.account, b.account)
-	})
-	return signerSeqs
+	slices.Sort(keys)
+	return keys
 }
 
 func invalidatesCosmosTx(tx cosmosTxWithMetadata, thresholds map[string]uint64) bool {

--- a/mempool/tx_store.go
+++ b/mempool/tx_store.go
@@ -195,8 +195,6 @@ func (s *CosmosTxStore) cosmosTxNonceMap(tx sdk.Tx) (map[string]uint64, bool) {
 	return nonceMap, true
 }
 
-// sortedSignerKeys returns the signer-address keys of nonceMap in stable
-// ascending byte order, for use in deterministic signer-set / tx keys.
 func sortedSignerKeys(nonceMap map[string]uint64) []string {
 	keys := make([]string, 0, len(nonceMap))
 	for k := range nonceMap {

--- a/mempool/txpool/legacypool/legacypool.go
+++ b/mempool/txpool/legacypool/legacypool.go
@@ -436,18 +436,6 @@ func New(
 	return pool
 }
 
-// SetLatestNonceForTx records the latest on chain nonce observed for an
-// account based on tx's values.
-func (pool *LegacyPool) SetLatestNonceForTx(tx *types.Transaction) error {
-	sender, err := types.Sender(pool.signer, tx)
-	if err != nil {
-		return fmt.Errorf("getting tx signer: %w", err)
-	}
-
-	pool.SetLatestNonce(sender, tx.Nonce())
-	return nil
-}
-
 // SetLatestNonce records the latest on chain nonce observed for an account.
 func (pool *LegacyPool) SetLatestNonce(sender common.Address, nonce uint64) {
 	existing, ok := pool.latestIncludedNonce.Get(sender)
@@ -1526,10 +1514,7 @@ func (pool *LegacyPool) computePendingTipNonces() map[common.Address]uint64 {
 		nextPendingNonce := list.LastElement().Nonce() + 1
 
 		// grab the latest nonce that we have observed on chain for this
-		// account if we have it cached. SetLatestNonce is called from the
-		// finalize-removal path for both EVM and cosmos txs, so the LRU
-		// tracks on chain nonce advances from either tx type — important
-		// on Cosmos-EVM chains where the account's nonce is shared.
+		// account if we have it cached
 		latestIncludedNonce, ok := pool.latestIncludedNonce.Get(addr)
 		if ok {
 			// if we have a cached on chain nonce for this account, it likely

--- a/mempool/txpool/legacypool/legacypool.go
+++ b/mempool/txpool/legacypool/legacypool.go
@@ -436,19 +436,24 @@ func New(
 	return pool
 }
 
-// ScheduleForRemoval schedules a tx to be removed from the mempool the next
-// time it is reset. This is typically called when a tx is included on chain.
-func (pool *LegacyPool) ScheduleForRemoval(tx *types.Transaction) error {
+// SetLatestNonceForTx records the latest on chain nonce observed for an
+// account based on tx's values.
+func (pool *LegacyPool) SetLatestNonceForTx(tx *types.Transaction) error {
 	sender, err := types.Sender(pool.signer, tx)
 	if err != nil {
 		return fmt.Errorf("getting tx signer: %w", err)
 	}
 
-	existing, ok := pool.latestIncludedNonce.Get(sender)
-	if !ok || tx.Nonce() > existing {
-		pool.latestIncludedNonce.Add(sender, tx.Nonce())
-	}
+	pool.SetLatestNonce(sender, tx.Nonce())
 	return nil
+}
+
+// SetLatestNonce records the latest on chain nonce observed for an account.
+func (pool *LegacyPool) SetLatestNonce(sender common.Address, nonce uint64) {
+	existing, ok := pool.latestIncludedNonce.Get(sender)
+	if !ok || nonce > existing {
+		pool.latestIncludedNonce.Add(sender, nonce)
+	}
 }
 
 // removeOlds removes txs that have been scheduled for removals from
@@ -1521,7 +1526,10 @@ func (pool *LegacyPool) computePendingTipNonces() map[common.Address]uint64 {
 		nextPendingNonce := list.LastElement().Nonce() + 1
 
 		// grab the latest nonce that we have observed on chain for this
-		// account if we have it cached
+		// account if we have it cached. SetLatestNonce is called from the
+		// finalize-removal path for both EVM and cosmos txs, so the LRU
+		// tracks on chain nonce advances from either tx type — important
+		// on Cosmos-EVM chains where the account's nonce is shared.
 		latestIncludedNonce, ok := pool.latestIncludedNonce.Get(addr)
 		if ok {
 			// if we have a cached on chain nonce for this account, it likely

--- a/mempool/txpool/legacypool/legacypool_test.go
+++ b/mempool/txpool/legacypool/legacypool_test.go
@@ -868,7 +868,7 @@ func TestScheduleForRemoval(t *testing.T) {
 	require.Len(t, pending, 4, "precondition: four pending txs")
 	require.Len(t, queued, 1, "precondition: one queued tx")
 
-	require.NoError(t, pool.ScheduleForRemoval(txs[1]))
+	pool.SetLatestNonce(addr, txs[1].Nonce())
 	<-pool.requestReset(nil, nil)
 
 	pending, queued = pool.ContentFrom(addr)
@@ -877,18 +877,18 @@ func TestScheduleForRemoval(t *testing.T) {
 	require.Equal(t, uint64(3), pending[1].Nonce())
 	require.Len(t, queued, 1, "queued tx@10 is above threshold and survives")
 
-	require.NoError(t, pool.ScheduleForRemoval(txs[0]))
+	pool.SetLatestNonce(addr, txs[0].Nonce())
 	<-pool.requestReset(nil, nil)
 
 	pending, _ = pool.ContentFrom(addr)
 	require.Len(t, pending, 2, "lower-nonce schedule must be a no-op")
 
-	require.NoError(t, pool.ScheduleForRemoval(queuedTx))
+	pool.SetLatestNonce(addr, queuedTx.Nonce())
 	<-pool.requestReset(nil, nil)
 
 	pending, queued = pool.ContentFrom(addr)
-	require.Empty(t, pending, "pending drained by ScheduleForRemoval at nonce 10")
-	require.Empty(t, queued, "queued tx@10 drained by ScheduleForRemoval")
+	require.Empty(t, pending, "pending drained by SetLatestNonce at nonce 10")
+	require.Empty(t, queued, "queued tx@10 drained by SetLatestNonce")
 }
 
 // Tests that if an account runs out of funds, any pending and queued transactions
@@ -2919,10 +2919,10 @@ func TestQueuedPromotionOnResetWithStalePending(t *testing.T) {
 
 	// mock that tx0 and tx1 **AND** tx2 were included on chain (simulating
 	// that another node had tx2, and filled the nonce gap for us)
-	require.NoError(t, pool.ScheduleForRemoval(tx0))
-	require.NoError(t, pool.ScheduleForRemoval(tx1))
+	pool.SetLatestNonce(addr, tx0.Nonce())
+	pool.SetLatestNonce(addr, tx1.Nonce())
 	tx2 := transaction(2, 100000, key)
-	require.NoError(t, pool.ScheduleForRemoval(tx2))
+	pool.SetLatestNonce(addr, tx2.Nonce())
 
 	// now we reset the pool to a new height. this reset will trigger a mempool
 	// state reset, plus a promotion of our queued tx to pending, and dropping


### PR DESCRIPTION
# Description

Whenever a cosmos tx is included, we also need to track its signers nonce advancements in the legacypool, to ensure that any new txs that have become stale due to the cosmos tx are properly removed from the legacypool.

This also refactors how we get signers for cosmos txs, previously we used a mix of `Signers` and `GetSignersV2` for cosmos txs + using `ethtypes.Signer()` for evm txs. Now, we only use the `EthSignerExtractionAdapter` with a fallback of the `sdkmempool.NewDefaultSignerExtractionAdapter()` for cosmos txs.

Closes: STACK-2646

---

## Author Checklist

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.

I have...

- [ ] tackled an existing issue or discussed with a team member
- [ ] left instructions on how to review the changes
- [ ] targeted the `main` branch
