### PR TITLE
feat: Make txtracker optional

### DIFF
--- a/mempool/internal/txtracker/txtracker.go
+++ b/mempool/internal/txtracker/txtracker.go
@@ -34,8 +34,22 @@ var (
 	pendingDurationKey = "pending_duration"
 )
 
-// TxTracker tracks timestamps about important events in a transactions
-// lifecycle and exposes metrics about these via prometheus.
+// Tracker tracks timestamps about important events in a transactions lifecycle
+// and exposes metrics about these via prometheus. A no-op implementation is
+// returned by NewNoop for use when tracking is disabled.
+type Tracker interface {
+	Track(hash common.Hash) error
+	EnteredQueued(hash common.Hash) error
+	ExitedQueued(hash common.Hash) error
+	EnteredPending(hash common.Hash) error
+	ExitedPending(hash common.Hash) error
+	IncludedInBlock(hash common.Hash) error
+	RemovedFromPending(hash common.Hash) error
+	RemovedFromQueue(hash common.Hash) error
+}
+
+// TxTracker is the active Tracker implementation that records lifecycle
+// timestamps and emits telemetry.
 type TxTracker struct {
 	txCheckpoints map[common.Hash]*checkpoints
 	lock          sync.RWMutex
@@ -157,3 +171,20 @@ type checkpoints struct {
 
 	LastEnteredPendingPoolAt time.Time
 }
+
+// noopTracker implements Tracker but performs no work. It is used when tx
+// tracking is disabled via config so that callers can keep an unconditional
+// tracker reference.
+type noopTracker struct{}
+
+// NewNoop returns a Tracker that records nothing.
+func NewNoop() Tracker { return noopTracker{} }
+
+func (noopTracker) Track(common.Hash) error              { return nil }
+func (noopTracker) EnteredQueued(common.Hash) error      { return nil }
+func (noopTracker) ExitedQueued(common.Hash) error       { return nil }
+func (noopTracker) EnteredPending(common.Hash) error     { return nil }
+func (noopTracker) ExitedPending(common.Hash) error      { return nil }
+func (noopTracker) IncludedInBlock(common.Hash) error    { return nil }
+func (noopTracker) RemovedFromPending(common.Hash) error { return nil }
+func (noopTracker) RemovedFromQueue(common.Hash) error   { return nil }

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -70,6 +70,9 @@ type Config struct {
 	// pending insertion into the mempool. Note the insert queue is only used
 	// for EVM txs.
 	InsertQueueSize int
+	// EnableTxTracker controls whether the mempool records per-tx lifecycle
+	// telemetry (queued/pending/included latencies). Defaults to false.
+	EnableTxTracker bool
 }
 
 // Mempool is an application side mempool implementation that operates
@@ -100,7 +103,7 @@ type Mempool struct {
 	reapList *reaplist.ReapList
 
 	/** Transaction Tracking **/
-	txTracker *txtracker.TxTracker
+	txTracker txtracker.Tracker
 
 	/** Transaction Inserting **/
 	cosmosInsertQueue *queue.Queue[sdk.Tx]
@@ -141,7 +144,10 @@ func NewMempool(
 	}
 
 	reapList := reaplist.New(NewTxEncoder(txConfig))
-	txTracker := txtracker.New()
+	var txTracker txtracker.Tracker = txtracker.NewNoop()
+	if config.EnableTxTracker {
+		txTracker = txtracker.New()
+	}
 	legacyPool := legacypool.New(
 		legacyConfig,
 		logger,

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -144,7 +144,7 @@ func NewMempool(
 	}
 
 	reapList := reaplist.New(NewTxEncoder(txConfig))
-	var txTracker txtracker.Tracker = txtracker.NewNoop()
+	txTracker := txtracker.NewNoop()
 	if config.EnableTxTracker {
 		txTracker = txtracker.New()
 	}

--- a/mempool/txpool/legacypool/legacypool.go
+++ b/mempool/txpool/legacypool/legacypool.go
@@ -474,7 +474,7 @@ type LegacyPool struct {
 	changesSinceReorg int // A counter for how many drops we've performed in-between reorg.
 
 	reapList *reaplist.ReapList   // Queue of txs to be reaped by comet and gossiped
-	tracker  *txtracker.TxTracker // Track tx lifecycle events for metrics
+	tracker  txtracker.Tracker    // Track tx lifecycle events for metrics
 }
 
 type txpoolResetRequest struct {
@@ -500,7 +500,7 @@ func New(
 	logger cosmoslog.Logger,
 	chain BlockChain,
 	reapList *reaplist.ReapList,
-	tracker *txtracker.TxTracker,
+	tracker txtracker.Tracker,
 	opts ...Option,
 ) *LegacyPool {
 	if reapList == nil {

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -189,6 +189,9 @@ type MempoolConfig struct {
 	// InsertQueueSize is the maximum number of transactions that can be in the
 	// insert queue at once (0 means unbounded)
 	InsertQueueSize int `mapstructure:"insert-queue-size"`
+	// EnableTxTracker enables per-tx lifecycle telemetry from the mempool
+	// (queued/pending/included latencies). Disabled by default.
+	EnableTxTracker bool `mapstructure:"enable-tx-tracker"`
 }
 
 // DefaultMempoolConfig returns the default mempool configuration
@@ -205,6 +208,7 @@ func DefaultMempoolConfig() MempoolConfig {
 		PendingTxProposalTimeout: 250 * time.Millisecond, // 250 milliseconds to wait for rechecks
 		CheckTxTimeout:           5 * time.Second,        // 5 seconds timeout for CheckTx handler.
 		InsertQueueSize:          5_000,                  // 5000 txs maximum in the insert queue
+		EnableTxTracker:          false,                  // tx lifecycle telemetry off by default
 	}
 }
 

--- a/server/config/toml.go
+++ b/server/config/toml.go
@@ -66,6 +66,10 @@ check-tx-timeout = "{{ .EVM.Mempool.CheckTxTimeout }}"
 # InsertQueueSize is the maximum number of transactions that can be in the insert queue at once (0 means unbounded)
 insert-queue-size = "{{ .EVM.Mempool.InsertQueueSize }}"
 
+# EnableTxTracker enables per-tx lifecycle telemetry from the mempool
+# (queued/pending/included latencies). Disabled by default.
+enable-tx-tracker = {{ .EVM.Mempool.EnableTxTracker }}
+
 ###############################################################################
 ###                           JSON RPC Configuration                        ###
 ###############################################################################

--- a/server/flags/flags.go
+++ b/server/flags/flags.go
@@ -83,6 +83,7 @@ const (
 	EVMMempoolPendingTxProposalTimeout = "evm.mempool.pending-tx-proposal-timeout"
 	EVMMempoolCheckTxTimeout           = "evm.mempool.check-tx-timeout"
 	EVMMempoolInsertQueueSize          = "evm.mempool.insert-queue-size"
+	EVMMempoolEnableTxTracker          = "evm.mempool.enable-tx-tracker"
 )
 
 // TLS flags

--- a/server/server_app_options.go
+++ b/server/server_app_options.go
@@ -31,6 +31,7 @@ func ResolveMempoolConfig(anteHandler sdk.AnteHandler, appOpts servertypes.AppOp
 		MinTip:                   GetMinTip(appOpts, logger),
 		PendingTxProposalTimeout: GetPendingTxProposalTimeout(appOpts, logger),
 		InsertQueueSize:          GetMempoolInsertQueueSize(appOpts, logger),
+		EnableTxTracker:          GetMempoolEnableTxTracker(appOpts),
 	}
 }
 
@@ -177,6 +178,15 @@ func GetMempoolInsertQueueSize(appOpts servertypes.AppOptions, logger log.Logger
 	}
 
 	return cast.ToInt(appOpts.Get(srvflags.EVMMempoolInsertQueueSize))
+}
+
+// GetMempoolEnableTxTracker reads whether per-tx lifecycle telemetry should be
+// recorded by the mempool. Defaults to false when not set or appOpts is nil.
+func GetMempoolEnableTxTracker(appOpts servertypes.AppOptions) bool {
+	if appOpts == nil {
+		return false
+	}
+	return cast.ToBool(appOpts.Get(srvflags.EVMMempoolEnableTxTracker))
 }
 
 func GetMempoolCheckTxTimeout(appOpts servertypes.AppOptions, logger log.Logger) time.Duration {

--- a/server/start.go
+++ b/server/start.go
@@ -237,6 +237,7 @@ which accepts a path for the resulting pprof file.
 	cmd.Flags().Duration(srvflags.EVMMempoolPendingTxProposalTimeout, mpDefaults.PendingTxProposalTimeout, "the maximum amount of time to spend waiting for rechecking of the mempool to complete when creating a proposal")
 	cmd.Flags().Duration(srvflags.EVMMempoolCheckTxTimeout, mpDefaults.CheckTxTimeout, "timeout for async CheckTx handler")
 	cmd.Flags().Int(srvflags.EVMMempoolInsertQueueSize, mpDefaults.InsertQueueSize, "the maximum number of transactions that can be in the insert queue at once")
+	cmd.Flags().Bool(srvflags.EVMMempoolEnableTxTracker, mpDefaults.EnableTxTracker, "enable per-tx lifecycle telemetry from the mempool (queued/pending/included latencies)")
 
 	cmd.Flags().String(srvflags.TLSCertPath, "", "the cert.pem file path for the server TLS configuration")
 	cmd.Flags().String(srvflags.TLSKeyPath, "", "the key.pem file path for the server TLS configuration")


### PR DESCRIPTION
# Description

* Converts txtracker to be an interface
* Adds a no-op implementation
* Adds EnableTxTracker option, defaults to off

Closes: #XXXX

---

## Author Checklist

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.

I have...

- [ ] tackled an existing issue or discussed with a team member
- [ ] left instructions on how to review the changes
- [ ] targeted the `main` branch
