### PR TITLE
fix(mempool)!: Remove VM keeper end blocker notification, use `PrepareCheckStater` instead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### DEPENDENCIES
 
+### API-BREAKING
+- [\#1146](https://github.com/cosmos/evm/pull/1146) Remove `EndBlocker` based mempool updates, use `PrepareCheckStater` instead. 
+
 ### IMPROVEMENTS
 
 - [\#758](https://github.com/cosmos/evm/pull/758) Cleanup precompiles abi.json.

--- a/evmd/mempool.go
+++ b/evmd/mempool.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	servertypes "github.com/cosmos/cosmos-sdk/server/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 // configureEVMMempool sets up the EVM mempool and related handlers using viper configuration.
@@ -64,6 +65,12 @@ func (app *EVMD) configureEVMMempool(appOpts servertypes.AppOptions, logger log.
 	app.SetCheckTxHandler(checkTxHandler)
 
 	app.SetMempool(mempool)
+
+	app.SetPrepareCheckStater(func(_ sdk.Context) {
+		if !mempool.HasEventBus() {
+			mempool.NotifyNewBlock()
+		}
+	})
 
 	return nil
 }

--- a/mempool/interface.go
+++ b/mempool/interface.go
@@ -12,17 +12,6 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
-// NotifiedMempool is the set of methods that a mempool must implement in order
-// to be notified of new blocks by this Keeper via the EndBlocker.
-type NotifiedMempool interface {
-	// HasEventBus returns true if the mempool has an event bus configured to
-	// get cometbft events
-	HasEventBus() bool
-
-	// GetBlockchain returns the mempools blockchain representation.
-	GetBlockchain() *Blockchain
-}
-
 type VMKeeperI interface {
 	GetBaseFee(ctx sdk.Context) *big.Int
 	GetParams(ctx sdk.Context) (params vmtypes.Params)

--- a/mempool/interface.go
+++ b/mempool/interface.go
@@ -39,7 +39,6 @@ type VMKeeperI interface {
 	SetCode(ctx sdk.Context, codeHash []byte, code []byte)
 	DeleteAccount(ctx sdk.Context, addr common.Address) error
 	KVStoreKeys() map[string]storetypes.StoreKey
-	SetEvmMempool(evmMempool NotifiedMempool)
 }
 
 type FeeMarketKeeperI interface {

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -212,8 +212,6 @@ func NewMempool(
 		config.InsertQueueSize,
 	)
 
-	vmKeeper.SetEvmMempool(mempool)
-
 	// Start the cosmos pool recheck loop
 	mempool.recheckCosmosPool.Start(blockchain.CurrentBlock())
 

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -469,13 +469,17 @@ func (m *Mempool) SetEventBus(eventBus *cmttypes.EventBus) {
 		panic(err)
 	}
 	go func() {
-		bc := m.GetBlockchain()
 		for range sub.Out() {
-			bc.NotifyNewBlock()
-			// Trigger cosmos pool recheck on new block (non-blocking)
-			m.recheckCosmosPool.TriggerRecheck(bc.CurrentBlock())
+			m.NotifyNewBlock()
 		}
 	}()
+}
+
+// NotifyNewBlock manually notifies that there has been a new block produced
+// and it should update its internal data structures.
+func (m *Mempool) NotifyNewBlock() {
+	m.blockchain.NotifyNewBlock()
+	m.recheckCosmosPool.TriggerRecheck(m.blockchain.CurrentBlock())
 }
 
 // HasEventBus returns true if the blockchain is configured to use an event bus for block notifications.

--- a/mempool/mocks/VMKeeperI.go
+++ b/mempool/mocks/VMKeeperI.go
@@ -5,7 +5,6 @@ package mocks
 import (
 	big "math/big"
 
-	mempool "github.com/cosmos/evm/mempool"
 	common "github.com/ethereum/go-ethereum/common"
 
 	mock "github.com/stretchr/testify/mock"
@@ -234,11 +233,6 @@ func (_m *VMKeeperI) SetAccount(ctx types.Context, addr common.Address, account 
 // SetCode provides a mock function with given fields: ctx, codeHash, code
 func (_m *VMKeeperI) SetCode(ctx types.Context, codeHash []byte, code []byte) {
 	_m.Called(ctx, codeHash, code)
-}
-
-// SetEvmMempool provides a mock function with given fields: evmMempool
-func (_m *VMKeeperI) SetEvmMempool(evmMempool mempool.NotifiedMempool) {
-	_m.Called(evmMempool)
 }
 
 // SetState provides a mock function with given fields: ctx, addr, key, value

--- a/x/vm/keeper/abci.go
+++ b/x/vm/keeper/abci.go
@@ -44,9 +44,6 @@ func (k *Keeper) BeginBlock(ctx sdk.Context) (err error) {
 func (k *Keeper) EndBlock(ctx sdk.Context) (err error) {
 	ctx, span := ctx.StartSpan(tracer, "EndBlock", trace.WithAttributes(attribute.Int64("block_num", ctx.BlockHeight())))
 	defer func() { evmtrace.EndSpanErr(span, err) }()
-	if k.evmMempool != nil && !k.evmMempool.HasEventBus() {
-		k.evmMempool.GetBlockchain().NotifyNewBlock()
-	}
 
 	k.CollectTxBloom(ctx)
 

--- a/x/vm/keeper/keeper.go
+++ b/x/vm/keeper/keeper.go
@@ -15,7 +15,6 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 
-	evmmempool "github.com/cosmos/evm/mempool"
 	evmtrace "github.com/cosmos/evm/trace"
 	"github.com/cosmos/evm/utils"
 	"github.com/cosmos/evm/x/vm/statedb"
@@ -83,10 +82,6 @@ type Keeper struct {
 	// Some of these precompiled contracts might not be active depending on the EVM
 	// parameters.
 	precompiles map[common.Address]vm.PrecompiledContract
-
-	// evmMempool is the custom EVM appside mempool
-	// if it is nil, the default comet mempool will be used
-	evmMempool evmmempool.NotifiedMempool
 
 	// virtualFeeCollection enabling will use "Virtual" methods from the bank module to accumulate
 	// fees to the fee collector module in the endBlocker instead of using regular sends during tx execution.
@@ -414,12 +409,6 @@ func (k Keeper) AddTransientGasUsed(ctx sdk.Context, gasUsed uint64) (uint64, er
 // KVStoreKeys returns KVStore keys injected to keeper
 func (k Keeper) KVStoreKeys() map[string]storetypes.StoreKey {
 	return k.storeKeys
-}
-
-// SetMempool sets the mempool that is notified of new blocks via the
-// EndBlocker.
-func (k *Keeper) SetEvmMempool(evmMempool evmmempool.NotifiedMempool) {
-	k.evmMempool = evmMempool
 }
 
 // SetHeaderHash sets current block hash into EIP-2935 compatible storage contract.


### PR DESCRIPTION
# Description

Removes the ability to notify the mempool of new blocks within the vm keepers end blocker. This is strictly incorrect now since it will trigger a reset of the mempool on stale state. This behavior is replicated by using the `PrepareCheckStater` hook that is called just after a block is committed and the check state is updated.

Closes: STACK-2688

---

## Author Checklist

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.

I have...

- [ ] tackled an existing issue or discussed with a team member
- [ ] left instructions on how to review the changes
- [ ] targeted the `main` branch
