### PR TITLE
chore: Convert all metrics

### DIFF
--- a/mempool/internal/queue/queue.go
+++ b/mempool/internal/queue/queue.go
@@ -28,7 +28,7 @@ var (
 func init() {
 	var err error
 	queueSize, err = meter.Int64Gauge(
-		"mempool.inserter.queue_size",
+		"insert_queue.queue_size",
 		metric.WithDescription("Number of txs waiting in the inserter queue"),
 	)
 	if err != nil {
@@ -36,7 +36,7 @@ func init() {
 	}
 
 	insertDuration, err = meter.Float64Histogram(
-		"mempool.inserter.add_duration",
+		"insert_queue.add_duration",
 		metric.WithDescription("Time to insert a batch of txs into the underlying mempool"),
 		metric.WithUnit("ms"),
 	)

--- a/mempool/internal/queue/queue.go
+++ b/mempool/internal/queue/queue.go
@@ -1,15 +1,49 @@
 package queue
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"sync"
 	"time"
 
 	"github.com/gammazero/deque"
-
-	"github.com/cosmos/cosmos-sdk/telemetry"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
 )
+
+var meter = otel.Meter("github.com/cosmos/evm/mempool/internal/queue")
+
+var (
+	// queueSize is the current number of txs waiting to be inserted into the
+	// underlying mempool.
+	queueSize metric.Int64Gauge
+
+	// insertDuration is the latency of a batch insert into the underlying
+	// mempool.
+	insertDuration metric.Float64Histogram
+)
+
+func init() {
+	var err error
+	queueSize, err = meter.Int64Gauge(
+		"mempool.inserter.queue_size",
+		metric.WithDescription("Number of txs waiting in the inserter queue"),
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	insertDuration, err = meter.Float64Histogram(
+		"mempool.inserter.add_duration",
+		metric.WithDescription("Time to insert a batch of txs into the underlying mempool"),
+		metric.WithUnit("ms"),
+	)
+	if err != nil {
+		panic(err)
+	}
+}
 
 // insertItem is an item in the queue that contains the user data (Tx) along
 // with a subscription that the user is using to wait on the response from the
@@ -38,18 +72,23 @@ type Queue[Tx any] struct {
 	// rejecting new additions
 	maxSize int
 
+	// metricAttrs identifies this queue in emitted metrics.
+	metricAttrs metric.MeasurementOption
+
 	done chan struct{}
 }
 
 var ErrQueueFull = errors.New("queue full")
 
-// New creates a new queue.
-func New[Tx any](insert func(txs []*Tx) []error, maxSize int) *Queue[Tx] {
+// New creates a new queue. name distinguishes this queue's metrics from other
+// queue instances (e.g. "evm" vs "cosmos").
+func New[Tx any](name string, insert func(txs []*Tx) []error, maxSize int) *Queue[Tx] {
 	iq := &Queue[Tx]{
-		insert:  insert,
-		maxSize: maxSize,
-		signal:  make(chan struct{}, 1),
-		done:    make(chan struct{}),
+		insert:      insert,
+		maxSize:     maxSize,
+		signal:      make(chan struct{}, 1),
+		done:        make(chan struct{}),
+		metricAttrs: metric.WithAttributeSet(attribute.NewSet(attribute.String("pool", name))),
 	}
 
 	go iq.loop()
@@ -93,7 +132,7 @@ func (iq *Queue[Tx]) loop() {
 		numTxsAvailable := iq.queue.Len()
 		iq.lock.RUnlock()
 
-		telemetry.SetGauge(float32(numTxsAvailable), "expmempool_inserter_queue_size")
+		queueSize.Record(context.Background(), int64(numTxsAvailable), iq.metricAttrs)
 
 		// if nothing is available, wait for new Tx's to become available
 		// before checking again
@@ -154,7 +193,7 @@ func (iq *Queue[Tx]) waitForNewTxs() bool {
 // insertTxs inserts Tx's, returning any errors that have occurred.
 func (iq *Queue[Tx]) insertTxs(txs []*Tx) []error {
 	defer func(t0 time.Time) {
-		telemetry.MeasureSince(t0, "expmempool_inserter_add") //nolint:staticcheck
+		insertDuration.Record(context.Background(), float64(time.Since(t0).Milliseconds()), iq.metricAttrs)
 	}(time.Now())
 
 	errs := iq.insert(txs)

--- a/mempool/internal/queue/queue_test.go
+++ b/mempool/internal/queue/queue_test.go
@@ -50,7 +50,7 @@ func (m *mockPool) setInsertFn(fn func([]*ethtypes.Transaction) []error) {
 
 func TestInsertQueue_PushAndProcess(t *testing.T) {
 	pool := newMockPool()
-	iq := New[ethtypes.Transaction](pool.insert, 1000)
+	iq := New[ethtypes.Transaction]("test", pool.insert, 1000)
 	defer iq.Close()
 
 	// Create a test transaction
@@ -72,7 +72,7 @@ func TestInsertQueue_PushAndProcess(t *testing.T) {
 
 func TestInsertQueue_ProcessesMultipleTransactions(t *testing.T) {
 	pool := newMockPool()
-	iq := New[ethtypes.Transaction](pool.insert, 1000)
+	iq := New[ethtypes.Transaction]("test", pool.insert, 1000)
 	defer iq.Close()
 
 	// Create multiple test transactions
@@ -100,7 +100,7 @@ func TestInsertQueue_ProcessesMultipleTransactions(t *testing.T) {
 
 func TestInsertQueue_IgnoresNilTransaction(t *testing.T) {
 	pool := newMockPool()
-	iq := New[ethtypes.Transaction](pool.insert, 1000)
+	iq := New[ethtypes.Transaction]("test", pool.insert, 1000)
 	defer iq.Close()
 
 	// Push nil transaction
@@ -123,7 +123,7 @@ func TestInsertQueue_SlowAddition(t *testing.T) {
 		return make([]error, len(txs))
 	})
 
-	iq := New[ethtypes.Transaction](pool.insert, 1000)
+	iq := New[ethtypes.Transaction]("test", pool.insert, 1000)
 	defer iq.Close()
 
 	// Push first transaction to start processing
@@ -156,7 +156,7 @@ func TestInsertQueue_RejectsWhenFull(t *testing.T) {
 		select {} // block forever
 	})
 
-	iq := New[ethtypes.Transaction](pool.insert, 5)
+	iq := New[ethtypes.Transaction]("test", pool.insert, 5)
 	defer iq.Close()
 
 	// This first tx will be immediately popped and start processing (where it

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -12,6 +12,7 @@ import (
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/holiman/uint256"
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/metric"
 
 	cmttypes "github.com/cometbft/cometbft/types"
 
@@ -30,7 +31,6 @@ import (
 	"cosmossdk.io/math"
 
 	"github.com/cosmos/cosmos-sdk/client"
-	"github.com/cosmos/cosmos-sdk/telemetry"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	sdkmempool "github.com/cosmos/cosmos-sdk/types/mempool"
@@ -49,6 +49,32 @@ const (
 var AllowUnsafeSyncInsert = false
 
 var meter = otel.Meter("github.com/cosmos/evm/mempool")
+
+var (
+	selectByDuration      metric.Float64Histogram
+	buildIteratorDuration metric.Float64Histogram
+)
+
+func init() {
+	var err error
+	selectByDuration, err = meter.Float64Histogram(
+		"mempool.selectby_duration",
+		metric.WithDescription("Time spent in SelectBy iterating over txs"),
+		metric.WithUnit("ms"),
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	buildIteratorDuration, err = meter.Float64Histogram(
+		"mempool.builditerator_duration",
+		metric.WithDescription("Time spent building the unified mempool iterator"),
+		metric.WithUnit("ms"),
+	)
+	if err != nil {
+		panic(err)
+	}
+}
 
 var _ sdkmempool.ExtMempool = (*Mempool)(nil)
 
@@ -192,6 +218,7 @@ func NewMempool(
 
 	// Setup queues
 	mempool.evmInsertQueue = queue.New(
+		"evm",
 		func(txs []*ethtypes.Transaction) []error {
 			return txPool.Add(txs, AllowUnsafeSyncInsert)
 		},
@@ -199,6 +226,7 @@ func NewMempool(
 	)
 
 	mempool.cosmosInsertQueue = queue.New(
+		"cosmos",
 		func(txs []*sdk.Tx) []error {
 			errs := make([]error, len(txs))
 			for i, tx := range txs {
@@ -329,7 +357,9 @@ func (m *Mempool) Select(goCtx context.Context, i [][]byte) sdkmempool.Iterator 
 // It uses the same unified iterator as Select but allows early termination based on
 // custom criteria defined by the filter function.
 func (m *Mempool) SelectBy(goCtx context.Context, txs [][]byte, filter func(sdk.Tx) bool) {
-	defer func(t0 time.Time) { telemetry.MeasureSince(t0, "expmempool_selectby_duration") }(time.Now()) //nolint:staticcheck
+	defer func(t0 time.Time) {
+		selectByDuration.Record(goCtx, float64(time.Since(t0).Milliseconds()))
+	}(time.Now())
 
 	iter := m.buildIterator(goCtx, txs)
 
@@ -341,7 +371,9 @@ func (m *Mempool) SelectBy(goCtx context.Context, txs [][]byte, filter func(sdk.
 // buildIterator ensures that EVM mempool has checked txs for reorgs up to COMMITTED
 // block height and then returns a combined iterator over EVM & Cosmos txs.
 func (m *Mempool) buildIterator(ctx context.Context, txs [][]byte) sdkmempool.Iterator {
-	defer func(t0 time.Time) { telemetry.MeasureSince(t0, "expmempool_builditerator_duration") }(time.Now()) //nolint:staticcheck
+	defer func(t0 time.Time) {
+		buildIteratorDuration.Record(ctx, float64(time.Since(t0).Milliseconds()))
+	}(time.Now())
 
 	evmIterator, cosmosIterator := m.getIterators(ctx, txs)
 


### PR DESCRIPTION
# Description

We've missed a couple of metrics when converting to otel in the mempool.

These are __the last ones__.

Also adds an attribute to the insert queue metrics so we can distinguish cosmos versus evm insert queue.

Closes: #XXXX

---

## Author Checklist

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.

I have...

- [ ] tackled an existing issue or discussed with a team member
- [ ] left instructions on how to review the changes
- [ ] targeted the `main` branch
