### PR TITLE
fix: Fix TOCTOU in insert queue

### DIFF
--- a/mempool/internal/queue/queue.go
+++ b/mempool/internal/queue/queue.go
@@ -66,13 +66,15 @@ func (iq *Queue[Tx]) Push(tx *Tx) <-chan error {
 		close(sub)
 		return sub
 	}
-	if iq.isFull() {
+
+	iq.lock.Lock()
+	if iq.queue.Len() >= iq.maxSize {
+		iq.lock.Unlock()
 		sub <- ErrQueueFull
 		close(sub)
 		return sub
 	}
 
-	iq.lock.Lock()
 	iq.queue.PushBack(insertItem[Tx]{tx: tx, sub: sub})
 	iq.lock.Unlock()
 
@@ -162,14 +164,6 @@ func (iq *Queue[Tx]) insertTxs(txs []*Tx) []error {
 		panic(fmt.Errorf("expected a %d errors from insert but instead got %d", len(txs), len(errs)))
 	}
 	return errs
-}
-
-// isFull returns true if the queue is at capacity and cannot accept anymore
-// Tx's, false otherwise.
-func (iq *Queue[Tx]) isFull() bool {
-	iq.lock.RLock()
-	defer iq.lock.RUnlock()
-	return iq.queue.Len() >= iq.maxSize
 }
 
 // Close stops the main loop of the queue.


### PR DESCRIPTION
# Description

I've moved the `isFull` method logic into the `Push` method (only place it was being used AFAICT). 

There is another TOCTOU technically in `loop` but that one would just cause the loop to iterate another time and I think it's simpler as is so I left it.

Closes: #XXXX

---

## Author Checklist

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.

I have...

- [ ] tackled an existing issue or discussed with a team member
- [ ] left instructions on how to review the changes
- [ ] targeted the `main` branch
