### PR TITLE
fix: panic on krakatoa when max block gas is -1

### DIFF
--- a/server/server_app_options.go
+++ b/server/server_app_options.go
@@ -38,14 +38,14 @@ func ResolveMempoolConfig(anteHandler sdk.AnteHandler, appOpts servertypes.AppOp
 // to extract the consensus block gas limit before InitChain is called.
 func GetBlockGasLimit(appOpts servertypes.AppOptions, logger log.Logger) uint64 {
 	if appOpts == nil {
-		logger.Error("app options is nil, using zero block gas limit")
-		return math.MaxUint64
+		logger.Error("app options is nil, using max int64 block gas limit")
+		return math.MaxInt64
 	}
 
 	homeDir := cast.ToString(appOpts.Get(flags.FlagHome))
 	if homeDir == "" {
-		logger.Error("home directory not found in app options, using zero block gas limit")
-		return math.MaxUint64
+		logger.Error("home directory not found in app options, using max int64 block gas limit")
+		return math.MaxInt64
 	}
 	genesisPath := filepath.Join(homeDir, "config", "genesis.json")
 
@@ -67,8 +67,8 @@ func GetBlockGasLimit(appOpts servertypes.AppOptions, logger log.Logger) uint64 
 
 	maxGas := genDoc.ConsensusParams.Block.MaxGas
 	if maxGas == -1 {
-		logger.Warn("genesis max_gas is unlimited (-1), using max uint64")
-		return math.MaxUint64
+		logger.Warn("genesis max_gas is unlimited (-1), using max int64 block gas limit")
+		return math.MaxInt64
 	}
 	if maxGas < -1 {
 		logger.Error("invalid max_gas value in genesis, using zero block gas limit")

--- a/server/server_app_options_test.go
+++ b/server/server_app_options_test.go
@@ -70,7 +70,6 @@ func TestGetBlockGasLimit(t *testing.T) {
 				opts.Set(flags.FlagHome, homeDir)
 				return opts
 			},
-			expected: math.MaxUint64,
 			expected: math.MaxInt64,
 		},
 		{

--- a/server/server_app_options_test.go
+++ b/server/server_app_options_test.go
@@ -46,12 +46,12 @@ func TestGetBlockGasLimit(t *testing.T) {
 		expected uint64
 	}{
 		{
-			name: "empty home directory returns max uint64",
+			name: "empty home directory returns max int64",
 			setupFn: func() servertypes.AppOptions {
 				opts := newMockAppOptions()
 				return opts
 			},
-			expected: math.MaxUint64,
+			expected: math.MaxInt64,
 		},
 		{
 			name: "genesis file not found returns 0",
@@ -63,7 +63,7 @@ func TestGetBlockGasLimit(t *testing.T) {
 			expected: 0,
 		},
 		{
-			name: "valid genesis with max_gas = -1 returns max uint64",
+			name: "valid genesis with max_gas = -1 returns max int64",
 			setupFn: func() servertypes.AppOptions {
 				homeDir := createGenesisWithMaxGas(t, -1)
 				opts := newMockAppOptions()
@@ -71,6 +71,7 @@ func TestGetBlockGasLimit(t *testing.T) {
 				return opts
 			},
 			expected: math.MaxUint64,
+			expected: math.MaxInt64,
 		},
 		{
 			name: "valid genesis with max_gas < -1 returns 0",


### PR DESCRIPTION
Changes -1 on max block gas to `MaxInt64` instead of `MaxUint64` to prevent Krakatoa from panicking during `SafeInt64(header.GasLimit)`