### PR TITLE
chore(mempool): add tests and document 7702 authority behaviour

### DIFF
--- a/mempool/mempool_test.go
+++ b/mempool/mempool_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/ecdsa"
 	"errors"
+	"fmt"
 	"math/big"
 	"strconv"
 	"sync"
@@ -629,6 +630,55 @@ type testMempoolDependencies struct {
 	accounts        []testAccount
 }
 
+// AdvanceNonce updates the mock vmKeeper to return newNonce for GetNonce(addr)
+// and a matching Account from GetAccount. Used to simulate chain-state advance
+// between blocks so legacypool's reactive reset path can observe the change.
+func (s *testMempoolDependencies) AdvanceNonce(t *testing.T, addr common.Address, newNonce uint64) {
+	t.Helper()
+	filtered := make([]*mock.Call, 0, len(s.vmKeeper.ExpectedCalls))
+	for _, c := range s.vmKeeper.ExpectedCalls {
+		if c.Method == "GetNonce" && len(c.Arguments) >= 1 {
+			if a, ok := c.Arguments[0].(common.Address); ok && a == addr {
+				continue
+			}
+		}
+		if c.Method == "GetAccount" && len(c.Arguments) >= 2 {
+			if a, ok := c.Arguments[1].(common.Address); ok && a == addr {
+				continue
+			}
+		}
+		filtered = append(filtered, c)
+	}
+	s.vmKeeper.ExpectedCalls = filtered
+	s.vmKeeper.On("GetNonce", addr).Return(newNonce).Maybe()
+	s.vmKeeper.On("GetAccount", mock.Anything, addr).Return(&statedb.Account{
+		Nonce:   newNonce,
+		Balance: uint256.NewInt(1e18),
+	}).Maybe()
+}
+
+// InstallNonceCheckingRechecker wires the EVM rechecker to reject txs whose
+// nonce is below the mock's GetAccount(sender).Nonce. Simulates the ante
+// handler's sequence check during reset's demoteUnexecutables.
+func (s *testMempoolDependencies) InstallNonceCheckingRechecker(t *testing.T) {
+	t.Helper()
+	signer := types.LatestSignerForChainID(big.NewInt(int64(constants.EighteenDecimalsChainID)))
+	s.evmRechecker.SetEVMRecheck(func(ctx sdk.Context, tx *types.Transaction) (sdk.Context, error) {
+		from, err := types.Sender(signer, tx)
+		if err != nil {
+			return ctx, nil
+		}
+		acc := s.vmKeeper.GetAccount(sdk.Context{}, from)
+		if acc == nil {
+			return ctx, nil
+		}
+		if tx.Nonce() < acc.Nonce {
+			return sdk.Context{}, fmt.Errorf("stale tx: nonce %d < chain %d", tx.Nonce(), acc.Nonce)
+		}
+		return ctx, nil
+	})
+}
+
 func setupMempoolWithAccounts(t *testing.T, numAccounts int) (*mempool.Mempool, testMempoolDependencies) {
 	t.Helper()
 
@@ -793,6 +843,248 @@ func createMsgEthereumTx(
 	cosmosTx, err := evmtestutiltx.PrepareEthTx(txConfig, priv, msg)
 	require.NoError(t, err)
 	return cosmosTx
+}
+
+// createMsgEthereum7702Tx builds a cosmos-wrapped MsgEthereumTx of type-04
+// (EIP-7702 SetCode) signed by senderKey with the supplied authorization
+// list. Each `auths` entry is signed by its `key` field with the embedded
+// nonce. Returns the cosmos-signed sdk.Tx and the underlying ethereum tx
+// for assertion convenience.
+func createMsgEthereum7702Tx(
+	t *testing.T,
+	txConfig client.TxConfig,
+	senderKey *ecdsa.PrivateKey,
+	txNonce uint64,
+	auths []types.SetCodeAuthorization,
+) (sdk.Tx, *types.Transaction) {
+	t.Helper()
+
+	chainID := vmtypes.GetEthChainConfig().ChainID
+	to := common.Address{0x55}
+	signedTx := types.MustSignNewTx(senderKey, types.LatestSignerForChainID(chainID), &types.SetCodeTx{
+		ChainID:   uint256.MustFromBig(chainID),
+		Nonce:     txNonce,
+		GasTipCap: uint256.NewInt(1),
+		GasFeeCap: uint256.NewInt(1e9),
+		Gas:       250000,
+		To:        to,
+		Value:     uint256.NewInt(0),
+		AuthList:  auths,
+	})
+
+	msg := &vmtypes.MsgEthereumTx{
+		Raw:  vmtypes.EthereumTx{Transaction: signedTx},
+		From: crypto.PubkeyToAddress(senderKey.PublicKey).Bytes(),
+	}
+
+	// priv=nil → PrepareEthTx skips re-signing (we already have a signed eth
+	// tx) and just wraps the message into a cosmos tx with the EVM extension
+	// option.
+	cosmosTx, err := evmtestutiltx.PrepareEthTx(txConfig, nil, msg)
+	require.NoError(t, err)
+	return cosmosTx, signedTx
+}
+
+// signSetCodeAuth is a small wrapper around types.SignSetCode for tests.
+func signSetCodeAuth(t *testing.T, key *ecdsa.PrivateKey, nonce uint64) types.SetCodeAuthorization {
+	t.Helper()
+	chainID := vmtypes.GetEthChainConfig().ChainID
+	auth, err := types.SignSetCode(key, types.SetCodeAuthorization{
+		ChainID: *uint256.MustFromBig(chainID),
+		Address: common.Address{0x42},
+		Nonce:   nonce,
+	})
+	require.NoError(t, err)
+	return auth
+}
+
+// Self-sponsored 7702: sender's nonce bumps twice on chain (tx + self-auth)
+// but eager only signals tx.Nonce(). A pending tx in the +1 gap is left for
+// async reset to evict.
+func TestRecordNonceAdvances_EIP7702_SenderIsAuthority_AuthBumpNotTrackedEagerly(t *testing.T) {
+	mp, s := setupMempoolWithAccounts(t, 1)
+	txConfig, accounts := s.txConfig, s.accounts
+
+	senderKey := accounts[0].key
+	senderAddr := accounts[0].address
+	legacyPool := mp.GetTxPool().Subpools[0].(*legacypool.LegacyPool)
+
+	txNonce := uint64(0)
+	auths := []types.SetCodeAuthorization{signSetCodeAuth(t, senderKey, txNonce+1)}
+	cosmosTx, _ := createMsgEthereum7702Tx(t, txConfig, senderKey, txNonce, auths)
+
+	require.NoError(t, mp.RemoveWithReason(context.Background(), cosmosTx, mempooltypes.RemoveReason{
+		Caller: mempooltypes.CallerRunTxFinalize,
+	}))
+
+	got, ok := legacyPool.LatestNonce(senderAddr)
+	require.True(t, ok)
+	require.Equal(t, txNonce, got)
+}
+
+// Cross-account 7702: authority's nonce bump is not tracked eagerly; async
+// reset picks it up on the next block-head event.
+func TestRecordNonceAdvances_EIP7702_AuthorityNotTrackedEagerly(t *testing.T) {
+	mp, s := setupMempoolWithAccounts(t, 2)
+	txConfig, accounts := s.txConfig, s.accounts
+
+	senderKey := accounts[0].key
+	senderAddr := accounts[0].address
+	authorityAddr := accounts[1].address
+	authorityKey := accounts[1].key
+	legacyPool := mp.GetTxPool().Subpools[0].(*legacypool.LegacyPool)
+
+	txNonce := uint64(2)
+	authNonce := uint64(7)
+	auths := []types.SetCodeAuthorization{signSetCodeAuth(t, authorityKey, authNonce)}
+	cosmosTx, _ := createMsgEthereum7702Tx(t, txConfig, senderKey, txNonce, auths)
+
+	require.NoError(t, mp.RemoveWithReason(context.Background(), cosmosTx, mempooltypes.RemoveReason{
+		Caller: mempooltypes.CallerRunTxFinalize,
+	}))
+
+	// Sender IS tracked eagerly via the standard recordNonceAdvances path.
+	gotSender, ok := legacyPool.LatestNonce(senderAddr)
+	require.True(t, ok, "expected LatestNonce to be recorded for sender")
+	require.Equal(t, txNonce, gotSender)
+
+	// Authority is NOT tracked eagerly. Async reset (block-head subscription)
+	// will pick up the on-chain advance later.
+	_, ok = legacyPool.LatestNonce(authorityAddr)
+	require.False(t, ok, "authority must not be tracked eagerly; rely on async reset")
+}
+
+// Reactive reset evicts a stale sender tx after the chain advances. Eager
+// mechanism not invoked; eviction is purely from legacypool.reset() reading
+// chain state on a new block-head event.
+func TestReactiveReset_EvictsStaleSenderTx(t *testing.T) {
+	mp, s := setupMempoolWithAccounts(t, 1)
+	txConfig, bus, accounts := s.txConfig, s.eventBus, s.accounts
+	sender := accounts[0]
+
+	require.NoError(t, bus.PublishEventNewBlockHeader(cmttypes.EventDataNewBlockHeader{
+		Header: cmttypes.Header{Height: 1, Time: time.Now(), ChainID: strconv.Itoa(constants.EighteenDecimalsChainID)},
+	}))
+	require.NoError(t, mp.GetTxPool().Sync())
+
+	tx := createMsgEthereumTx(t, txConfig, sender.key, 0, big.NewInt(1e8))
+	require.NoError(t, mp.Insert(context.Background(), tx))
+	require.NoError(t, mp.GetTxPool().Sync())
+
+	legacyPool := mp.GetTxPool().Subpools[0].(*legacypool.LegacyPool)
+	pending, _ := legacyPool.ContentFrom(sender.address)
+	require.Len(t, pending, 1)
+
+	// Advance chain state without calling RemoveWithReason: eager path stays silent.
+	s.InstallNonceCheckingRechecker(t)
+	s.AdvanceNonce(t, sender.address, 1)
+
+	require.NoError(t, bus.PublishEventNewBlockHeader(cmttypes.EventDataNewBlockHeader{
+		Header: cmttypes.Header{Height: 2, Time: time.Now(), ChainID: strconv.Itoa(constants.EighteenDecimalsChainID)},
+	}))
+	require.NoError(t, mp.GetTxPool().Sync())
+
+	require.Eventually(t, func() bool {
+		p, q := legacyPool.ContentFrom(sender.address)
+		return len(p) == 0 && len(q) == 0
+	}, time.Second, 10*time.Millisecond, "reactive reset must evict stale sender tx")
+}
+
+// Cross-account 7702: authority's pending tx is evicted by reactive reset.
+// Eager only signals sender; authority eviction depends on legacypool.reset()
+// observing the chain advance.
+func TestReactiveReset_EvictsAuthorityTxAfter7702(t *testing.T) {
+	mp, s := setupMempoolWithAccounts(t, 2)
+	txConfig, bus, accounts := s.txConfig, s.eventBus, s.accounts
+	senderAcc := accounts[0]
+	authorityAcc := accounts[1]
+
+	require.NoError(t, bus.PublishEventNewBlockHeader(cmttypes.EventDataNewBlockHeader{
+		Header: cmttypes.Header{Height: 1, Time: time.Now(), ChainID: strconv.Itoa(constants.EighteenDecimalsChainID)},
+	}))
+	require.NoError(t, mp.GetTxPool().Sync())
+
+	authorityTx := createMsgEthereumTx(t, txConfig, authorityAcc.key, 0, big.NewInt(1e8))
+	require.NoError(t, mp.Insert(context.Background(), authorityTx))
+	require.NoError(t, mp.GetTxPool().Sync())
+
+	legacyPool := mp.GetTxPool().Subpools[0].(*legacypool.LegacyPool)
+	pending, _ := legacyPool.ContentFrom(authorityAcc.address)
+	require.Len(t, pending, 1)
+
+	// Finalize a 7702 tx where authorityAcc authorizes a target. Eager fires
+	// for sender only; authority is not signaled.
+	txNonce := uint64(0)
+	auths := []types.SetCodeAuthorization{signSetCodeAuth(t, authorityAcc.key, 1)}
+	cosmosTx, _ := createMsgEthereum7702Tx(t, txConfig, senderAcc.key, txNonce, auths)
+	require.NoError(t, mp.RemoveWithReason(context.Background(), cosmosTx, mempooltypes.RemoveReason{
+		Caller: mempooltypes.CallerRunTxFinalize,
+	}))
+	_, ok := legacyPool.LatestNonce(authorityAcc.address)
+	require.False(t, ok, "authority must not be eagerly tracked")
+
+	// Simulate the auth applying: authority's chain nonce now 1.
+	s.InstallNonceCheckingRechecker(t)
+	s.AdvanceNonce(t, authorityAcc.address, 1)
+
+	require.NoError(t, bus.PublishEventNewBlockHeader(cmttypes.EventDataNewBlockHeader{
+		Header: cmttypes.Header{Height: 2, Time: time.Now(), ChainID: strconv.Itoa(constants.EighteenDecimalsChainID)},
+	}))
+	require.NoError(t, mp.GetTxPool().Sync())
+
+	require.Eventually(t, func() bool {
+		p, q := legacyPool.ContentFrom(authorityAcc.address)
+		return len(p) == 0 && len(q) == 0
+	}, time.Second, 10*time.Millisecond, "reactive reset must evict authority tx after 7702")
+}
+
+// Self-sponsored 7702: sender's tx in the +1 nonce gap is evicted by reactive
+// reset. Eager only signals tx.Nonce(); the auth-driven +1 bump is caught only
+// when reset reads chain state.
+func TestReactiveReset_EvictsSenderGapAfterSelfSponsored7702(t *testing.T) {
+	mp, s := setupMempoolWithAccounts(t, 1)
+	txConfig, bus, accounts := s.txConfig, s.eventBus, s.accounts
+	sender := accounts[0]
+
+	require.NoError(t, bus.PublishEventNewBlockHeader(cmttypes.EventDataNewBlockHeader{
+		Header: cmttypes.Header{Height: 1, Time: time.Now(), ChainID: strconv.Itoa(constants.EighteenDecimalsChainID)},
+	}))
+	require.NoError(t, mp.GetTxPool().Sync())
+
+	// Pre-seed sender's pending txs at nonces 0 and 1.
+	for nonce := uint64(0); nonce < 2; nonce++ {
+		tx := createMsgEthereumTx(t, txConfig, sender.key, nonce, big.NewInt(1e8))
+		require.NoError(t, mp.Insert(context.Background(), tx))
+	}
+	require.NoError(t, mp.GetTxPool().Sync())
+
+	legacyPool := mp.GetTxPool().Subpools[0].(*legacypool.LegacyPool)
+	pending, _ := legacyPool.ContentFrom(sender.address)
+	require.Len(t, pending, 2)
+
+	// Finalize a self-sponsored 7702 tx. Eager: SetLatestNonce(sender, 0).
+	// removeOlds drops nonce ≤ 0; sender@1 stays. The auth-driven +1 bump is
+	// invisible to eager.
+	txNonce := uint64(0)
+	auths := []types.SetCodeAuthorization{signSetCodeAuth(t, sender.key, txNonce+1)}
+	cosmosTx, _ := createMsgEthereum7702Tx(t, txConfig, sender.key, txNonce, auths)
+	require.NoError(t, mp.RemoveWithReason(context.Background(), cosmosTx, mempooltypes.RemoveReason{
+		Caller: mempooltypes.CallerRunTxFinalize,
+	}))
+
+	// Simulate both bumps applied: chain nonce now 2.
+	s.InstallNonceCheckingRechecker(t)
+	s.AdvanceNonce(t, sender.address, 2)
+
+	require.NoError(t, bus.PublishEventNewBlockHeader(cmttypes.EventDataNewBlockHeader{
+		Header: cmttypes.Header{Height: 2, Time: time.Now(), ChainID: strconv.Itoa(constants.EighteenDecimalsChainID)},
+	}))
+	require.NoError(t, mp.GetTxPool().Sync())
+
+	require.Eventually(t, func() bool {
+		p, q := legacyPool.ContentFrom(sender.address)
+		return len(p) == 0 && len(q) == 0
+	}, time.Second, 10*time.Millisecond, "reactive reset must evict sender's +1 gap tx after self-sponsored 7702")
 }
 
 // decodeTxBytes decodes transaction bytes returned from ReapNewValidTxs back into an Ethereum transaction

--- a/mempool/mempool_test.go
+++ b/mempool/mempool_test.go
@@ -920,6 +920,11 @@ func TestEvictsStaleTx(t *testing.T) {
 		seedNonces   []uint64 // nonces to pre-seed for accounts[targetIdx]
 		finalize7702 func(t *testing.T, mp *mempool.Mempool, txConfig client.TxConfig, accs []testAccount)
 		advanceTo    uint64 // chain nonce to set for accounts[targetIdx]
+		// Expected eager-cache state for accounts[targetIdx] AFTER the test:
+		// expectsEager=false when no SetLatestNonce was triggered for the target;
+		// expectsEager=true with eagerNonce set when the eager path fired.
+		expectsEager bool
+		eagerNonce   uint64
 	}
 
 	cases := []scenario{
@@ -929,6 +934,8 @@ func TestEvictsStaleTx(t *testing.T) {
 			targetIdx:   0,
 			seedNonces:  []uint64{0},
 			advanceTo:   1,
+			// no RemoveWithReason call → eager cache untouched.
+			expectsEager: false,
 		},
 		{
 			name:        "authority-after-cross-account-7702",
@@ -944,6 +951,8 @@ func TestEvictsStaleTx(t *testing.T) {
 				}))
 			},
 			advanceTo: 1,
+			// Eager fires for sender (idx 0); authority (idx 1, the target) is invisible.
+			expectsEager: false,
 		},
 		{
 			name:        "sender-+1-gap-after-self-sponsored-7702",
@@ -959,6 +968,9 @@ func TestEvictsStaleTx(t *testing.T) {
 				}))
 			},
 			advanceTo: 2,
+			// Eager fires for sender (== target) at tx.Nonce()=0; the +1 bump is reactive.
+			expectsEager: true,
+			eagerNonce:   0,
 		},
 	}
 
@@ -999,6 +1011,14 @@ func TestEvictsStaleTx(t *testing.T) {
 				p, q := legacyPool.ContentFrom(target.address)
 				return len(p) == 0 && len(q) == 0
 			}, time.Second, 10*time.Millisecond, "reset must evict stale tx")
+
+			got, ok := legacyPool.LatestNonce(target.address)
+			if tc.expectsEager {
+				require.True(t, ok, "eager cache should have an entry for target")
+				require.Equal(t, tc.eagerNonce, got)
+			} else {
+				require.False(t, ok, "no eager signal expected; eviction proves reactive path")
+			}
 		})
 	}
 }

--- a/mempool/mempool_test.go
+++ b/mempool/mempool_test.go
@@ -633,23 +633,34 @@ type testMempoolDependencies struct {
 // AdvanceNonce updates the mock vmKeeper to return newNonce for GetNonce(addr)
 // and a matching Account from GetAccount. Used to simulate chain-state advance
 // between blocks so legacypool's reactive reset path can observe the change.
+//
+// Assumes prior GetNonce/GetAccount expectations were registered with a
+// concrete common.Address argument (as setupMempool does). Expectations
+// registered with mock.Anything or other non-Address matchers would not match
+// the type assertion below and would survive — leaving stale entries that race
+// with the new ones.
 func (s *testMempoolDependencies) AdvanceNonce(t *testing.T, addr common.Address, newNonce uint64) {
 	t.Helper()
-	filtered := make([]*mock.Call, 0, len(s.vmKeeper.ExpectedCalls))
+	var toUnset []*mock.Call
 	for _, c := range s.vmKeeper.ExpectedCalls {
-		if c.Method == "GetNonce" && len(c.Arguments) >= 1 {
-			if a, ok := c.Arguments[0].(common.Address); ok && a == addr {
-				continue
+		switch c.Method {
+		case "GetNonce":
+			if len(c.Arguments) >= 1 {
+				if a, ok := c.Arguments[0].(common.Address); ok && a == addr {
+					toUnset = append(toUnset, c)
+				}
+			}
+		case "GetAccount":
+			if len(c.Arguments) >= 2 {
+				if a, ok := c.Arguments[1].(common.Address); ok && a == addr {
+					toUnset = append(toUnset, c)
+				}
 			}
 		}
-		if c.Method == "GetAccount" && len(c.Arguments) >= 2 {
-			if a, ok := c.Arguments[1].(common.Address); ok && a == addr {
-				continue
-			}
-		}
-		filtered = append(filtered, c)
 	}
-	s.vmKeeper.ExpectedCalls = filtered
+	for _, c := range toUnset {
+		c.Unset() // acquires the mock's internal mutex
+	}
 	s.vmKeeper.On("GetNonce", addr).Return(newNonce).Maybe()
 	s.vmKeeper.On("GetAccount", mock.Anything, addr).Return(&statedb.Account{
 		Nonce:   newNonce,
@@ -856,7 +867,7 @@ func createMsgEthereum7702Tx(
 	senderKey *ecdsa.PrivateKey,
 	txNonce uint64,
 	auths []types.SetCodeAuthorization,
-) (sdk.Tx, *types.Transaction) {
+) sdk.Tx {
 	t.Helper()
 
 	chainID := vmtypes.GetEthChainConfig().ChainID
@@ -882,7 +893,7 @@ func createMsgEthereum7702Tx(
 	// option.
 	cosmosTx, err := evmtestutiltx.PrepareEthTx(txConfig, nil, msg)
 	require.NoError(t, err)
-	return cosmosTx, signedTx
+	return cosmosTx
 }
 
 // signSetCodeAuth is a small wrapper around types.SignSetCode for tests.
@@ -925,8 +936,9 @@ func TestEvictsStaleTx(t *testing.T) {
 			targetIdx:   1,
 			seedNonces:  []uint64{0},
 			finalize7702: func(t *testing.T, mp *mempool.Mempool, txConfig client.TxConfig, accs []testAccount) {
+				t.Helper()
 				auths := []types.SetCodeAuthorization{signSetCodeAuth(t, accs[1].key, 1)}
-				cosmosTx, _ := createMsgEthereum7702Tx(t, txConfig, accs[0].key, 0, auths)
+				cosmosTx := createMsgEthereum7702Tx(t, txConfig, accs[0].key, 0, auths)
 				require.NoError(t, mp.RemoveWithReason(context.Background(), cosmosTx, mempooltypes.RemoveReason{
 					Caller: mempooltypes.CallerRunTxFinalize,
 				}))
@@ -939,8 +951,9 @@ func TestEvictsStaleTx(t *testing.T) {
 			targetIdx:   0,
 			seedNonces:  []uint64{0, 1},
 			finalize7702: func(t *testing.T, mp *mempool.Mempool, txConfig client.TxConfig, accs []testAccount) {
+				t.Helper()
 				auths := []types.SetCodeAuthorization{signSetCodeAuth(t, accs[0].key, 1)}
-				cosmosTx, _ := createMsgEthereum7702Tx(t, txConfig, accs[0].key, 0, auths)
+				cosmosTx := createMsgEthereum7702Tx(t, txConfig, accs[0].key, 0, auths)
 				require.NoError(t, mp.RemoveWithReason(context.Background(), cosmosTx, mempooltypes.RemoveReason{
 					Caller: mempooltypes.CallerRunTxFinalize,
 				}))

--- a/mempool/mempool_test.go
+++ b/mempool/mempool_test.go
@@ -898,193 +898,96 @@ func signSetCodeAuth(t *testing.T, key *ecdsa.PrivateKey, nonce uint64) types.Se
 	return auth
 }
 
-// Self-sponsored 7702: sender's nonce bumps twice on chain (tx + self-auth)
-// but eager only signals tx.Nonce(). A pending tx in the +1 gap is left for
-// async reset to evict.
-func TestRecordNonceAdvances_EIP7702_SenderIsAuthority_AuthBumpNotTrackedEagerly(t *testing.T) {
-	mp, s := setupMempoolWithAccounts(t, 1)
-	txConfig, accounts := s.txConfig, s.accounts
-
-	senderKey := accounts[0].key
-	senderAddr := accounts[0].address
-	legacyPool := mp.GetTxPool().Subpools[0].(*legacypool.LegacyPool)
-
-	txNonce := uint64(0)
-	auths := []types.SetCodeAuthorization{signSetCodeAuth(t, senderKey, txNonce+1)}
-	cosmosTx, _ := createMsgEthereum7702Tx(t, txConfig, senderKey, txNonce, auths)
-
-	require.NoError(t, mp.RemoveWithReason(context.Background(), cosmosTx, mempooltypes.RemoveReason{
-		Caller: mempooltypes.CallerRunTxFinalize,
-	}))
-
-	got, ok := legacyPool.LatestNonce(senderAddr)
-	require.True(t, ok)
-	require.Equal(t, txNonce, got)
-}
-
-// Cross-account 7702: authority's nonce bump is not tracked eagerly; async
-// reset picks it up on the next block-head event.
-func TestRecordNonceAdvances_EIP7702_AuthorityNotTrackedEagerly(t *testing.T) {
-	mp, s := setupMempoolWithAccounts(t, 2)
-	txConfig, accounts := s.txConfig, s.accounts
-
-	senderKey := accounts[0].key
-	senderAddr := accounts[0].address
-	authorityAddr := accounts[1].address
-	authorityKey := accounts[1].key
-	legacyPool := mp.GetTxPool().Subpools[0].(*legacypool.LegacyPool)
-
-	txNonce := uint64(2)
-	authNonce := uint64(7)
-	auths := []types.SetCodeAuthorization{signSetCodeAuth(t, authorityKey, authNonce)}
-	cosmosTx, _ := createMsgEthereum7702Tx(t, txConfig, senderKey, txNonce, auths)
-
-	require.NoError(t, mp.RemoveWithReason(context.Background(), cosmosTx, mempooltypes.RemoveReason{
-		Caller: mempooltypes.CallerRunTxFinalize,
-	}))
-
-	// Sender IS tracked eagerly via the standard recordNonceAdvances path.
-	gotSender, ok := legacyPool.LatestNonce(senderAddr)
-	require.True(t, ok, "expected LatestNonce to be recorded for sender")
-	require.Equal(t, txNonce, gotSender)
-
-	// Authority is NOT tracked eagerly. Async reset (block-head subscription)
-	// will pick up the on-chain advance later.
-	_, ok = legacyPool.LatestNonce(authorityAddr)
-	require.False(t, ok, "authority must not be tracked eagerly; rely on async reset")
-}
-
-// Reactive reset evicts a stale sender tx after the chain advances. Eager
-// mechanism not invoked; eviction is purely from legacypool.reset() reading
-// chain state on a new block-head event.
-func TestReactiveReset_EvictsStaleSenderTx(t *testing.T) {
-	mp, s := setupMempoolWithAccounts(t, 1)
-	txConfig, bus, accounts := s.txConfig, s.eventBus, s.accounts
-	sender := accounts[0]
-
-	require.NoError(t, bus.PublishEventNewBlockHeader(cmttypes.EventDataNewBlockHeader{
-		Header: cmttypes.Header{Height: 1, Time: time.Now(), ChainID: strconv.Itoa(constants.EighteenDecimalsChainID)},
-	}))
-	require.NoError(t, mp.GetTxPool().Sync())
-
-	tx := createMsgEthereumTx(t, txConfig, sender.key, 0, big.NewInt(1e8))
-	require.NoError(t, mp.Insert(context.Background(), tx))
-	require.NoError(t, mp.GetTxPool().Sync())
-
-	legacyPool := mp.GetTxPool().Subpools[0].(*legacypool.LegacyPool)
-	pending, _ := legacyPool.ContentFrom(sender.address)
-	require.Len(t, pending, 1)
-
-	// Advance chain state without calling RemoveWithReason: eager path stays silent.
-	s.InstallNonceCheckingRechecker(t)
-	s.AdvanceNonce(t, sender.address, 1)
-
-	require.NoError(t, bus.PublishEventNewBlockHeader(cmttypes.EventDataNewBlockHeader{
-		Header: cmttypes.Header{Height: 2, Time: time.Now(), ChainID: strconv.Itoa(constants.EighteenDecimalsChainID)},
-	}))
-	require.NoError(t, mp.GetTxPool().Sync())
-
-	require.Eventually(t, func() bool {
-		p, q := legacyPool.ContentFrom(sender.address)
-		return len(p) == 0 && len(q) == 0
-	}, time.Second, 10*time.Millisecond, "reactive reset must evict stale sender tx")
-}
-
-// Cross-account 7702: authority's pending tx is evicted by reactive reset.
-// Eager only signals sender; authority eviction depends on legacypool.reset()
-// observing the chain advance.
-func TestReactiveReset_EvictsAuthorityTxAfter7702(t *testing.T) {
-	mp, s := setupMempoolWithAccounts(t, 2)
-	txConfig, bus, accounts := s.txConfig, s.eventBus, s.accounts
-	senderAcc := accounts[0]
-	authorityAcc := accounts[1]
-
-	require.NoError(t, bus.PublishEventNewBlockHeader(cmttypes.EventDataNewBlockHeader{
-		Header: cmttypes.Header{Height: 1, Time: time.Now(), ChainID: strconv.Itoa(constants.EighteenDecimalsChainID)},
-	}))
-	require.NoError(t, mp.GetTxPool().Sync())
-
-	authorityTx := createMsgEthereumTx(t, txConfig, authorityAcc.key, 0, big.NewInt(1e8))
-	require.NoError(t, mp.Insert(context.Background(), authorityTx))
-	require.NoError(t, mp.GetTxPool().Sync())
-
-	legacyPool := mp.GetTxPool().Subpools[0].(*legacypool.LegacyPool)
-	pending, _ := legacyPool.ContentFrom(authorityAcc.address)
-	require.Len(t, pending, 1)
-
-	// Finalize a 7702 tx where authorityAcc authorizes a target. Eager fires
-	// for sender only; authority is not signaled.
-	txNonce := uint64(0)
-	auths := []types.SetCodeAuthorization{signSetCodeAuth(t, authorityAcc.key, 1)}
-	cosmosTx, _ := createMsgEthereum7702Tx(t, txConfig, senderAcc.key, txNonce, auths)
-	require.NoError(t, mp.RemoveWithReason(context.Background(), cosmosTx, mempooltypes.RemoveReason{
-		Caller: mempooltypes.CallerRunTxFinalize,
-	}))
-	_, ok := legacyPool.LatestNonce(authorityAcc.address)
-	require.False(t, ok, "authority must not be eagerly tracked")
-
-	// Simulate the auth applying: authority's chain nonce now 1.
-	s.InstallNonceCheckingRechecker(t)
-	s.AdvanceNonce(t, authorityAcc.address, 1)
-
-	require.NoError(t, bus.PublishEventNewBlockHeader(cmttypes.EventDataNewBlockHeader{
-		Header: cmttypes.Header{Height: 2, Time: time.Now(), ChainID: strconv.Itoa(constants.EighteenDecimalsChainID)},
-	}))
-	require.NoError(t, mp.GetTxPool().Sync())
-
-	require.Eventually(t, func() bool {
-		p, q := legacyPool.ContentFrom(authorityAcc.address)
-		return len(p) == 0 && len(q) == 0
-	}, time.Second, 10*time.Millisecond, "reactive reset must evict authority tx after 7702")
-}
-
-// Self-sponsored 7702: sender's tx in the +1 nonce gap is evicted by reactive
-// reset. Eager only signals tx.Nonce(); the auth-driven +1 bump is caught only
-// when reset reads chain state.
-func TestReactiveReset_EvictsSenderGapAfterSelfSponsored7702(t *testing.T) {
-	mp, s := setupMempoolWithAccounts(t, 1)
-	txConfig, bus, accounts := s.txConfig, s.eventBus, s.accounts
-	sender := accounts[0]
-
-	require.NoError(t, bus.PublishEventNewBlockHeader(cmttypes.EventDataNewBlockHeader{
-		Header: cmttypes.Header{Height: 1, Time: time.Now(), ChainID: strconv.Itoa(constants.EighteenDecimalsChainID)},
-	}))
-	require.NoError(t, mp.GetTxPool().Sync())
-
-	// Pre-seed sender's pending txs at nonces 0 and 1.
-	for nonce := uint64(0); nonce < 2; nonce++ {
-		tx := createMsgEthereumTx(t, txConfig, sender.key, nonce, big.NewInt(1e8))
-		require.NoError(t, mp.Insert(context.Background(), tx))
+// TestEvictsStaleTx covers eviction of stale txs via demoteUnexecutables →
+// RecheckEVM during reset, across three scenarios where the eager mechanism
+// can't or doesn't catch the chain advance.
+func TestEvictsStaleTx(t *testing.T) {
+	type scenario struct {
+		name         string
+		numAccounts  int
+		targetIdx    int      // account whose pool should drain
+		seedNonces   []uint64 // nonces to pre-seed for accounts[targetIdx]
+		finalize7702 func(t *testing.T, mp *mempool.Mempool, txConfig client.TxConfig, accs []testAccount)
+		advanceTo    uint64 // chain nonce to set for accounts[targetIdx]
 	}
-	require.NoError(t, mp.GetTxPool().Sync())
 
-	legacyPool := mp.GetTxPool().Subpools[0].(*legacypool.LegacyPool)
-	pending, _ := legacyPool.ContentFrom(sender.address)
-	require.Len(t, pending, 2)
+	cases := []scenario{
+		{
+			name:        "stale-sender-no-7702",
+			numAccounts: 1,
+			targetIdx:   0,
+			seedNonces:  []uint64{0},
+			advanceTo:   1,
+		},
+		{
+			name:        "authority-after-cross-account-7702",
+			numAccounts: 2,
+			targetIdx:   1,
+			seedNonces:  []uint64{0},
+			finalize7702: func(t *testing.T, mp *mempool.Mempool, txConfig client.TxConfig, accs []testAccount) {
+				auths := []types.SetCodeAuthorization{signSetCodeAuth(t, accs[1].key, 1)}
+				cosmosTx, _ := createMsgEthereum7702Tx(t, txConfig, accs[0].key, 0, auths)
+				require.NoError(t, mp.RemoveWithReason(context.Background(), cosmosTx, mempooltypes.RemoveReason{
+					Caller: mempooltypes.CallerRunTxFinalize,
+				}))
+			},
+			advanceTo: 1,
+		},
+		{
+			name:        "sender-+1-gap-after-self-sponsored-7702",
+			numAccounts: 1,
+			targetIdx:   0,
+			seedNonces:  []uint64{0, 1},
+			finalize7702: func(t *testing.T, mp *mempool.Mempool, txConfig client.TxConfig, accs []testAccount) {
+				auths := []types.SetCodeAuthorization{signSetCodeAuth(t, accs[0].key, 1)}
+				cosmosTx, _ := createMsgEthereum7702Tx(t, txConfig, accs[0].key, 0, auths)
+				require.NoError(t, mp.RemoveWithReason(context.Background(), cosmosTx, mempooltypes.RemoveReason{
+					Caller: mempooltypes.CallerRunTxFinalize,
+				}))
+			},
+			advanceTo: 2,
+		},
+	}
 
-	// Finalize a self-sponsored 7702 tx. Eager: SetLatestNonce(sender, 0).
-	// removeOlds drops nonce ≤ 0; sender@1 stays. The auth-driven +1 bump is
-	// invisible to eager.
-	txNonce := uint64(0)
-	auths := []types.SetCodeAuthorization{signSetCodeAuth(t, sender.key, txNonce+1)}
-	cosmosTx, _ := createMsgEthereum7702Tx(t, txConfig, sender.key, txNonce, auths)
-	require.NoError(t, mp.RemoveWithReason(context.Background(), cosmosTx, mempooltypes.RemoveReason{
-		Caller: mempooltypes.CallerRunTxFinalize,
-	}))
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mp, s := setupMempoolWithAccounts(t, tc.numAccounts)
+			txConfig, bus, accounts := s.txConfig, s.eventBus, s.accounts
+			target := accounts[tc.targetIdx]
 
-	// Simulate both bumps applied: chain nonce now 2.
-	s.InstallNonceCheckingRechecker(t)
-	s.AdvanceNonce(t, sender.address, 2)
+			require.NoError(t, bus.PublishEventNewBlockHeader(cmttypes.EventDataNewBlockHeader{
+				Header: cmttypes.Header{Height: 1, Time: time.Now(), ChainID: strconv.Itoa(constants.EighteenDecimalsChainID)},
+			}))
+			require.NoError(t, mp.GetTxPool().Sync())
 
-	require.NoError(t, bus.PublishEventNewBlockHeader(cmttypes.EventDataNewBlockHeader{
-		Header: cmttypes.Header{Height: 2, Time: time.Now(), ChainID: strconv.Itoa(constants.EighteenDecimalsChainID)},
-	}))
-	require.NoError(t, mp.GetTxPool().Sync())
+			for _, n := range tc.seedNonces {
+				tx := createMsgEthereumTx(t, txConfig, target.key, n, big.NewInt(1e8))
+				require.NoError(t, mp.Insert(context.Background(), tx))
+			}
+			require.NoError(t, mp.GetTxPool().Sync())
 
-	require.Eventually(t, func() bool {
-		p, q := legacyPool.ContentFrom(sender.address)
-		return len(p) == 0 && len(q) == 0
-	}, time.Second, 10*time.Millisecond, "reactive reset must evict sender's +1 gap tx after self-sponsored 7702")
+			legacyPool := mp.GetTxPool().Subpools[0].(*legacypool.LegacyPool)
+			pending, _ := legacyPool.ContentFrom(target.address)
+			require.Len(t, pending, len(tc.seedNonces))
+
+			if tc.finalize7702 != nil {
+				tc.finalize7702(t, mp, txConfig, accounts)
+			}
+
+			s.InstallNonceCheckingRechecker(t)
+			s.AdvanceNonce(t, target.address, tc.advanceTo)
+
+			require.NoError(t, bus.PublishEventNewBlockHeader(cmttypes.EventDataNewBlockHeader{
+				Header: cmttypes.Header{Height: 2, Time: time.Now(), ChainID: strconv.Itoa(constants.EighteenDecimalsChainID)},
+			}))
+			require.NoError(t, mp.GetTxPool().Sync())
+
+			require.Eventually(t, func() bool {
+				p, q := legacyPool.ContentFrom(target.address)
+				return len(p) == 0 && len(q) == 0
+			}, time.Second, 10*time.Millisecond, "reset must evict stale tx")
+		})
+	}
 }
 
 // decodeTxBytes decodes transaction bytes returned from ReapNewValidTxs back into an Ethereum transaction

--- a/mempool/signer.go
+++ b/mempool/signer.go
@@ -22,8 +22,11 @@ func NewEthSignerExtractionAdapter(fallback mempool.SignerExtractionAdapter) Eth
 }
 
 // GetSigners returns the EVM tx sender. EIP-7702 authorities are NOT enumerated:
-// auth.Nonce is unverifiable from tx data, so eager signaling could falsely
-// evict pending txs. Async reset catches authority nonce advances instead.
+// whether each authorization succeeds on chain (and therefore actually bumps
+// the authority's nonce) is unverifiable without chain state — a failed
+// authorization does not increment the nonce. Eagerly reporting auth.Nonce
+// would falsely evict legitimate pending txs from authorities whose auths
+// failed. Async reset catches authority nonce advances instead.
 // Non-EVM cosmos txs fall through to the SDK default.
 func (s EthSignerExtractionAdapter) GetSigners(tx sdk.Tx) ([]mempool.SignerData, error) {
 	if txWithExtensions, ok := tx.(authante.HasExtensionOptionsTx); ok {

--- a/mempool/signer.go
+++ b/mempool/signer.go
@@ -21,8 +21,10 @@ func NewEthSignerExtractionAdapter(fallback mempool.SignerExtractionAdapter) Eth
 	return EthSignerExtractionAdapter{fallback}
 }
 
-// GetSigners implements the Adapter interface
-// NOTE: only the first item is used by the mempool
+// GetSigners returns the EVM tx sender. EIP-7702 authorities are NOT enumerated:
+// auth.Nonce is unverifiable from tx data, so eager signaling could falsely
+// evict pending txs. Async reset catches authority nonce advances instead.
+// Non-EVM cosmos txs fall through to the SDK default.
 func (s EthSignerExtractionAdapter) GetSigners(tx sdk.Tx) ([]mempool.SignerData, error) {
 	if txWithExtensions, ok := tx.(authante.HasExtensionOptionsTx); ok {
 		opts := txWithExtensions.GetExtensionOptions()

--- a/mempool/txpool/legacypool/legacypool.go
+++ b/mempool/txpool/legacypool/legacypool.go
@@ -555,6 +555,13 @@ func (pool *LegacyPool) SetLatestNonce(sender common.Address, nonce uint64) {
 	}
 }
 
+// LatestNonce returns the most recently recorded latest-included nonce for
+// addr and whether an entry exists in the cache. Primarily useful for tests
+// and debugging.
+func (pool *LegacyPool) LatestNonce(addr common.Address) (uint64, bool) {
+	return pool.latestIncludedNonce.Get(addr)
+}
+
 // removeOlds removes txs that have been scheduled for removals from
 // list l for sender addr. Returns the txs successfully removed.
 func (pool *LegacyPool) removeOlds(addr common.Address, l *list, poolType PoolType) types.Transactions {


### PR DESCRIPTION
Closes: STACK-2668

Context:
  - Type-04 EVM tx that delegates an EOA's code to a contract. Has a sender (pays gas) and authorizations signed by authorities (the EOAs being delegated).
  - Sender's nonce always +1 on inclusion. Each successfully applied authorization bumps its authority's nonce +1.

  Added:

  - `LegacyPool.LatestNonce` as read counterpart to SetLatestNonce.
  - Test for three scenarios:
    - `stale-sender-no-7702`: Tests regular removals of stale sender nonces in the reset loop
    - `authority-after-cross-account-7702`: Tests for stale removals of an authority signed by a different sender in the reset loop
    - `sender-+1-gap-after-self-sponsored-7702`: Tests for a self-sponsored stale removal of a += 2 nonce in the reset loop

Decided not to pursue adding authorities to the signer extractor as we would need to get nonce state to ensure the authorizations pass. There's a case where the authorizations fail, and that should not increment the nonce. There's just no good way of figuring that out within the extractor without threading in some kind of data. Keeping it light and following up with STACK-2686.