### PR TITLE
fix: reap list size and large tx bug

### DIFF
--- a/mempool/internal/reaplist/metrics.go
+++ b/mempool/internal/reaplist/metrics.go
@@ -96,7 +96,7 @@ func init() {
 
 	metrics.evictedTxs, err = meter.Int64Counter(
 		"reap_list.evicted_txs",
-		metric.WithDescription("Total number of transactions evicted from the reap list, by reason (oversized_bytes, oversized_gas, cap_full)"),
+		metric.WithDescription("Total number of transactions evicted from the reap list, by reason (oversized_bytes, oversized_gas, oversized_both, cap_full)"),
 	)
 	if err != nil {
 		panic(err)

--- a/mempool/internal/reaplist/metrics.go
+++ b/mempool/internal/reaplist/metrics.go
@@ -42,8 +42,7 @@ func (rlm *reapListMetrics) TxDropped(txType txType) {
 	rlm.droppedTxs.Add(context.Background(), 1, metric.WithAttributeSet(attributes))
 }
 
-// TxEvicted records that a tx was evicted from the reap list with the given
-// reason (e.g. "oversized_bytes", "oversized_gas", "cap_full").
+// TxEvicted records that a tx was evicted from the reap list with the given reason.
 func (rlm *reapListMetrics) TxEvicted(reason string) {
 	attributes := attribute.NewSet(attribute.String("reason", reason))
 	rlm.evictedTxs.Add(context.Background(), 1, metric.WithAttributeSet(attributes))

--- a/mempool/internal/reaplist/metrics.go
+++ b/mempool/internal/reaplist/metrics.go
@@ -16,6 +16,7 @@ type reapListMetrics struct {
 	numIndexTxs metric.Int64Gauge
 	pushedTxs   metric.Int64Counter
 	droppedTxs  metric.Int64Counter
+	evictedTxs  metric.Int64Counter
 }
 
 var metrics = reapListMetrics{}
@@ -39,6 +40,13 @@ func (rlm *reapListMetrics) TxPushed(txType txType) {
 func (rlm *reapListMetrics) TxDropped(txType txType) {
 	attributes := attribute.NewSet(attribute.String("tx_type", string(txType)))
 	rlm.droppedTxs.Add(context.Background(), 1, metric.WithAttributeSet(attributes))
+}
+
+// TxEvicted records that a tx was evicted from the reap list with the given
+// reason (e.g. "oversized_bytes", "oversized_gas", "cap_full").
+func (rlm *reapListMetrics) TxEvicted(reason string) {
+	attributes := attribute.NewSet(attribute.String("reason", reason))
+	rlm.evictedTxs.Add(context.Background(), 1, metric.WithAttributeSet(attributes))
 }
 
 // RecordNumTxs records the number of entires in txs
@@ -81,6 +89,14 @@ func init() {
 	metrics.droppedTxs, err = meter.Int64Counter(
 		"reap_list.dropped_txs",
 		metric.WithDescription("Total number of transactions that have been dropped from the reap list"),
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	metrics.evictedTxs, err = meter.Int64Counter(
+		"reap_list.evicted_txs",
+		metric.WithDescription("Total number of transactions evicted from the reap list, by reason (oversized_bytes, oversized_gas, cap_full)"),
 	)
 	if err != nil {
 		panic(err)

--- a/mempool/internal/reaplist/reaplist.go
+++ b/mempool/internal/reaplist/reaplist.go
@@ -1,6 +1,7 @@
 package reaplist
 
 import (
+	"errors"
 	"fmt"
 	"slices"
 	"sync"
@@ -12,6 +13,40 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
+// Unbounded is the sentinel value for ReapList.maxSize that disables the
+// capacity check, restoring legacy unbounded behavior.
+const Unbounded = 0
+
+// ErrReapListFull is returned by Push* when the reap list is at capacity.
+var ErrReapListFull = errors.New("reap list full")
+
+// Eviction reasons used by metrics and surfaced via the drop callback.
+const (
+	reasonOversizedBytes = "oversized_bytes"
+	reasonOversizedGas   = "oversized_gas"
+	reasonCapFull        = "cap_full"
+)
+
+// TxKind identifies which sub-pool owns a tx so the drop callback can route
+// the eviction without re-decoding bytes.
+type TxKind int
+
+const (
+	KindEVM TxKind = iota
+	KindCosmos
+)
+
+// DropCallback is invoked from Reap when a tx is evicted from the reap list
+// (e.g. permanently oversized for any block). The callback should remove the
+// tx from its owning sub-pool. It is invoked AFTER the reap list lock has been
+// released so callbacks may safely re-enter the reap list.
+//
+// For KindCosmos evictions, cosmosTx is the original sdk.Tx (populated at
+// PushCosmosTx time) so callers can drive the cosmos pool's typed removal API
+// without re-decoding bytes. For KindEVM evictions, cosmosTx is nil and
+// callers should remove via the hash.
+type DropCallback func(hash string, kind TxKind, cosmosTx sdk.Tx)
+
 type EVMCosmosTxEncoder interface {
 	EVMTx(tx *ethtypes.Transaction) ([]byte, error)
 	CosmosTx(tx sdk.Tx) ([]byte, error)
@@ -21,11 +56,15 @@ type txWithHash struct {
 	bytes []byte
 	hash  string
 	gas   uint64
+	kind  TxKind
+	// cosmosTx is populated for KindCosmos entries only. The drop callback
+	// requires the original sdk.Tx to remove from the cosmos sub-pool, since
+	// the cosmos pool API takes sdk.Tx (not bytes/hash).
+	cosmosTx sdk.Tx
 }
 
 type ReapList struct {
 	// txs is a list of transactions and their respective hashes
-	// NOTE: this currently has unbound size
 	txs []*txWithHash
 
 	// txIndex is a map of tx hashes to what index that tx is stored in inside
@@ -39,27 +78,57 @@ type ReapList struct {
 
 	// txEncoder encodes evm and cosmos txs to bytes.
 	txEncoder EVMCosmosTxEncoder
+
+	// maxSize is the upper bound on len(txs). Tombstones (nil entries) count
+	// toward the cap until the next Reap compacts them. If maxSize == Unbounded
+	// the cap check is skipped.
+	maxSize int
+
+	// dropCallback, if set, is invoked from Reap when a tx is evicted (e.g.
+	// permanently oversized) so the owning sub-pool can also drop it. May be
+	// nil; callers in tests can pass nil to disable the side effect.
+	dropCallback DropCallback
 }
 
-func New(txEncoder EVMCosmosTxEncoder) *ReapList {
-	return &ReapList{
-		txEncoder: txEncoder,
-		txIndex:   make(map[string]int),
+// New constructs a ReapList. Pass Unbounded for maxSize to disable the cap.
+// dropCallback may be nil.
+func New(txEncoder EVMCosmosTxEncoder, maxSize int, dropCallback DropCallback) *ReapList {
+	if maxSize < 0 {
+		maxSize = Unbounded
 	}
+	return &ReapList{
+		txEncoder:    txEncoder,
+		txIndex:      make(map[string]int),
+		maxSize:      maxSize,
+		dropCallback: dropCallback,
+	}
+}
+
+// pendingDrop carries a deferred drop callback invocation collected during
+// Reap. Callbacks are invoked after the reap list lock is released so they
+// may safely re-enter the reap list.
+type pendingDrop struct {
+	hash string
+	kind TxKind
+	tx   sdk.Tx
 }
 
 // Reap returns a list of the oldest to newest transactions bytes from the reap
 // list until either maxBytes or maxGas is reached for the list of transactions
 // being returned. If maxBytes and maxGas are both 0 all txs will be returned.
+//
+// Permanently oversized txs (txSize > maxBytes or txGas > maxGas) are evicted
+// from the reap list (and their owning sub-pool, via dropCallback) since they
+// can never fit in any block under the current limits.
 func (rl *ReapList) Reap(maxBytes uint64, maxGas uint64) [][]byte {
 	rl.txsLock.Lock()
-	defer rl.txsLock.Unlock()
 
 	var (
 		totalBytes uint64
 		totalGas   uint64
 		result     [][]byte
 		nextStart  int
+		drops      []pendingDrop
 	)
 
 	for idx, tx := range rl.txs {
@@ -73,7 +142,27 @@ func (rl *ReapList) Reap(maxBytes uint64, maxGas uint64) [][]byte {
 		txSize := uint64(len(tx.bytes))
 		txGas := tx.gas
 
-		// Check if adding this tx would exceed limits
+		// Permanently oversized: tx alone exceeds the block limit. Evict so a
+		// single oversized tx at the head of the list cannot block subsequent
+		// reaps indefinitely.
+		oversizedBytes := maxBytes > 0 && txSize > maxBytes
+		oversizedGas := maxGas > 0 && txGas > maxGas
+		if oversizedBytes || oversizedGas {
+			reason := reasonOversizedBytes
+			if oversizedGas && !oversizedBytes {
+				reason = reasonOversizedGas
+			}
+			rl.evict(idx, reason)
+			drops = append(drops, pendingDrop{hash: tx.hash, kind: tx.kind, tx: tx.cosmosTx})
+			// the slot is now nil; advance nextStart so we don't keep
+			// re-considering it on subsequent iterations (handled naturally
+			// since loop is over a fixed snapshot of rl.txs).
+			nextStart = idx + 1
+			continue
+		}
+
+		// Adding this tx would exceed the remaining budget. Stop here -- the
+		// tx itself fits, just not in this reap.
 		if (maxBytes > 0 && totalBytes+txSize > maxBytes) || (maxGas > 0 && totalGas+txGas > maxGas) {
 			break
 		}
@@ -117,6 +206,16 @@ func (rl *ReapList) Reap(maxBytes uint64, maxGas uint64) [][]byte {
 	}
 	metrics.RecordNumIndexTxs(rl.txIndex)
 
+	rl.txsLock.Unlock()
+
+	// Invoke drop callbacks AFTER releasing the lock so the sub-pool's drop
+	// path may safely re-enter the reap list (e.g. via DropCosmosTx -> drop).
+	if rl.dropCallback != nil {
+		for _, d := range drops {
+			rl.dropCallback(d.hash, d.kind, d.tx)
+		}
+	}
+
 	return result
 }
 
@@ -131,12 +230,17 @@ func (rl *ReapList) PushEVMTx(tx *ethtypes.Transaction) error {
 		return nil
 	}
 
+	if rl.atCapacityLocked() {
+		metrics.TxEvicted(reasonCapFull)
+		return ErrReapListFull
+	}
+
 	txBytes, err := rl.txEncoder.EVMTx(tx)
 	if err != nil {
 		return fmt.Errorf("encoding evm tx to bytes: %w", err)
 	}
 
-	rl.push(hash, txBytes, tx.Gas())
+	rl.push(&txWithHash{bytes: txBytes, hash: hash, gas: tx.Gas(), kind: KindEVM})
 
 	metrics.TxPushed(evmType)
 	return nil
@@ -157,6 +261,11 @@ func (rl *ReapList) PushCosmosTx(tx sdk.Tx) error {
 		return nil
 	}
 
+	if rl.atCapacityLocked() {
+		metrics.TxEvicted(reasonCapFull)
+		return ErrReapListFull
+	}
+
 	var gas uint64
 	if feeTx, ok := tx.(sdk.FeeTx); ok {
 		gas = feeTx.GetGas()
@@ -164,7 +273,7 @@ func (rl *ReapList) PushCosmosTx(tx sdk.Tx) error {
 		return fmt.Errorf("error getting tx gas: cosmos tx must implement sdk.FeeTx")
 	}
 
-	rl.push(hash, txBytes, gas)
+	rl.push(&txWithHash{bytes: txBytes, hash: hash, gas: gas, kind: KindCosmos, cosmosTx: tx})
 
 	metrics.TxPushed(cosmosType)
 	return nil
@@ -175,12 +284,24 @@ func (rl *ReapList) PushCosmosTx(tx sdk.Tx) error {
 // already in the ReapList, this should be checked via exists.
 //
 // NOTE: this is not thread safe, callers should be holding the txsLock.
-func (rl *ReapList) push(hash string, tx []byte, gas uint64) {
-	rl.txs = append(rl.txs, &txWithHash{tx, hash, gas})
-	rl.txIndex[hash] = len(rl.txs) - 1
+func (rl *ReapList) push(entry *txWithHash) {
+	rl.txs = append(rl.txs, entry)
+	rl.txIndex[entry.hash] = len(rl.txs) - 1
 
 	metrics.RecordNumTxs(rl.txs)
 	metrics.RecordNumIndexTxs(rl.txIndex)
+}
+
+// atCapacityLocked reports whether the reap list is at its configured cap.
+// Tombstones (nil entries) count toward the cap; they hold memory until the
+// next Reap compacts them.
+//
+// NOTE: this is not thread safe, callers should be holding the txsLock.
+func (rl *ReapList) atCapacityLocked() bool {
+	if rl.maxSize == Unbounded {
+		return false
+	}
+	return len(rl.txs) >= rl.maxSize
 }
 
 // exists returns true if a hash is in the index, false otherwise.
@@ -240,6 +361,22 @@ func (rl *ReapList) drop(hash string) bool {
 	// reap list **including** tombstones. We will update numTxs when the
 	// tombstone is removed via the next `Reap` call.
 	return true
+}
+
+// evict tombstones the slot at idx and removes the hash from the index.
+// Increments the eviction metric for the given reason. Caller must hold
+// rl.txsLock and must invoke any associated dropCallback AFTER the lock is
+// released.
+//
+// NOTE: this is not thread safe, callers should be holding the txsLock.
+func (rl *ReapList) evict(idx int, reason string) {
+	tx := rl.txs[idx]
+	if tx == nil {
+		return
+	}
+	delete(rl.txIndex, tx.hash)
+	rl.txs[idx] = nil
+	metrics.TxEvicted(reason)
 }
 
 func cosmosHash(txBytes []byte) string {

--- a/mempool/internal/reaplist/reaplist.go
+++ b/mempool/internal/reaplist/reaplist.go
@@ -24,6 +24,7 @@ var ErrReapListFull = errors.New("reap list full")
 const (
 	reasonOversizedBytes = "oversized_bytes"
 	reasonOversizedGas   = "oversized_gas"
+	reasonOversizedBoth  = "oversized_both"
 	reasonCapFull        = "cap_full"
 )
 
@@ -154,8 +155,13 @@ func (rl *ReapList) Reap(maxBytes uint64, maxGas uint64) [][]byte {
 		oversizedBytes := maxBytes > 0 && txSize > maxBytes
 		oversizedGas := maxGas > 0 && txGas > maxGas
 		if oversizedBytes || oversizedGas {
-			reason := reasonOversizedBytes
-			if oversizedGas && !oversizedBytes {
+			var reason string
+			switch {
+			case oversizedBytes && oversizedGas:
+				reason = reasonOversizedBoth
+			case oversizedBytes:
+				reason = reasonOversizedBytes
+			default:
 				reason = reasonOversizedGas
 			}
 			rl.evict(idx, reason)

--- a/mempool/internal/reaplist/reaplist.go
+++ b/mempool/internal/reaplist/reaplist.go
@@ -79,10 +79,16 @@ type ReapList struct {
 	// txEncoder encodes evm and cosmos txs to bytes.
 	txEncoder EVMCosmosTxEncoder
 
-	// maxSize is the upper bound on len(txs). Tombstones (nil entries) count
-	// toward the cap until the next Reap compacts them. If maxSize == Unbounded
-	// the cap check is skipped.
+	// maxSize is the upper bound on the number of LIVE entries (non-nil slots)
+	// in txs. Tombstones do not count toward the cap, so a drop+push between
+	// Reaps cannot strand a promoted tx by transiently overshooting maxSize.
+	// If maxSize == Unbounded the cap check is skipped.
 	maxSize int
+
+	// liveCount is the number of non-nil entries in txs. Maintained
+	// incrementally by push/drop/evict and reconciled to len(txs) at the end
+	// of Reap (post-compaction txs has no nils). Used by atCapacityLocked.
+	liveCount int
 
 	// dropCallback, if set, is invoked from Reap when a tx is evicted (e.g.
 	// permanently oversized) so the owning sub-pool can also drop it. May be
@@ -206,6 +212,12 @@ func (rl *ReapList) Reap(maxBytes uint64, maxGas uint64) [][]byte {
 	}
 	metrics.RecordNumIndexTxs(rl.txIndex)
 
+	// After compaction txs has no nils, so live count equals slice length.
+	// Reconciles liveCount with reaped txs that were resliced away (those were
+	// live but never decremented in the loop) and acts as a defense-in-depth
+	// invariant against accounting drift in push/drop/evict.
+	rl.liveCount = len(rl.txs)
+
 	rl.txsLock.Unlock()
 
 	// Invoke drop callbacks AFTER releasing the lock so the sub-pool's drop
@@ -287,21 +299,22 @@ func (rl *ReapList) PushCosmosTx(tx sdk.Tx) error {
 func (rl *ReapList) push(entry *txWithHash) {
 	rl.txs = append(rl.txs, entry)
 	rl.txIndex[entry.hash] = len(rl.txs) - 1
+	rl.liveCount++
 
 	metrics.RecordNumTxs(rl.txs)
 	metrics.RecordNumIndexTxs(rl.txIndex)
 }
 
 // atCapacityLocked reports whether the reap list is at its configured cap.
-// Tombstones (nil entries) count toward the cap; they hold memory until the
-// next Reap compacts them.
+// Counts only live (non-nil) entries; tombstones do not count, so a
+// drop+push between Reaps does not transiently strand a promoted tx.
 //
 // NOTE: this is not thread safe, callers should be holding the txsLock.
 func (rl *ReapList) atCapacityLocked() bool {
 	if rl.maxSize == Unbounded {
 		return false
 	}
-	return len(rl.txs) >= rl.maxSize
+	return rl.liveCount >= rl.maxSize
 }
 
 // exists returns true if a hash is in the index, false otherwise.
@@ -357,6 +370,7 @@ func (rl *ReapList) drop(hash string) bool {
 	}
 
 	rl.txs[idx] = nil
+	rl.liveCount--
 	// NOTE: Not updating numTxs metric here since that reports the size of the
 	// reap list **including** tombstones. We will update numTxs when the
 	// tombstone is removed via the next `Reap` call.
@@ -376,6 +390,7 @@ func (rl *ReapList) evict(idx int, reason string) {
 	}
 	delete(rl.txIndex, tx.hash)
 	rl.txs[idx] = nil
+	rl.liveCount--
 	metrics.TxEvicted(reason)
 }
 

--- a/mempool/internal/reaplist/reaplist.go
+++ b/mempool/internal/reaplist/reaplist.go
@@ -13,14 +13,12 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
-// Unbounded is the sentinel value for ReapList.maxSize that disables the
-// capacity check, restoring legacy unbounded behavior.
+// Unbounded disables the capacity check.
 const Unbounded = 0
 
 // ErrReapListFull is returned by Push* when the reap list is at capacity.
 var ErrReapListFull = errors.New("reap list full")
 
-// Eviction reasons used by metrics and surfaced via the drop callback.
 const (
 	reasonOversizedBytes = "oversized_bytes"
 	reasonOversizedGas   = "oversized_gas"
@@ -37,15 +35,9 @@ const (
 	KindCosmos
 )
 
-// DropCallback is invoked from Reap when a tx is evicted from the reap list
-// (e.g. permanently oversized for any block). The callback should remove the
-// tx from its owning sub-pool. It is invoked AFTER the reap list lock has been
-// released so callbacks may safely re-enter the reap list.
-//
-// For KindCosmos evictions, cosmosTx is the original sdk.Tx (populated at
-// PushCosmosTx time) so callers can drive the cosmos pool's typed removal API
-// without re-decoding bytes. For KindEVM evictions, cosmosTx is nil and
-// callers should remove via the hash.
+// DropCallback is invoked after Reap evicts a tx so the owning sub-pool can
+// drop it too. cosmosTx is set for KindCosmos only; KindEVM removes via hash.
+// Invoked outside the reap list lock so callbacks may re-enter the reap list.
 type DropCallback func(hash string, kind TxKind, cosmosTx sdk.Tx)
 
 type EVMCosmosTxEncoder interface {
@@ -58,9 +50,7 @@ type txWithHash struct {
 	hash  string
 	gas   uint64
 	kind  TxKind
-	// cosmosTx is populated for KindCosmos entries only. The drop callback
-	// requires the original sdk.Tx to remove from the cosmos sub-pool, since
-	// the cosmos pool API takes sdk.Tx (not bytes/hash).
+	// cosmosTx is set for KindCosmos only; the cosmos pool's Remove takes sdk.Tx.
 	cosmosTx sdk.Tx
 }
 
@@ -80,25 +70,17 @@ type ReapList struct {
 	// txEncoder encodes evm and cosmos txs to bytes.
 	txEncoder EVMCosmosTxEncoder
 
-	// maxSize is the upper bound on the number of LIVE entries (non-nil slots)
-	// in txs. Tombstones do not count toward the cap, so a drop+push between
-	// Reaps cannot strand a promoted tx by transiently overshooting maxSize.
-	// If maxSize == Unbounded the cap check is skipped.
+	// maxSize bounds the number of live entries. Unbounded disables the cap.
 	maxSize int
 
-	// liveCount is the number of non-nil entries in txs. Maintained
-	// incrementally by push/drop/evict and reconciled to len(txs) at the end
-	// of Reap (post-compaction txs has no nils). Used by atCapacityLocked.
+	// liveCount is the count of non-nil entries in txs.
 	liveCount int
 
-	// dropCallback, if set, is invoked from Reap when a tx is evicted (e.g.
-	// permanently oversized) so the owning sub-pool can also drop it. May be
-	// nil; callers in tests can pass nil to disable the side effect.
+	// dropCallback notifies the owning sub-pool when Reap evicts a tx. May be nil.
 	dropCallback DropCallback
 }
 
-// New constructs a ReapList. Pass Unbounded for maxSize to disable the cap.
-// dropCallback may be nil.
+// New constructs a ReapList. Pass Unbounded to disable the cap; dropCallback may be nil.
 func New(txEncoder EVMCosmosTxEncoder, maxSize int, dropCallback DropCallback) *ReapList {
 	if maxSize < 0 {
 		maxSize = Unbounded
@@ -111,9 +93,6 @@ func New(txEncoder EVMCosmosTxEncoder, maxSize int, dropCallback DropCallback) *
 	}
 }
 
-// pendingDrop carries a deferred drop callback invocation collected during
-// Reap. Callbacks are invoked after the reap list lock is released so they
-// may safely re-enter the reap list.
 type pendingDrop struct {
 	hash string
 	kind TxKind
@@ -124,9 +103,8 @@ type pendingDrop struct {
 // list until either maxBytes or maxGas is reached for the list of transactions
 // being returned. If maxBytes and maxGas are both 0 all txs will be returned.
 //
-// Permanently oversized txs (txSize > maxBytes or txGas > maxGas) are evicted
-// from the reap list (and their owning sub-pool, via dropCallback) since they
-// can never fit in any block under the current limits.
+// Txs that exceed maxBytes or maxGas standalone are evicted (they can never fit
+// in any block) and the owning sub-pool is notified via dropCallback.
 func (rl *ReapList) Reap(maxBytes uint64, maxGas uint64) [][]byte {
 	rl.txsLock.Lock()
 
@@ -149,9 +127,7 @@ func (rl *ReapList) Reap(maxBytes uint64, maxGas uint64) [][]byte {
 		txSize := uint64(len(tx.bytes))
 		txGas := tx.gas
 
-		// Permanently oversized: tx alone exceeds the block limit. Evict so a
-		// single oversized tx at the head of the list cannot block subsequent
-		// reaps indefinitely.
+		// Standalone-oversized: evict so it can't wedge the head of the list.
 		oversizedBytes := maxBytes > 0 && txSize > maxBytes
 		oversizedGas := maxGas > 0 && txGas > maxGas
 		if oversizedBytes || oversizedGas {
@@ -166,15 +142,11 @@ func (rl *ReapList) Reap(maxBytes uint64, maxGas uint64) [][]byte {
 			}
 			rl.evict(idx, reason)
 			drops = append(drops, pendingDrop{hash: tx.hash, kind: tx.kind, tx: tx.cosmosTx})
-			// the slot is now nil; advance nextStart so we don't keep
-			// re-considering it on subsequent iterations (handled naturally
-			// since loop is over a fixed snapshot of rl.txs).
 			nextStart = idx + 1
 			continue
 		}
 
-		// Adding this tx would exceed the remaining budget. Stop here -- the
-		// tx itself fits, just not in this reap.
+		// Over the remaining budget; tx fits in some block, just not this reap.
 		if (maxBytes > 0 && totalBytes+txSize > maxBytes) || (maxGas > 0 && totalGas+txGas > maxGas) {
 			break
 		}
@@ -218,16 +190,12 @@ func (rl *ReapList) Reap(maxBytes uint64, maxGas uint64) [][]byte {
 	}
 	metrics.RecordNumIndexTxs(rl.txIndex)
 
-	// After compaction txs has no nils, so live count equals slice length.
-	// Reconciles liveCount with reaped txs that were resliced away (those were
-	// live but never decremented in the loop) and acts as a defense-in-depth
-	// invariant against accounting drift in push/drop/evict.
+	// Post-compaction txs has no nils, so liveCount == len(txs).
 	rl.liveCount = len(rl.txs)
 
 	rl.txsLock.Unlock()
 
-	// Invoke drop callbacks AFTER releasing the lock so the sub-pool's drop
-	// path may safely re-enter the reap list (e.g. via DropCosmosTx -> drop).
+	// Callbacks fire outside the lock so they may safely re-enter the reap list.
 	if rl.dropCallback != nil {
 		for _, d := range drops {
 			rl.dropCallback(d.hash, d.kind, d.tx)
@@ -312,8 +280,6 @@ func (rl *ReapList) push(entry *txWithHash) {
 }
 
 // atCapacityLocked reports whether the reap list is at its configured cap.
-// Counts only live (non-nil) entries; tombstones do not count, so a
-// drop+push between Reaps does not transiently strand a promoted tx.
 //
 // NOTE: this is not thread safe, callers should be holding the txsLock.
 func (rl *ReapList) atCapacityLocked() bool {
@@ -384,9 +350,7 @@ func (rl *ReapList) drop(hash string) bool {
 }
 
 // evict tombstones the slot at idx and removes the hash from the index.
-// Increments the eviction metric for the given reason. Caller must hold
-// rl.txsLock and must invoke any associated dropCallback AFTER the lock is
-// released.
+// Caller must invoke any associated dropCallback AFTER the lock is released.
 //
 // NOTE: this is not thread safe, callers should be holding the txsLock.
 func (rl *ReapList) evict(idx int, reason string) {

--- a/mempool/internal/reaplist/reaplist_test.go
+++ b/mempool/internal/reaplist/reaplist_test.go
@@ -8,6 +8,7 @@ import (
 	"math/big"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -146,7 +147,7 @@ func testEVMTx(t *testing.T, key *ecdsa.PrivateKey, nonce uint64, gas uint64) *t
 }
 
 func TestEmptyList(t *testing.T) {
-	rl := New(newDeterministicEncoder(100, 100))
+	rl := New(newDeterministicEncoder(100, 100), Unbounded, nil)
 
 	result := rl.Reap(0, 0)
 
@@ -157,7 +158,7 @@ func TestSingleTransaction(t *testing.T) {
 	key, err := crypto.GenerateKey()
 	require.NoError(t, err)
 
-	rl := New(newDeterministicEncoder(100, 100))
+	rl := New(newDeterministicEncoder(100, 100), Unbounded, nil)
 	tx := testEVMTx(t, key, 0, 21000)
 	err = rl.PushEVMTx(tx)
 	require.NoError(t, err)
@@ -183,7 +184,7 @@ func TestNoLimits(t *testing.T) {
 	key, err := crypto.GenerateKey()
 	require.NoError(t, err)
 
-	rl := New(newDeterministicEncoder(100, 100))
+	rl := New(newDeterministicEncoder(100, 100), Unbounded, nil)
 
 	// Add 10 transactions
 	for i := uint64(0); i < 10; i++ {
@@ -202,7 +203,7 @@ func TestMaxBytesLimit(t *testing.T) {
 	require.NoError(t, err)
 
 	// Each tx is 100 bytes
-	rl := New(newDeterministicEncoder(100, 100))
+	rl := New(newDeterministicEncoder(100, 100), Unbounded, nil)
 
 	// Add 10 transactions
 	for i := uint64(0); i < 10; i++ {
@@ -225,7 +226,7 @@ func TestMaxGasLimit(t *testing.T) {
 	key, err := crypto.GenerateKey()
 	require.NoError(t, err)
 
-	rl := New(newDeterministicEncoder(100, 100))
+	rl := New(newDeterministicEncoder(100, 100), Unbounded, nil)
 
 	// Add transactions with varying gas
 	txGases := []uint64{21000, 30000, 40000, 50000, 60000}
@@ -251,7 +252,7 @@ func TestBothLimits(t *testing.T) {
 	key, err := crypto.GenerateKey()
 	require.NoError(t, err)
 
-	rl := New(newDeterministicEncoder(100, 100))
+	rl := New(newDeterministicEncoder(100, 100), Unbounded, nil)
 
 	// Add transactions with varying gas
 	txGases := []uint64{21000, 30000, 40000, 50000, 60000}
@@ -283,7 +284,7 @@ func TestExactBytesLimit(t *testing.T) {
 	require.NoError(t, err)
 
 	// Each tx is 100 bytes
-	rl := New(newDeterministicEncoder(100, 100))
+	rl := New(newDeterministicEncoder(100, 100), Unbounded, nil)
 
 	// Add 5 transactions
 	for i := uint64(0); i < 5; i++ {
@@ -302,7 +303,7 @@ func TestExactGasLimit(t *testing.T) {
 	key, err := crypto.GenerateKey()
 	require.NoError(t, err)
 
-	rl := New(newDeterministicEncoder(100, 100))
+	rl := New(newDeterministicEncoder(100, 100), Unbounded, nil)
 
 	// Add transactions with specific gas amounts
 	txGases := []uint64{21000, 30000, 40000}
@@ -326,7 +327,7 @@ func TestEncodingFailure(t *testing.T) {
 
 	// Create encoder that fails for nonce 1 and 3
 	failNonces := map[uint64]bool{1: true, 3: true}
-	rl := New(newFailingEVMEncoder(failNonces))
+	rl := New(newFailingEVMEncoder(failNonces), Unbounded, nil)
 
 	// Add 5 transactions (nonces 0-4)
 	// Nonces 1 and 3 will fail during Push, so only 0, 2, 4 will be added
@@ -367,7 +368,7 @@ func TestOrderPreservation(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create encoder that embeds nonce in the bytes for verification
-	rl := New(&nonceEncoder{})
+	rl := New(&nonceEncoder{}, Unbounded, nil)
 
 	// Add transactions in specific order
 	var nonce uint64
@@ -393,7 +394,7 @@ func TestMultipleReaps(t *testing.T) {
 	key, err := crypto.GenerateKey()
 	require.NoError(t, err)
 
-	rl := New(newDeterministicEncoder(100, 100))
+	rl := New(newDeterministicEncoder(100, 100), Unbounded, nil)
 
 	// Add 10 transactions
 	var nonce uint64
@@ -424,7 +425,7 @@ func TestPushAfterReap(t *testing.T) {
 	key, err := crypto.GenerateKey()
 	require.NoError(t, err)
 
-	rl := New(newDeterministicEncoder(100, 100))
+	rl := New(newDeterministicEncoder(100, 100), Unbounded, nil)
 
 	// Add 5 transactions
 	var nonce uint64
@@ -454,7 +455,7 @@ func TestConcurrentPushAndReap(t *testing.T) {
 	key, err := crypto.GenerateKey()
 	require.NoError(t, err)
 
-	rl := New(newDeterministicEncoder(100, 100))
+	rl := New(newDeterministicEncoder(100, 100), Unbounded, nil)
 
 	var wg sync.WaitGroup
 	var totalReaped int
@@ -499,22 +500,24 @@ func TestFirstTransactionExceedsLimit(t *testing.T) {
 	key, err := crypto.GenerateKey()
 	require.NoError(t, err)
 
-	rl := New(newDeterministicEncoder(1000, 1000))
+	rl := New(newDeterministicEncoder(1000, 1000), Unbounded, nil)
 
 	// Add transaction
 	tx := testEVMTx(t, key, 0, 21000)
 	err = rl.PushEVMTx(tx)
 	require.NoError(t, err)
 
-	// Try to reap with limit smaller than first tx
+	// Try to reap with limit smaller than the tx (1000 bytes vs 500 byte limit).
+	// Under HOL eviction (STACK-2669) the tx is permanently oversized for any
+	// block at this limit, so it is evicted from the reap list rather than
+	// retained.
 	result := rl.Reap(500, 0)
-
-	// Should return empty as first tx exceeds limit
 	require.Empty(t, result, "should return empty when first tx exceeds limit")
 
-	// Transaction should still be in list for next reap with higher limit
-	result = rl.Reap(1000, 0)
-	require.Len(t, result, 1, "transaction should still be available with higher limit")
+	// Even with a higher limit, the tx is gone -- it was evicted on the
+	// previous reap.
+	result = rl.Reap(2000, 0)
+	require.Empty(t, result, "evicted tx must not reappear in subsequent reaps")
 }
 
 // alwaysFailEncoder always returns an error for encoding
@@ -533,7 +536,7 @@ func TestAllTransactionsFailEncoding(t *testing.T) {
 	require.NoError(t, err)
 
 	// Encoder that always fails
-	rl := New(&alwaysFailEncoder{})
+	rl := New(&alwaysFailEncoder{}, Unbounded, nil)
 
 	// Add transactions - all will fail during Push
 	var nonce uint64
@@ -551,7 +554,7 @@ func TestAllTransactionsFailEncoding(t *testing.T) {
 // Tests for Cosmos transactions
 
 func TestPushCosmosTx(t *testing.T) {
-	rl := New(newDeterministicEncoder(100, 150))
+	rl := New(newDeterministicEncoder(100, 150), Unbounded, nil)
 
 	// Add Cosmos transactions
 	for i := 0; i < 5; i++ {
@@ -574,7 +577,7 @@ func TestMixedEVMAndCosmosTx(t *testing.T) {
 	require.NoError(t, err)
 
 	// EVM txs are 100 bytes, Cosmos txs are 150 bytes
-	rl := New(newDeterministicEncoder(100, 150))
+	rl := New(newDeterministicEncoder(100, 150), Unbounded, nil)
 
 	// Add mixed transactions
 	evmTx1 := testEVMTx(t, key, 0, 21000)
@@ -609,7 +612,7 @@ func TestMixedEVMAndCosmosTx(t *testing.T) {
 }
 
 func TestCosmosTxWithGasLimit(t *testing.T) {
-	rl := New(newDeterministicEncoder(100, 100))
+	rl := New(newDeterministicEncoder(100, 100), Unbounded, nil)
 
 	// Add Cosmos transactions with varying gas
 	txGases := []uint64{30000, 40000, 50000, 60000}
@@ -659,7 +662,7 @@ func TestCosmosEncodingFailure(t *testing.T) {
 	// Create encoder that fails for tx with id=1
 	failEncoder := &selectiveCosmosFailEncoder{failID: 1}
 
-	rl := New(failEncoder)
+	rl := New(failEncoder, Unbounded, nil)
 
 	// Add Cosmos transactions - tx with id=1 will fail
 	for i := 0; i < 5; i++ {
@@ -679,7 +682,7 @@ func TestDropEVMTx(t *testing.T) {
 	key, err := crypto.GenerateKey()
 	require.NoError(t, err)
 
-	rl := New(newDeterministicEncoder(100, 100))
+	rl := New(newDeterministicEncoder(100, 100), Unbounded, nil)
 
 	// Add 5 EVM transactions
 	txs := make([]*types.Transaction, 5)
@@ -699,7 +702,7 @@ func TestDropEVMTx(t *testing.T) {
 }
 
 func TestDropCosmosTx(t *testing.T) {
-	rl := New(newDeterministicEncoder(100, 100))
+	rl := New(newDeterministicEncoder(100, 100), Unbounded, nil)
 
 	// Add 5 Cosmos transactions
 	txs := make([]*mockCosmosTx, 5)
@@ -723,7 +726,7 @@ func TestDropAfterReap(t *testing.T) {
 	key, err := crypto.GenerateKey()
 	require.NoError(t, err)
 
-	rl := New(newDeterministicEncoder(100, 100))
+	rl := New(newDeterministicEncoder(100, 100), Unbounded, nil)
 
 	// Add 5 transactions
 	txs := make([]*types.Transaction, 5)
@@ -753,7 +756,7 @@ func TestDropNonExistent(t *testing.T) {
 	key, err := crypto.GenerateKey()
 	require.NoError(t, err)
 
-	rl := New(newDeterministicEncoder(100, 100))
+	rl := New(newDeterministicEncoder(100, 100), Unbounded, nil)
 
 	// Add 3 transactions
 	for i := uint64(0); i < 3; i++ {
@@ -775,7 +778,7 @@ func TestMixedDrops(t *testing.T) {
 	key, err := crypto.GenerateKey()
 	require.NoError(t, err)
 
-	rl := New(newDeterministicEncoder(100, 150))
+	rl := New(newDeterministicEncoder(100, 150), Unbounded, nil)
 
 	// Add mixed transactions
 	evmTxs := make([]*types.Transaction, 3)
@@ -813,7 +816,7 @@ func TestConcurrentSameHashPush(t *testing.T) {
 		key, err := crypto.GenerateKey()
 		require.NoError(t, err)
 
-		rl := New(newDeterministicEncoder(100, 100))
+		rl := New(newDeterministicEncoder(100, 100), Unbounded, nil)
 		tx := testEVMTx(t, key, 0, 21000)
 
 		var wg sync.WaitGroup
@@ -836,5 +839,317 @@ func TestConcurrentSameHashPush(t *testing.T) {
 			rl.DropEVMTx(tx)
 			_ = rl.Reap(0, 0)
 		}, "iter %d: drop after concurrent push must not orphan a slot", i)
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Capacity tests (STACK-2670)
+// -----------------------------------------------------------------------------
+
+func TestPushRefusedWhenAtCapacity(t *testing.T) {
+	key, err := crypto.GenerateKey()
+	require.NoError(t, err)
+
+	const cap = 3
+	rl := New(newDeterministicEncoder(100, 100), cap, nil)
+
+	for i := uint64(0); i < cap; i++ {
+		require.NoError(t, rl.PushEVMTx(testEVMTx(t, key, i, 21000)))
+	}
+
+	// Next push must be refused with ErrReapListFull.
+	overflow := testEVMTx(t, key, uint64(cap), 21000)
+	err = rl.PushEVMTx(overflow)
+	require.ErrorIs(t, err, ErrReapListFull)
+
+	// Cosmos pushes are refused under the same cap.
+	require.ErrorIs(t, rl.PushCosmosTx(newMockCosmosTx(99, 21000)), ErrReapListFull)
+}
+
+func TestCapacityRecoversAfterReap(t *testing.T) {
+	key, err := crypto.GenerateKey()
+	require.NoError(t, err)
+
+	const cap = 2
+	rl := New(newDeterministicEncoder(100, 100), cap, nil)
+
+	require.NoError(t, rl.PushEVMTx(testEVMTx(t, key, 0, 21000)))
+	require.NoError(t, rl.PushEVMTx(testEVMTx(t, key, 1, 21000)))
+	require.ErrorIs(t, rl.PushEVMTx(testEVMTx(t, key, 2, 21000)), ErrReapListFull)
+
+	// Reap clears the slots and capacity recovers.
+	result := rl.Reap(0, 0)
+	require.Len(t, result, 2)
+
+	require.NoError(t, rl.PushEVMTx(testEVMTx(t, key, 2, 21000)))
+	require.NoError(t, rl.PushEVMTx(testEVMTx(t, key, 3, 21000)))
+}
+
+func TestCapacityRecoversAfterDrop(t *testing.T) {
+	key, err := crypto.GenerateKey()
+	require.NoError(t, err)
+
+	const cap = 2
+	rl := New(newDeterministicEncoder(100, 100), cap, nil)
+
+	tx0 := testEVMTx(t, key, 0, 21000)
+	tx1 := testEVMTx(t, key, 1, 21000)
+	require.NoError(t, rl.PushEVMTx(tx0))
+	require.NoError(t, rl.PushEVMTx(tx1))
+
+	// Drop tombstones the slot but DOES NOT free capacity until the next
+	// Reap compacts. This matches the documented behavior: "tombstones count
+	// toward the cap".
+	rl.DropEVMTx(tx0)
+	require.ErrorIs(t, rl.PushEVMTx(testEVMTx(t, key, 2, 21000)), ErrReapListFull)
+
+	// After Reap, the tombstone is compacted away and capacity recovers.
+	_ = rl.Reap(0, 0)
+	require.NoError(t, rl.PushEVMTx(testEVMTx(t, key, 2, 21000)))
+}
+
+func TestCapacityWithMixedEVMAndCosmos(t *testing.T) {
+	key, err := crypto.GenerateKey()
+	require.NoError(t, err)
+
+	const cap = 4
+	rl := New(newDeterministicEncoder(100, 100), cap, nil)
+
+	require.NoError(t, rl.PushEVMTx(testEVMTx(t, key, 0, 21000)))
+	require.NoError(t, rl.PushCosmosTx(newMockCosmosTx(0, 21000)))
+	require.NoError(t, rl.PushEVMTx(testEVMTx(t, key, 1, 21000)))
+	require.NoError(t, rl.PushCosmosTx(newMockCosmosTx(1, 21000)))
+
+	require.ErrorIs(t, rl.PushEVMTx(testEVMTx(t, key, 2, 21000)), ErrReapListFull)
+	require.ErrorIs(t, rl.PushCosmosTx(newMockCosmosTx(2, 21000)), ErrReapListFull)
+}
+
+func TestUnboundedWhenCosmosUnbounded(t *testing.T) {
+	key, err := crypto.GenerateKey()
+	require.NoError(t, err)
+
+	rl := New(newDeterministicEncoder(100, 100), Unbounded, nil)
+
+	// Push many txs; no cap should ever fire.
+	for i := uint64(0); i < 200; i++ {
+		require.NoError(t, rl.PushEVMTx(testEVMTx(t, key, i, 21000)))
+	}
+}
+
+func TestConcurrentPushAtCapacity(t *testing.T) {
+	const cap = 50
+	const workers = 16
+	const perWorker = 20
+
+	key, err := crypto.GenerateKey()
+	require.NoError(t, err)
+
+	rl := New(newDeterministicEncoder(100, 100), cap, nil)
+
+	var (
+		wg       sync.WaitGroup
+		start    = make(chan struct{})
+		accepted int64
+		mu       sync.Mutex
+	)
+	for w := 0; w < workers; w++ {
+		wg.Add(1)
+		go func(workerID int) {
+			defer wg.Done()
+			<-start
+			for i := 0; i < perWorker; i++ {
+				nonce := uint64(workerID*perWorker + i)
+				if err := rl.PushEVMTx(testEVMTx(t, key, nonce, 21000)); err == nil {
+					mu.Lock()
+					accepted++
+					mu.Unlock()
+				} else {
+					require.ErrorIs(t, err, ErrReapListFull)
+				}
+			}
+		}(w)
+	}
+	close(start)
+	wg.Wait()
+
+	// Cap must never be exceeded under contention.
+	require.LessOrEqual(t, accepted, int64(cap), "accepted txs must not exceed cap")
+	// And subsequent reap should return at most cap txs.
+	result := rl.Reap(0, 0)
+	require.LessOrEqual(t, len(result), cap)
+}
+
+// -----------------------------------------------------------------------------
+// Head-of-line eviction tests (STACK-2669)
+// -----------------------------------------------------------------------------
+
+func TestOversizedHeadEvicted_Bytes(t *testing.T) {
+	key, err := crypto.GenerateKey()
+	require.NoError(t, err)
+
+	// 1000 byte EVM txs; the first one is permanently too large for a 500
+	// byte block.
+	rl := New(newDeterministicEncoder(1000, 1000), Unbounded, nil)
+
+	require.NoError(t, rl.PushEVMTx(testEVMTx(t, key, 0, 21000)))
+	require.NoError(t, rl.PushEVMTx(testEVMTx(t, key, 1, 21000)))
+
+	// Reap with a byte limit smaller than a single tx -- both are oversized
+	// and both should be evicted.
+	result := rl.Reap(500, 0)
+	require.Empty(t, result)
+
+	// Subsequent reap must not see the evicted txs even when the limit
+	// would have accommodated them.
+	result = rl.Reap(0, 0)
+	require.Empty(t, result, "evicted oversized txs must not reappear")
+}
+
+func TestOversizedHeadEvicted_Gas(t *testing.T) {
+	key, err := crypto.GenerateKey()
+	require.NoError(t, err)
+
+	rl := New(newDeterministicEncoder(100, 100), Unbounded, nil)
+
+	// First tx is 1_000_000 gas; second is 21_000.
+	require.NoError(t, rl.PushEVMTx(testEVMTx(t, key, 0, 1_000_000)))
+	require.NoError(t, rl.PushEVMTx(testEVMTx(t, key, 1, 21_000)))
+
+	// Reap with a 100k gas budget. The head tx alone exceeds the budget and
+	// must be evicted; the second tx must still be reapable.
+	result := rl.Reap(0, 100_000)
+	require.Len(t, result, 1, "second tx should be reaped after head eviction")
+
+	// The evicted tx is gone permanently.
+	result = rl.Reap(0, 10_000_000)
+	require.Empty(t, result)
+}
+
+func TestOversizedMiddleEvicted(t *testing.T) {
+	key, err := crypto.GenerateKey()
+	require.NoError(t, err)
+
+	rl := New(newDeterministicEncoder(100, 100), Unbounded, nil)
+
+	// Three txs with the middle one having huge gas.
+	require.NoError(t, rl.PushEVMTx(testEVMTx(t, key, 0, 21_000)))
+	require.NoError(t, rl.PushEVMTx(testEVMTx(t, key, 1, 5_000_000)))
+	require.NoError(t, rl.PushEVMTx(testEVMTx(t, key, 2, 21_000)))
+
+	// Reap with 100k gas: tx0 fits, tx1 is oversized (evicted), tx2 fits.
+	result := rl.Reap(0, 100_000)
+	require.Len(t, result, 2, "tx0 and tx2 should be reaped, oversized tx1 evicted")
+}
+
+func TestMultipleConsecutiveOversized(t *testing.T) {
+	key, err := crypto.GenerateKey()
+	require.NoError(t, err)
+
+	rl := New(newDeterministicEncoder(100, 100), Unbounded, nil)
+
+	// Three consecutive oversized-by-gas txs followed by one fitting tx.
+	require.NoError(t, rl.PushEVMTx(testEVMTx(t, key, 0, 5_000_000)))
+	require.NoError(t, rl.PushEVMTx(testEVMTx(t, key, 1, 5_000_000)))
+	require.NoError(t, rl.PushEVMTx(testEVMTx(t, key, 2, 5_000_000)))
+	require.NoError(t, rl.PushEVMTx(testEVMTx(t, key, 3, 21_000)))
+
+	result := rl.Reap(0, 100_000)
+	require.Len(t, result, 1, "all three oversized evicted, last tx reaped")
+
+	// Subsequent reap is empty: all oversized are gone, the last was reaped.
+	result = rl.Reap(0, 10_000_000)
+	require.Empty(t, result)
+}
+
+func TestOversizedThenBudgetExceeded(t *testing.T) {
+	key, err := crypto.GenerateKey()
+	require.NoError(t, err)
+
+	rl := New(newDeterministicEncoder(100, 100), Unbounded, nil)
+
+	// tx0: oversized for the budget (must be evicted)
+	// tx1: fits the budget
+	// tx2: would push us over the budget (must be retained, not evicted)
+	require.NoError(t, rl.PushEVMTx(testEVMTx(t, key, 0, 5_000_000)))
+	require.NoError(t, rl.PushEVMTx(testEVMTx(t, key, 1, 80_000)))
+	require.NoError(t, rl.PushEVMTx(testEVMTx(t, key, 2, 80_000)))
+
+	result := rl.Reap(0, 100_000)
+	require.Len(t, result, 1, "only tx1 fits in this reap")
+
+	// tx2 is still in the list and reapable next time.
+	result = rl.Reap(0, 100_000)
+	require.Len(t, result, 1, "tx2 should reap on the next call")
+}
+
+func TestOversizedDropCallbackInvoked(t *testing.T) {
+	key, err := crypto.GenerateKey()
+	require.NoError(t, err)
+
+	type cbRecord struct {
+		hash  string
+		kind  TxKind
+		hasTx bool
+	}
+	var (
+		mu  sync.Mutex
+		got []cbRecord
+	)
+	cb := func(hash string, kind TxKind, tx sdk.Tx) {
+		mu.Lock()
+		defer mu.Unlock()
+		got = append(got, cbRecord{hash: hash, kind: kind, hasTx: tx != nil})
+	}
+
+	rl := New(newDeterministicEncoder(100, 100), Unbounded, cb)
+
+	evmTx := testEVMTx(t, key, 0, 5_000_000)
+	require.NoError(t, rl.PushEVMTx(evmTx))
+	cosmosTx := newMockCosmosTx(0, 5_000_000)
+	require.NoError(t, rl.PushCosmosTx(cosmosTx))
+
+	// Reap with 100k gas: both are oversized, both must invoke the callback.
+	_ = rl.Reap(0, 100_000)
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Len(t, got, 2)
+
+	// Order must match insertion order (EVM, then Cosmos).
+	require.Equal(t, KindEVM, got[0].kind)
+	require.Equal(t, evmTx.Hash().String(), got[0].hash)
+	require.False(t, got[0].hasTx, "EVM eviction should not carry sdk.Tx")
+
+	require.Equal(t, KindCosmos, got[1].kind)
+	require.True(t, got[1].hasTx, "Cosmos eviction must carry sdk.Tx for sub-pool removal")
+}
+
+// TestEvictionDropCallbackReentrant verifies that the drop callback is invoked
+// after the reap list lock is released, so callbacks can safely call back
+// into the reap list (e.g. via DropEVMTx) without deadlock.
+func TestEvictionDropCallbackReentrant(t *testing.T) {
+	key, err := crypto.GenerateKey()
+	require.NoError(t, err)
+
+	var rl *ReapList
+	cb := func(hash string, kind TxKind, _ sdk.Tx) {
+		// Re-entering the reap list from the callback must not deadlock.
+		// Using a non-existent tx so this is a no-op drop.
+		fakeTx := testEVMTx(t, key, 999, 21000)
+		rl.DropEVMTx(fakeTx)
+	}
+	rl = New(newDeterministicEncoder(100, 100), Unbounded, cb)
+
+	require.NoError(t, rl.PushEVMTx(testEVMTx(t, key, 0, 5_000_000)))
+
+	done := make(chan struct{})
+	go func() {
+		_ = rl.Reap(0, 100_000)
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("reap did not complete - drop callback likely caused a deadlock")
 	}
 }

--- a/mempool/internal/reaplist/reaplist_test.go
+++ b/mempool/internal/reaplist/reaplist_test.go
@@ -850,19 +850,19 @@ func TestPushRefusedWhenAtCapacity(t *testing.T) {
 	key, err := crypto.GenerateKey()
 	require.NoError(t, err)
 
-	const cap = 3
-	rl := New(newDeterministicEncoder(100, 100), cap, nil)
+	const capacity = 3
+	rl := New(newDeterministicEncoder(100, 100), capacity, nil)
 
-	for i := uint64(0); i < cap; i++ {
+	for i := uint64(0); i < capacity; i++ {
 		require.NoError(t, rl.PushEVMTx(testEVMTx(t, key, i, 21000)))
 	}
 
 	// Next push must be refused with ErrReapListFull.
-	overflow := testEVMTx(t, key, uint64(cap), 21000)
+	overflow := testEVMTx(t, key, uint64(capacity), 21000)
 	err = rl.PushEVMTx(overflow)
 	require.ErrorIs(t, err, ErrReapListFull)
 
-	// Cosmos pushes are refused under the same cap.
+	// Cosmos pushes are refused under the same capacity.
 	require.ErrorIs(t, rl.PushCosmosTx(newMockCosmosTx(99, 21000)), ErrReapListFull)
 }
 
@@ -870,8 +870,8 @@ func TestCapacityRecoversAfterReap(t *testing.T) {
 	key, err := crypto.GenerateKey()
 	require.NoError(t, err)
 
-	const cap = 2
-	rl := New(newDeterministicEncoder(100, 100), cap, nil)
+	const capacity = 2
+	rl := New(newDeterministicEncoder(100, 100), capacity, nil)
 
 	require.NoError(t, rl.PushEVMTx(testEVMTx(t, key, 0, 21000)))
 	require.NoError(t, rl.PushEVMTx(testEVMTx(t, key, 1, 21000)))
@@ -889,8 +889,8 @@ func TestCapacityFreesOnDrop(t *testing.T) {
 	key, err := crypto.GenerateKey()
 	require.NoError(t, err)
 
-	const cap = 2
-	rl := New(newDeterministicEncoder(100, 100), cap, nil)
+	const capacity = 2
+	rl := New(newDeterministicEncoder(100, 100), capacity, nil)
 
 	tx0 := testEVMTx(t, key, 0, 21000)
 	tx1 := testEVMTx(t, key, 1, 21000)
@@ -911,8 +911,8 @@ func TestCapacityWithMixedEVMAndCosmos(t *testing.T) {
 	key, err := crypto.GenerateKey()
 	require.NoError(t, err)
 
-	const cap = 4
-	rl := New(newDeterministicEncoder(100, 100), cap, nil)
+	const capacity = 4
+	rl := New(newDeterministicEncoder(100, 100), capacity, nil)
 
 	require.NoError(t, rl.PushEVMTx(testEVMTx(t, key, 0, 21000)))
 	require.NoError(t, rl.PushCosmosTx(newMockCosmosTx(0, 21000)))
@@ -929,21 +929,21 @@ func TestUnboundedWhenCosmosUnbounded(t *testing.T) {
 
 	rl := New(newDeterministicEncoder(100, 100), Unbounded, nil)
 
-	// Push many txs; no cap should ever fire.
+	// Push many txs; no capacity should ever fire.
 	for i := uint64(0); i < 200; i++ {
 		require.NoError(t, rl.PushEVMTx(testEVMTx(t, key, i, 21000)))
 	}
 }
 
 func TestConcurrentPushAtCapacity(t *testing.T) {
-	const cap = 50
+	const capacity = 50
 	const workers = 16
 	const perWorker = 20
 
 	key, err := crypto.GenerateKey()
 	require.NoError(t, err)
 
-	rl := New(newDeterministicEncoder(100, 100), cap, nil)
+	rl := New(newDeterministicEncoder(100, 100), capacity, nil)
 
 	var (
 		wg       sync.WaitGroup
@@ -957,7 +957,7 @@ func TestConcurrentPushAtCapacity(t *testing.T) {
 			defer wg.Done()
 			<-start
 			for i := 0; i < perWorker; i++ {
-				nonce := uint64(workerID*perWorker + i)
+				nonce := uint64(workerID*perWorker + i) //nolint:gosec // bounded by perWorker*workers, safe for test
 				if err := rl.PushEVMTx(testEVMTx(t, key, nonce, 21000)); err == nil {
 					mu.Lock()
 					accepted++
@@ -972,10 +972,10 @@ func TestConcurrentPushAtCapacity(t *testing.T) {
 	wg.Wait()
 
 	// Cap must never be exceeded under contention.
-	require.LessOrEqual(t, accepted, int64(cap), "accepted txs must not exceed cap")
-	// And subsequent reap should return at most cap txs.
+	require.LessOrEqual(t, accepted, int64(capacity), "accepted txs must not exceed capacity")
+	// And subsequent reap should return at most capacity txs.
 	result := rl.Reap(0, 0)
-	require.LessOrEqual(t, len(result), cap)
+	require.LessOrEqual(t, len(result), capacity)
 }
 
 // -----------------------------------------------------------------------------

--- a/mempool/internal/reaplist/reaplist_test.go
+++ b/mempool/internal/reaplist/reaplist_test.go
@@ -885,7 +885,7 @@ func TestCapacityRecoversAfterReap(t *testing.T) {
 	require.NoError(t, rl.PushEVMTx(testEVMTx(t, key, 3, 21000)))
 }
 
-func TestCapacityRecoversAfterDrop(t *testing.T) {
+func TestCapacityFreesOnDrop(t *testing.T) {
 	key, err := crypto.GenerateKey()
 	require.NoError(t, err)
 
@@ -897,15 +897,14 @@ func TestCapacityRecoversAfterDrop(t *testing.T) {
 	require.NoError(t, rl.PushEVMTx(tx0))
 	require.NoError(t, rl.PushEVMTx(tx1))
 
-	// Drop tombstones the slot but DOES NOT free capacity until the next
-	// Reap compacts. This matches the documented behavior: "tombstones count
-	// toward the cap".
+	// Drop frees a live slot immediately. A subsequent push must succeed
+	// even before the next Reap compacts the tombstone -- otherwise a
+	// drop+promote sequence between Reaps could strand a promoted tx.
 	rl.DropEVMTx(tx0)
-	require.ErrorIs(t, rl.PushEVMTx(testEVMTx(t, key, 2, 21000)), ErrReapListFull)
-
-	// After Reap, the tombstone is compacted away and capacity recovers.
-	_ = rl.Reap(0, 0)
 	require.NoError(t, rl.PushEVMTx(testEVMTx(t, key, 2, 21000)))
+
+	// Cap still holds: pushing past the live count fails.
+	require.ErrorIs(t, rl.PushEVMTx(testEVMTx(t, key, 3, 21000)), ErrReapListFull)
 }
 
 func TestCapacityWithMixedEVMAndCosmos(t *testing.T) {

--- a/mempool/internal/reaplist/reaplist_test.go
+++ b/mempool/internal/reaplist/reaplist_test.go
@@ -507,17 +507,13 @@ func TestFirstTransactionExceedsLimit(t *testing.T) {
 	err = rl.PushEVMTx(tx)
 	require.NoError(t, err)
 
-	// Try to reap with limit smaller than the tx (1000 bytes vs 500 byte limit).
-	// Under HOL eviction (STACK-2669) the tx is permanently oversized for any
-	// block at this limit, so it is evicted from the reap list rather than
-	// retained.
+	// Tx (1000 bytes) exceeds the 500-byte limit standalone, so it is evicted.
 	result := rl.Reap(500, 0)
-	require.Empty(t, result, "should return empty when first tx exceeds limit")
+	require.Empty(t, result)
 
-	// Even with a higher limit, the tx is gone -- it was evicted on the
-	// previous reap.
+	// Evicted tx must not reappear even when the limit grows.
 	result = rl.Reap(2000, 0)
-	require.Empty(t, result, "evicted tx must not reappear in subsequent reaps")
+	require.Empty(t, result)
 }
 
 // alwaysFailEncoder always returns an error for encoding
@@ -842,9 +838,7 @@ func TestConcurrentSameHashPush(t *testing.T) {
 	}
 }
 
-// -----------------------------------------------------------------------------
-// Capacity tests (STACK-2670)
-// -----------------------------------------------------------------------------
+// Capacity tests
 
 func TestPushRefusedWhenAtCapacity(t *testing.T) {
 	key, err := crypto.GenerateKey()
@@ -857,12 +851,8 @@ func TestPushRefusedWhenAtCapacity(t *testing.T) {
 		require.NoError(t, rl.PushEVMTx(testEVMTx(t, key, i, 21000)))
 	}
 
-	// Next push must be refused with ErrReapListFull.
 	overflow := testEVMTx(t, key, uint64(capacity), 21000)
-	err = rl.PushEVMTx(overflow)
-	require.ErrorIs(t, err, ErrReapListFull)
-
-	// Cosmos pushes are refused under the same capacity.
+	require.ErrorIs(t, rl.PushEVMTx(overflow), ErrReapListFull)
 	require.ErrorIs(t, rl.PushCosmosTx(newMockCosmosTx(99, 21000)), ErrReapListFull)
 }
 
@@ -877,7 +867,6 @@ func TestCapacityRecoversAfterReap(t *testing.T) {
 	require.NoError(t, rl.PushEVMTx(testEVMTx(t, key, 1, 21000)))
 	require.ErrorIs(t, rl.PushEVMTx(testEVMTx(t, key, 2, 21000)), ErrReapListFull)
 
-	// Reap clears the slots and capacity recovers.
 	result := rl.Reap(0, 0)
 	require.Len(t, result, 2)
 
@@ -897,13 +886,10 @@ func TestCapacityFreesOnDrop(t *testing.T) {
 	require.NoError(t, rl.PushEVMTx(tx0))
 	require.NoError(t, rl.PushEVMTx(tx1))
 
-	// Drop frees a live slot immediately. A subsequent push must succeed
-	// even before the next Reap compacts the tombstone -- otherwise a
-	// drop+promote sequence between Reaps could strand a promoted tx.
+	// Drop frees a live slot before the next Reap compacts the tombstone.
 	rl.DropEVMTx(tx0)
 	require.NoError(t, rl.PushEVMTx(testEVMTx(t, key, 2, 21000)))
 
-	// Cap still holds: pushing past the live count fails.
 	require.ErrorIs(t, rl.PushEVMTx(testEVMTx(t, key, 3, 21000)), ErrReapListFull)
 }
 
@@ -929,7 +915,6 @@ func TestUnboundedWhenCosmosUnbounded(t *testing.T) {
 
 	rl := New(newDeterministicEncoder(100, 100), Unbounded, nil)
 
-	// Push many txs; no capacity should ever fire.
 	for i := uint64(0); i < 200; i++ {
 		require.NoError(t, rl.PushEVMTx(testEVMTx(t, key, i, 21000)))
 	}
@@ -971,37 +956,29 @@ func TestConcurrentPushAtCapacity(t *testing.T) {
 	close(start)
 	wg.Wait()
 
-	// Cap must never be exceeded under contention.
-	require.LessOrEqual(t, accepted, int64(capacity), "accepted txs must not exceed capacity")
-	// And subsequent reap should return at most capacity txs.
+	require.LessOrEqual(t, accepted, int64(capacity))
 	result := rl.Reap(0, 0)
 	require.LessOrEqual(t, len(result), capacity)
 }
 
-// -----------------------------------------------------------------------------
-// Head-of-line eviction tests (STACK-2669)
-// -----------------------------------------------------------------------------
+// Head-of-line eviction tests
 
 func TestOversizedHeadEvicted_Bytes(t *testing.T) {
 	key, err := crypto.GenerateKey()
 	require.NoError(t, err)
 
-	// 1000 byte EVM txs; the first one is permanently too large for a 500
-	// byte block.
+	// 1000 byte txs vs a 500 byte block: both are oversized.
 	rl := New(newDeterministicEncoder(1000, 1000), Unbounded, nil)
 
 	require.NoError(t, rl.PushEVMTx(testEVMTx(t, key, 0, 21000)))
 	require.NoError(t, rl.PushEVMTx(testEVMTx(t, key, 1, 21000)))
 
-	// Reap with a byte limit smaller than a single tx -- both are oversized
-	// and both should be evicted.
 	result := rl.Reap(500, 0)
 	require.Empty(t, result)
 
-	// Subsequent reap must not see the evicted txs even when the limit
-	// would have accommodated them.
+	// Evicted txs must not reappear under a larger limit.
 	result = rl.Reap(0, 0)
-	require.Empty(t, result, "evicted oversized txs must not reappear")
+	require.Empty(t, result)
 }
 
 func TestOversizedHeadEvicted_Gas(t *testing.T) {
@@ -1010,16 +987,14 @@ func TestOversizedHeadEvicted_Gas(t *testing.T) {
 
 	rl := New(newDeterministicEncoder(100, 100), Unbounded, nil)
 
-	// First tx is 1_000_000 gas; second is 21_000.
+	// Head tx exceeds the 100k gas budget standalone; second tx fits.
 	require.NoError(t, rl.PushEVMTx(testEVMTx(t, key, 0, 1_000_000)))
 	require.NoError(t, rl.PushEVMTx(testEVMTx(t, key, 1, 21_000)))
 
-	// Reap with a 100k gas budget. The head tx alone exceeds the budget and
-	// must be evicted; the second tx must still be reapable.
 	result := rl.Reap(0, 100_000)
-	require.Len(t, result, 1, "second tx should be reaped after head eviction")
+	require.Len(t, result, 1)
 
-	// The evicted tx is gone permanently.
+	// Evicted tx must not reappear.
 	result = rl.Reap(0, 10_000_000)
 	require.Empty(t, result)
 }
@@ -1030,14 +1005,13 @@ func TestOversizedMiddleEvicted(t *testing.T) {
 
 	rl := New(newDeterministicEncoder(100, 100), Unbounded, nil)
 
-	// Three txs with the middle one having huge gas.
+	// tx1 is oversized; tx0 and tx2 fit.
 	require.NoError(t, rl.PushEVMTx(testEVMTx(t, key, 0, 21_000)))
 	require.NoError(t, rl.PushEVMTx(testEVMTx(t, key, 1, 5_000_000)))
 	require.NoError(t, rl.PushEVMTx(testEVMTx(t, key, 2, 21_000)))
 
-	// Reap with 100k gas: tx0 fits, tx1 is oversized (evicted), tx2 fits.
 	result := rl.Reap(0, 100_000)
-	require.Len(t, result, 2, "tx0 and tx2 should be reaped, oversized tx1 evicted")
+	require.Len(t, result, 2)
 }
 
 func TestMultipleConsecutiveOversized(t *testing.T) {
@@ -1046,16 +1020,15 @@ func TestMultipleConsecutiveOversized(t *testing.T) {
 
 	rl := New(newDeterministicEncoder(100, 100), Unbounded, nil)
 
-	// Three consecutive oversized-by-gas txs followed by one fitting tx.
+	// Three oversized txs followed by one fitting tx.
 	require.NoError(t, rl.PushEVMTx(testEVMTx(t, key, 0, 5_000_000)))
 	require.NoError(t, rl.PushEVMTx(testEVMTx(t, key, 1, 5_000_000)))
 	require.NoError(t, rl.PushEVMTx(testEVMTx(t, key, 2, 5_000_000)))
 	require.NoError(t, rl.PushEVMTx(testEVMTx(t, key, 3, 21_000)))
 
 	result := rl.Reap(0, 100_000)
-	require.Len(t, result, 1, "all three oversized evicted, last tx reaped")
+	require.Len(t, result, 1)
 
-	// Subsequent reap is empty: all oversized are gone, the last was reaped.
 	result = rl.Reap(0, 10_000_000)
 	require.Empty(t, result)
 }
@@ -1066,19 +1039,16 @@ func TestOversizedThenBudgetExceeded(t *testing.T) {
 
 	rl := New(newDeterministicEncoder(100, 100), Unbounded, nil)
 
-	// tx0: oversized for the budget (must be evicted)
-	// tx1: fits the budget
-	// tx2: would push us over the budget (must be retained, not evicted)
+	// tx0: oversized (evicted). tx1: fits. tx2: over remaining budget (retained).
 	require.NoError(t, rl.PushEVMTx(testEVMTx(t, key, 0, 5_000_000)))
 	require.NoError(t, rl.PushEVMTx(testEVMTx(t, key, 1, 80_000)))
 	require.NoError(t, rl.PushEVMTx(testEVMTx(t, key, 2, 80_000)))
 
 	result := rl.Reap(0, 100_000)
-	require.Len(t, result, 1, "only tx1 fits in this reap")
+	require.Len(t, result, 1)
 
-	// tx2 is still in the list and reapable next time.
 	result = rl.Reap(0, 100_000)
-	require.Len(t, result, 1, "tx2 should reap on the next call")
+	require.Len(t, result, 1)
 }
 
 func TestOversizedDropCallbackInvoked(t *testing.T) {
@@ -1107,33 +1077,29 @@ func TestOversizedDropCallbackInvoked(t *testing.T) {
 	cosmosTx := newMockCosmosTx(0, 5_000_000)
 	require.NoError(t, rl.PushCosmosTx(cosmosTx))
 
-	// Reap with 100k gas: both are oversized, both must invoke the callback.
 	_ = rl.Reap(0, 100_000)
 
 	mu.Lock()
 	defer mu.Unlock()
 	require.Len(t, got, 2)
 
-	// Order must match insertion order (EVM, then Cosmos).
+	// Order matches insertion order.
 	require.Equal(t, KindEVM, got[0].kind)
 	require.Equal(t, evmTx.Hash().String(), got[0].hash)
-	require.False(t, got[0].hasTx, "EVM eviction should not carry sdk.Tx")
+	require.False(t, got[0].hasTx)
 
 	require.Equal(t, KindCosmos, got[1].kind)
-	require.True(t, got[1].hasTx, "Cosmos eviction must carry sdk.Tx for sub-pool removal")
+	require.True(t, got[1].hasTx)
 }
 
-// TestEvictionDropCallbackReentrant verifies that the drop callback is invoked
-// after the reap list lock is released, so callbacks can safely call back
-// into the reap list (e.g. via DropEVMTx) without deadlock.
+// TestEvictionDropCallbackReentrant ensures the callback runs outside the lock
+// so re-entering the reap list cannot deadlock.
 func TestEvictionDropCallbackReentrant(t *testing.T) {
 	key, err := crypto.GenerateKey()
 	require.NoError(t, err)
 
 	var rl *ReapList
 	cb := func(hash string, kind TxKind, _ sdk.Tx) {
-		// Re-entering the reap list from the callback must not deadlock.
-		// Using a non-existent tx so this is a no-op drop.
 		fakeTx := testEVMTx(t, key, 999, 21000)
 		rl.DropEVMTx(fakeTx)
 	}
@@ -1149,6 +1115,6 @@ func TestEvictionDropCallbackReentrant(t *testing.T) {
 	select {
 	case <-done:
 	case <-time.After(2 * time.Second):
-		t.Fatal("reap did not complete - drop callback likely caused a deadlock")
+		t.Fatal("reap deadlocked")
 	}
 }

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -170,17 +170,11 @@ func NewMempool(
 		legacyConfig = *config.LegacyPoolConfig
 	}
 
-	// Reap list capacity is sized so it can hold every tx that could legally
-	// live in the two sub-pools simultaneously: the cosmos pool (resolved cap)
-	// plus the legacypool's pending+queued slots.
+	// Sized to hold every tx that could legally live in both sub-pools at once.
 	reapListCap := resolveReapListCap(cosmosPoolMaxTx, legacyConfig.GlobalSlots, legacyConfig.GlobalQueue)
 
-	// reapDropCallback is wired after both sub-pools are constructed. It is
-	// invoked when the reap list evicts a permanently-oversized tx so the
-	// owning sub-pool can also drop it. The closure reads the pool refs via
-	// pointers that are populated below once those pools exist; the reap list
-	// only invokes the callback during Reap, which can only happen after
-	// NewMempool returns.
+	// Pool refs are populated below; the callback only fires from Reap, which
+	// can't run before NewMempool returns.
 	var (
 		legacyPoolRef     *legacypool.LegacyPool
 		recheckCosmosPool *RecheckMempool
@@ -718,16 +712,9 @@ func convertRemovalReason(caller sdkmempool.RemovalCaller) txpool.RemovalReason 
 	}
 }
 
-// resolveReapListCap computes the reap list capacity from the cosmos pool's
-// configured cap and the legacypool's pending+queued slots. Sub-pools
-// individually enforce their own caps; the reap list cap is the sum so a
-// legitimate full state in both pools never trips ErrReapListFull.
-//
-// Semantics for cosmosPoolMaxTx:
-//   - 0  -> resolved to sdkmempool.DefaultMaxTx (matches the SDK convention)
-//   - <= 0 after resolution -> reap list is unbounded (operator opted into an
-//     unbounded cosmos pool, no new DOS surface).
-//   - otherwise -> cosmosPoolMaxTx + GlobalSlots + GlobalQueue.
+// resolveReapListCap returns cosmosPoolMaxTx + GlobalSlots + GlobalQueue.
+// cosmosPoolMaxTx == 0 resolves to sdkmempool.DefaultMaxTx; <= 0 -> Unbounded.
+// Overflow falls back to Unbounded.
 func resolveReapListCap(cosmosPoolMaxTx int, globalSlots, globalQueue uint64) int {
 	effective := cosmosPoolMaxTx
 	if effective == 0 {
@@ -736,9 +723,6 @@ func resolveReapListCap(cosmosPoolMaxTx int, globalSlots, globalQueue uint64) in
 	if effective <= 0 {
 		return reaplist.Unbounded
 	}
-	// globalSlots and globalQueue are operator-supplied legacypool config
-	// values. Clamp to math.MaxInt to avoid overflow on 32-bit platforms or
-	// pathological configs; treat that as effectively unbounded.
 	const maxAdd = uint64(stdmath.MaxInt)
 	if globalSlots > maxAdd-uint64(effective) || globalQueue > maxAdd-uint64(effective)-globalSlots {
 		return reaplist.Unbounded

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	stdmath "math"
 	"math/big"
 	"sync"
 	"time"
@@ -735,5 +736,12 @@ func resolveReapListCap(cosmosPoolMaxTx int, globalSlots, globalQueue uint64) in
 	if effective <= 0 {
 		return reaplist.Unbounded
 	}
-	return effective + int(globalSlots) + int(globalQueue)
+	// globalSlots and globalQueue are operator-supplied legacypool config
+	// values. Clamp to math.MaxInt to avoid overflow on 32-bit platforms or
+	// pathological configs; treat that as effectively unbounded.
+	const maxAdd = uint64(stdmath.MaxInt)
+	if globalSlots > maxAdd-uint64(effective) || globalQueue > maxAdd-uint64(effective)-globalSlots {
+		return reaplist.Unbounded
+	}
+	return effective + int(globalSlots) + int(globalQueue) //nolint:gosec // bounded above
 }

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -169,7 +169,39 @@ func NewMempool(
 		legacyConfig = *config.LegacyPoolConfig
 	}
 
-	reapList := reaplist.New(NewTxEncoder(txConfig))
+	// Reap list capacity is sized so it can hold every tx that could legally
+	// live in the two sub-pools simultaneously: the cosmos pool (resolved cap)
+	// plus the legacypool's pending+queued slots.
+	reapListCap := resolveReapListCap(cosmosPoolMaxTx, legacyConfig.GlobalSlots, legacyConfig.GlobalQueue)
+
+	// reapDropCallback is wired after both sub-pools are constructed. It is
+	// invoked when the reap list evicts a permanently-oversized tx so the
+	// owning sub-pool can also drop it. The closure reads the pool refs via
+	// pointers that are populated below once those pools exist; the reap list
+	// only invokes the callback during Reap, which can only happen after
+	// NewMempool returns.
+	var (
+		legacyPoolRef     *legacypool.LegacyPool
+		recheckCosmosPool *RecheckMempool
+	)
+	reapDropCallback := func(hash string, kind reaplist.TxKind, cosmosTx sdk.Tx) {
+		switch kind {
+		case reaplist.KindEVM:
+			if legacyPoolRef == nil {
+				return
+			}
+			legacyPoolRef.RemoveTx(common.HexToHash(hash), false, true, legacypool.RemovalReasonReapEvicted)
+		case reaplist.KindCosmos:
+			if recheckCosmosPool == nil || cosmosTx == nil {
+				return
+			}
+			if err := recheckCosmosPool.Remove(cosmosTx); err != nil {
+				logger.Debug("reap list eviction: failed to remove cosmos tx from sub-pool", "hash", hash, "err", err)
+			}
+		}
+	}
+
+	reapList := reaplist.New(NewTxEncoder(txConfig), reapListCap, reapDropCallback)
 	txTracker := txtracker.NewNoop()
 	if config.EnableTxTracker {
 		txTracker = txtracker.New()
@@ -182,6 +214,7 @@ func NewMempool(
 		txTracker,
 		legacypool.WithRecheck(evmRechecker),
 	)
+	legacyPoolRef = legacyPool
 
 	reservationTracker := reserver.NewReservationTracker()
 	txPool, err := txpool.New(uint64(0), blockchain, reservationTracker, []txpool.SubPool{legacyPool})
@@ -205,6 +238,7 @@ func NewMempool(
 		reapList,
 		blockchain,
 	)
+	recheckCosmosPool = recheckPool
 
 	mempool := &Mempool{
 		vmKeeper:                 vmKeeper,
@@ -681,4 +715,25 @@ func convertRemovalReason(caller sdkmempool.RemovalCaller) txpool.RemovalReason 
 	default:
 		return txpool.RemovalReason("")
 	}
+}
+
+// resolveReapListCap computes the reap list capacity from the cosmos pool's
+// configured cap and the legacypool's pending+queued slots. Sub-pools
+// individually enforce their own caps; the reap list cap is the sum so a
+// legitimate full state in both pools never trips ErrReapListFull.
+//
+// Semantics for cosmosPoolMaxTx:
+//   - 0  -> resolved to sdkmempool.DefaultMaxTx (matches the SDK convention)
+//   - <= 0 after resolution -> reap list is unbounded (operator opted into an
+//     unbounded cosmos pool, no new DOS surface).
+//   - otherwise -> cosmosPoolMaxTx + GlobalSlots + GlobalQueue.
+func resolveReapListCap(cosmosPoolMaxTx int, globalSlots, globalQueue uint64) int {
+	effective := cosmosPoolMaxTx
+	if effective == 0 {
+		effective = sdkmempool.DefaultMaxTx
+	}
+	if effective <= 0 {
+		return reaplist.Unbounded
+	}
+	return effective + int(globalSlots) + int(globalQueue)
 }

--- a/mempool/mempool_internal_test.go
+++ b/mempool/mempool_internal_test.go
@@ -10,14 +10,8 @@ import (
 	sdkmempool "github.com/cosmos/cosmos-sdk/types/mempool"
 )
 
-// TestResolveReapListCap verifies the wiring math for the reap list cap.
-// Workstream A (STACK-2670): the cap must be the sum of the cosmos pool's
-// resolved cap and the legacypool's pending+queued slots, with the special
-// cases that an unbounded cosmos pool yields an unbounded reap list and a
-// configured-to-zero cosmos pool resolves to the SDK's DefaultMaxTx first.
 func TestResolveReapListCap(t *testing.T) {
-	// Snapshot the SDK default so the test does not depend on its current
-	// numeric value (it has flipped between -1 and 0 across SDK versions).
+	// Snapshot the SDK default; it has flipped between -1 and 0 across versions.
 	sdkDefault := sdkmempool.DefaultMaxTx
 
 	tests := []struct {

--- a/mempool/mempool_internal_test.go
+++ b/mempool/mempool_internal_test.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	sdkmempool "github.com/cosmos/cosmos-sdk/types/mempool"
-
 	"github.com/cosmos/evm/mempool/internal/reaplist"
+
+	sdkmempool "github.com/cosmos/cosmos-sdk/types/mempool"
 )
 
 // TestResolveReapListCap verifies the wiring math for the reap list cap.

--- a/mempool/mempool_internal_test.go
+++ b/mempool/mempool_internal_test.go
@@ -1,0 +1,78 @@
+package mempool
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	sdkmempool "github.com/cosmos/cosmos-sdk/types/mempool"
+
+	"github.com/cosmos/evm/mempool/internal/reaplist"
+)
+
+// TestResolveReapListCap verifies the wiring math for the reap list cap.
+// Workstream A (STACK-2670): the cap must be the sum of the cosmos pool's
+// resolved cap and the legacypool's pending+queued slots, with the special
+// cases that an unbounded cosmos pool yields an unbounded reap list and a
+// configured-to-zero cosmos pool resolves to the SDK's DefaultMaxTx first.
+func TestResolveReapListCap(t *testing.T) {
+	// Snapshot the SDK default so the test does not depend on its current
+	// numeric value (it has flipped between -1 and 0 across SDK versions).
+	sdkDefault := sdkmempool.DefaultMaxTx
+
+	tests := []struct {
+		name        string
+		cosmosMaxTx int
+		globalSlots uint64
+		globalQueue uint64
+		expectedCap int
+		expectUnbnd bool
+	}{
+		{
+			name:        "unbounded cosmos pool -> unbounded reap list",
+			cosmosMaxTx: -1,
+			globalSlots: 4096,
+			globalQueue: 1024,
+			expectUnbnd: true,
+		},
+		{
+			name:        "zero cosmos pool resolves to sdk default",
+			cosmosMaxTx: 0,
+			globalSlots: 4096,
+			globalQueue: 1024,
+			// behavior depends on whether sdkDefault is -1 (unbounded) or > 0.
+			expectedCap: func() int {
+				if sdkDefault <= 0 {
+					return 0 // unbounded sentinel
+				}
+				return sdkDefault + 4096 + 1024
+			}(),
+			expectUnbnd: sdkDefault <= 0,
+		},
+		{
+			name:        "bounded cosmos pool -> sum of all three",
+			cosmosMaxTx: 1000,
+			globalSlots: 4096,
+			globalQueue: 1024,
+			expectedCap: 1000 + 4096 + 1024,
+		},
+		{
+			name:        "single slot pool",
+			cosmosMaxTx: 1,
+			globalSlots: 1,
+			globalQueue: 1,
+			expectedCap: 3,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := resolveReapListCap(tc.cosmosMaxTx, tc.globalSlots, tc.globalQueue)
+			if tc.expectUnbnd {
+				require.Equal(t, reaplist.Unbounded, got)
+				return
+			}
+			require.Equal(t, tc.expectedCap, got)
+		})
+	}
+}

--- a/mempool/mempool_test.go
+++ b/mempool/mempool_test.go
@@ -607,6 +607,54 @@ func TestMempool_InsertMultiMsgEthereumTx(t *testing.T) {
 	require.Len(t, txs, 0, "expected no txs to be reaped")
 }
 
+// TestMempool_ReapList_OversizedEvicted asserts the wiring between the reap
+// list and the legacypool: when a tx is evicted by the reap list during Reap
+// (because it is permanently oversized for any block under the supplied
+// limits), the drop callback configured by NewMempool must also remove it
+// from the legacypool. This is the wiring proof for STACK-2669 and the cap
+// plumbing for STACK-2670 (drop callback signature is exercised by the
+// eviction path).
+func TestMempool_ReapList_OversizedEvicted(t *testing.T) {
+	mp, s := setupMempoolWithAccounts(t, 1)
+	txConfig, bus, accounts := s.txConfig, s.eventBus, s.accounts
+
+	require.NoError(t, bus.PublishEventNewBlockHeader(cmttypes.EventDataNewBlockHeader{
+		Header: cmttypes.Header{
+			Height:  1,
+			Time:    time.Now(),
+			ChainID: strconv.Itoa(constants.EighteenDecimalsChainID),
+		},
+	}))
+	require.NoError(t, mp.GetTxPool().Sync())
+
+	// Insert a tx with the standard test gas limit (txGasLimit = 50000).
+	tx := createMsgEthereumTx(t, txConfig, accounts[0].key, 0, big.NewInt(1e8))
+	require.NoError(t, mp.Insert(sdk.Context{}.WithContext(context.Background()), tx))
+	require.NoError(t, mp.GetTxPool().Sync())
+	require.Equal(t, 1, mp.CountTx())
+
+	legacyPool := mp.GetTxPool().Subpools[0].(*legacypool.LegacyPool)
+	pending, _ := legacyPool.ContentFrom(accounts[0].address)
+	require.Len(t, pending, 1, "tx should be in legacypool pending")
+
+	// Reap with a gas budget tighter than tx gas (50000). The tx is
+	// permanently oversized for this budget and the reap list must evict it
+	// AND, via the wired drop callback, instruct the legacypool to remove
+	// it.
+	reaped, err := mp.ReapNewValidTxs(0, 10_000)
+	require.NoError(t, err)
+	require.Empty(t, reaped, "oversized tx must not be returned by reap")
+
+	// Drain async work; the legacypool RemoveTx is invoked synchronously
+	// from within Reap (after the reap list lock is released), so by the
+	// time Reap returns the legacypool already reflects the eviction.
+	require.NoError(t, mp.GetTxPool().Sync())
+
+	pending, queued := legacyPool.ContentFrom(accounts[0].address)
+	require.Empty(t, pending, "legacypool pending must drop evicted tx")
+	require.Empty(t, queued, "legacypool queued must drop evicted tx")
+}
+
 // Helper types and functions
 
 const (

--- a/mempool/mempool_test.go
+++ b/mempool/mempool_test.go
@@ -607,13 +607,9 @@ func TestMempool_InsertMultiMsgEthereumTx(t *testing.T) {
 	require.Len(t, txs, 0, "expected no txs to be reaped")
 }
 
-// TestMempool_ReapList_OversizedEvicted asserts the wiring between the reap
-// list and the legacypool: when a tx is evicted by the reap list during Reap
-// (because it is permanently oversized for any block under the supplied
-// limits), the drop callback configured by NewMempool must also remove it
-// from the legacypool. This is the wiring proof for STACK-2669 and the cap
-// plumbing for STACK-2670 (drop callback signature is exercised by the
-// eviction path).
+// TestMempool_ReapList_OversizedEvicted is the end-to-end wiring proof: an
+// oversized tx evicted during Reap must also be removed from the legacypool
+// via the drop callback configured by NewMempool.
 func TestMempool_ReapList_OversizedEvicted(t *testing.T) {
 	mp, s := setupMempoolWithAccounts(t, 1)
 	txConfig, bus, accounts := s.txConfig, s.eventBus, s.accounts
@@ -627,7 +623,7 @@ func TestMempool_ReapList_OversizedEvicted(t *testing.T) {
 	}))
 	require.NoError(t, mp.GetTxPool().Sync())
 
-	// Insert a tx with the standard test gas limit (txGasLimit = 50000).
+	// Insert with the standard test gas limit (txGasLimit = 50000).
 	tx := createMsgEthereumTx(t, txConfig, accounts[0].key, 0, big.NewInt(1e8))
 	require.NoError(t, mp.Insert(sdk.Context{}.WithContext(context.Background()), tx))
 	require.NoError(t, mp.GetTxPool().Sync())
@@ -635,24 +631,18 @@ func TestMempool_ReapList_OversizedEvicted(t *testing.T) {
 
 	legacyPool := mp.GetTxPool().Subpools[0].(*legacypool.LegacyPool)
 	pending, _ := legacyPool.ContentFrom(accounts[0].address)
-	require.Len(t, pending, 1, "tx should be in legacypool pending")
+	require.Len(t, pending, 1)
 
-	// Reap with a gas budget tighter than tx gas (50000). The tx is
-	// permanently oversized for this budget and the reap list must evict it
-	// AND, via the wired drop callback, instruct the legacypool to remove
-	// it.
+	// Reap with a gas budget tighter than the tx gas (50000); the tx is oversized.
 	reaped, err := mp.ReapNewValidTxs(0, 10_000)
 	require.NoError(t, err)
-	require.Empty(t, reaped, "oversized tx must not be returned by reap")
+	require.Empty(t, reaped)
 
-	// Drain async work; the legacypool RemoveTx is invoked synchronously
-	// from within Reap (after the reap list lock is released), so by the
-	// time Reap returns the legacypool already reflects the eviction.
 	require.NoError(t, mp.GetTxPool().Sync())
 
 	pending, queued := legacyPool.ContentFrom(accounts[0].address)
-	require.Empty(t, pending, "legacypool pending must drop evicted tx")
-	require.Empty(t, queued, "legacypool queued must drop evicted tx")
+	require.Empty(t, pending)
+	require.Empty(t, queued)
 }
 
 // Helper types and functions

--- a/mempool/recheck_pool_test.go
+++ b/mempool/recheck_pool_test.go
@@ -114,7 +114,7 @@ func (testTxEncoder) CosmosTx(tx sdk.Tx) ([]byte, error) {
 }
 
 func newTestReapList() *reaplist.ReapList {
-	return reaplist.New(testTxEncoder{})
+	return reaplist.New(testTxEncoder{}, reaplist.Unbounded, nil)
 }
 
 // testHeader creates a minimal header for testing with the given height.

--- a/mempool/txpool/legacypool/legacypool.go
+++ b/mempool/txpool/legacypool/legacypool.go
@@ -106,6 +106,7 @@ const (
 	RemovalReasonRunTxRecheck           txpool.RemovalReason = "runtx_recheck"
 	RemovalReasonRunTxFinalize          txpool.RemovalReason = "runtx_finalize"
 	RemovalReasonPrepareProposalInvalid txpool.RemovalReason = "prepare_proposal_invalid"
+	RemovalReasonReapEvicted            txpool.RemovalReason = "reap_evicted" // Tx was evicted from the reap list (permanently oversized for any block)
 )
 
 var (
@@ -139,13 +140,13 @@ var (
 	// Metrics for the pending pool
 	pendingDiscardMeter         metric.Int64Counter
 	pendingReplaceMeter         metric.Int64Counter
-	pendingRateLimitMeter       metric.Int64Counter       // Dropped due to rate limiting
-	pendingRecheckDropMeter     metric.Int64Counter       // Dropped due to recheck failing
-	pendingRecheckDurationTimer metric.Float64Histogram   // How long rechecking txs in the pending pool takes (demoteUnexecutables)
-	pendingTruncateTimer        metric.Float64Histogram   // How long truncating the pending pool takes
-	pendingDemotedRecheck       metric.Int64Counter       // Demoted due to parent tx failing recheck
-	pendingDemotedRemoved       metric.Int64Counter       // Demoted due to parent tx being explicitly removed
-	pendingDemotedCancelled     metric.Int64Counter       // Demote loop cancelled due to a new block arriving
+	pendingRateLimitMeter       metric.Int64Counter     // Dropped due to rate limiting
+	pendingRecheckDropMeter     metric.Int64Counter     // Dropped due to recheck failing
+	pendingRecheckDurationTimer metric.Float64Histogram // How long rechecking txs in the pending pool takes (demoteUnexecutables)
+	pendingTruncateTimer        metric.Float64Histogram // How long truncating the pending pool takes
+	pendingDemotedRecheck       metric.Int64Counter     // Demoted due to parent tx failing recheck
+	pendingDemotedRemoved       metric.Int64Counter     // Demoted due to parent tx being explicitly removed
+	pendingDemotedCancelled     metric.Int64Counter     // Demote loop cancelled due to a new block arriving
 
 	// Metrics for queued promotions
 	queuedPromotedCancelled metric.Int64Counter // Promote loop cancelled due to a new block arriving
@@ -668,7 +669,7 @@ func (pool *LegacyPool) loop() {
 					for _, tx := range list {
 						pool.removeTx(tx.Hash(), true, true, RemovalReasonLifetime)
 					}
-					queuedEvictionMeter.Add(context.Background(),int64(len(list)))
+					queuedEvictionMeter.Add(context.Background(), int64(len(list)))
 				}
 			}
 			pool.mu.Unlock()
@@ -989,14 +990,14 @@ func (pool *LegacyPool) add(tx *types.Transaction) (replaced bool, err error) {
 	hash := tx.Hash()
 	if pool.all.Get(hash) != nil {
 		log.Trace("Discarding already known transaction", "hash", hash)
-		knownTxMeter.Add(context.Background(),1)
+		knownTxMeter.Add(context.Background(), 1)
 		return false, txpool.ErrAlreadyKnown
 	}
 
 	// If the transaction fails basic validation, discard it
 	if err := pool.validateTx(tx); err != nil {
 		log.Trace("Discarding invalid transaction", "hash", hash, "err", err)
-		invalidTxMeter.Add(context.Background(),1)
+		invalidTxMeter.Add(context.Background(), 1)
 		return false, err
 	}
 	// already validated by this point
@@ -1029,7 +1030,7 @@ func (pool *LegacyPool) add(tx *types.Transaction) (replaced bool, err error) {
 		// If the new transaction is underpriced, don't accept it
 		if pool.priced.Underpriced(tx) {
 			log.Trace("Discarding underpriced transaction", "hash", hash, "gasTipCap", tx.GasTipCap(), "gasFeeCap", tx.GasFeeCap())
-			underpricedTxMeter.Add(context.Background(),1)
+			underpricedTxMeter.Add(context.Background(), 1)
 			return false, txpool.ErrUnderpriced
 		}
 
@@ -1038,7 +1039,7 @@ func (pool *LegacyPool) add(tx *types.Transaction) (replaced bool, err error) {
 		// do too many replacements between reorg-runs, so we cap the number of
 		// replacements to 25% of the slots
 		if pool.changesSinceReorg > int(pool.config.GlobalSlots/4) {
-			throttleTxMeter.Add(context.Background(),1)
+			throttleTxMeter.Add(context.Background(), 1)
 			return false, ErrTxPoolOverflow
 		}
 
@@ -1049,7 +1050,7 @@ func (pool *LegacyPool) add(tx *types.Transaction) (replaced bool, err error) {
 		// Special case, we still can't make the room for the new remote one.
 		if !success {
 			log.Trace("Discarding overflown transaction", "hash", hash)
-			overflowedTxMeter.Add(context.Background(),1)
+			overflowedTxMeter.Add(context.Background(), 1)
 			return false, ErrTxPoolOverflow
 		}
 
@@ -1076,7 +1077,7 @@ func (pool *LegacyPool) add(tx *types.Transaction) (replaced bool, err error) {
 		// Kick out the underpriced remote transactions.
 		for _, tx := range drop {
 			log.Trace("Discarding freshly underpriced transaction", "hash", tx.Hash(), "gasTipCap", tx.GasTipCap(), "gasFeeCap", tx.GasFeeCap())
-			underpricedTxMeter.Add(context.Background(),1)
+			underpricedTxMeter.Add(context.Background(), 1)
 
 			sender, _ := types.Sender(pool.signer, tx)
 			dropped := pool.removeTx(tx.Hash(), false, sender != from, RemovalReasonUnderpricedFull) // Don't unreserve the sender of the tx being added if last from the acc
@@ -1090,7 +1091,7 @@ func (pool *LegacyPool) add(tx *types.Transaction) (replaced bool, err error) {
 		// Nonce already pending, check if required price bump is met
 		inserted, old := list.Add(tx, pool.config.PriceBump)
 		if !inserted {
-			pendingDiscardMeter.Add(context.Background(),1)
+			pendingDiscardMeter.Add(context.Background(), 1)
 			return false, txpool.ErrReplaceUnderpriced
 		}
 		// New transaction is better, replace old one
@@ -1098,7 +1099,7 @@ func (pool *LegacyPool) add(tx *types.Transaction) (replaced bool, err error) {
 			pool.all.Remove(old.Hash())
 			pool.priced.Removed(1)
 			pool.markTxRemoved(from, old, Pending)
-			pendingReplaceMeter.Add(context.Background(),1)
+			pendingReplaceMeter.Add(context.Background(), 1)
 		}
 		pool.all.Add(tx)
 		pool.priced.Put(tx)
@@ -1159,18 +1160,18 @@ func (pool *LegacyPool) enqueueTx(hash common.Hash, tx *types.Transaction, addAl
 	inserted, old := pool.queue[from].Add(tx, pool.config.PriceBump)
 	if !inserted {
 		// An older transaction was better, discard this
-		queuedDiscardMeter.Add(context.Background(),1)
+		queuedDiscardMeter.Add(context.Background(), 1)
 		return false, txpool.ErrReplaceUnderpriced
 	}
 	// Discard any previous transaction and mark this
 	if old != nil {
 		pool.all.Remove(old.Hash())
 		pool.priced.Removed(1)
-		queuedReplaceMeter.Add(context.Background(),1)
+		queuedReplaceMeter.Add(context.Background(), 1)
 		pool.markTxRemoved(from, old, Queue)
 	} else {
 		// Nothing was replaced, bump the queued counter
-		queuedGauge.Add(context.Background(),1)
+		queuedGauge.Add(context.Background(), 1)
 	}
 	// If the transaction isn't in lookup set but it's expected to be there,
 	// show the error log.
@@ -1206,7 +1207,7 @@ func (pool *LegacyPool) promoteTx(addr common.Address, hash common.Hash, tx *typ
 		pool.all.Remove(hash)
 		pool.priced.Removed(1)
 		pool.markTxRemoved(addr, tx, Queue)
-		pendingDiscardMeter.Add(context.Background(),1)
+		pendingDiscardMeter.Add(context.Background(), 1)
 		return false
 	}
 	// Otherwise discard any previous transaction and mark this
@@ -1216,10 +1217,10 @@ func (pool *LegacyPool) promoteTx(addr common.Address, hash common.Hash, tx *typ
 		pool.all.Remove(old.Hash())
 		pool.priced.Removed(1)
 		pool.markTxRemoved(addr, old, Pending)
-		pendingReplaceMeter.Add(context.Background(),1)
+		pendingReplaceMeter.Add(context.Background(), 1)
 	} else {
 		// Nothing was replaced, bump the pending counter
-		pendingGauge.Add(context.Background(),1)
+		pendingGauge.Add(context.Background(), 1)
 	}
 	// Set the potentially new pending nonce and notify any subsystems of the new tx
 	pool.pendingNonces.set(addr, tx.Nonce()+1)
@@ -1269,7 +1270,7 @@ func (pool *LegacyPool) Add(txs []*types.Transaction, sync bool) []error {
 		// If the transaction is known, pre-set the error slot
 		if pool.all.Get(tx.Hash()) != nil {
 			errs[i] = txpool.ErrAlreadyKnown
-			knownTxMeter.Add(context.Background(),1)
+			knownTxMeter.Add(context.Background(), 1)
 			continue
 		}
 		// Exclude transactions with basic errors, e.g invalid signatures and
@@ -1278,7 +1279,7 @@ func (pool *LegacyPool) Add(txs []*types.Transaction, sync bool) []error {
 		if err := pool.ValidateTxBasics(tx); err != nil {
 			errs[i] = err
 			log.Trace("Discarding invalid transaction", "hash", tx.Hash(), "err", err)
-			invalidTxMeter.Add(context.Background(),1)
+			invalidTxMeter.Add(context.Background(), 1)
 			continue
 		}
 		// Accumulate all unknown transactions for deeper processing
@@ -1321,7 +1322,7 @@ func (pool *LegacyPool) addTxsLocked(txs []*types.Transaction) ([]error, *accoun
 			dirty.addTx(tx)
 		}
 	}
-	validTxMeter.Add(context.Background(),int64(len(dirty.accounts)))
+	validTxMeter.Add(context.Background(), int64(len(dirty.accounts)))
 	return errs, dirty
 }
 
@@ -1455,7 +1456,7 @@ func (pool *LegacyPool) removeTx(hash common.Hash, outofbound bool, unreserve bo
 	if pending := pool.pending[addr]; pending != nil {
 		if removed, invalids := pending.Remove(tx); removed {
 			pool.markTxRemoved(addr, tx, Pending)
-			pendingRemovalMetric(reason).Add(context.Background(),1)
+			pendingRemovalMetric(reason).Add(context.Background(), 1)
 
 			// If no more pending transactions are left, remove the list
 			if pending.Empty() {
@@ -1470,7 +1471,7 @@ func (pool *LegacyPool) removeTx(hash common.Hash, outofbound bool, unreserve bo
 			pool.pendingNonces.setIfLower(addr, tx.Nonce())
 			// Reduce the pending counter
 			pendingGauge.Add(context.Background(), -int64(1+len(invalids)))
-			pendingDemotedRemoved.Add(context.Background(),int64(len(invalids)))
+			pendingDemotedRemoved.Add(context.Background(), int64(len(invalids)))
 			return 1 + len(invalids)
 		}
 	}
@@ -1478,7 +1479,7 @@ func (pool *LegacyPool) removeTx(hash common.Hash, outofbound bool, unreserve bo
 	if future := pool.queue[addr]; future != nil {
 		if removed, _ := future.Remove(tx); removed {
 			pool.markTxRemoved(addr, tx, Queue)
-			queueRemovalMetric(reason).Add(context.Background(),1)
+			queueRemovalMetric(reason).Add(context.Background(), 1)
 
 			// Reduce the queued counter
 			queuedGauge.Add(context.Background(), -1)
@@ -1839,7 +1840,7 @@ func (pool *LegacyPool) promoteExecutables(accounts []common.Address, cancelled 
 	// Iterate over all accounts and promote any executable transactions
 	for _, addr := range accounts {
 		if isReorgCancelled(reset, cancelled) {
-			queuedPromotedCancelled.Add(context.Background(),1)
+			queuedPromotedCancelled.Add(context.Background(), 1)
 			return promoted
 		}
 		list := pool.queue[addr]
@@ -1853,7 +1854,7 @@ func (pool *LegacyPool) promoteExecutables(accounts []common.Address, cancelled 
 		var olds types.Transactions
 		if reset != nil {
 			olds = pool.removeOlds(addr, list, Queue)
-			queuedRemovedOld.Add(context.Background(),int64(len(olds)))
+			queuedRemovedOld.Add(context.Background(), int64(len(olds)))
 		}
 
 		// Drop all transactions that now fail the pools RecheckTxFn
@@ -1879,13 +1880,13 @@ func (pool *LegacyPool) promoteExecutables(accounts []common.Address, cancelled 
 			pool.markTxRemoved(addr, tx, Queue)
 		}
 		log.Trace("Removed queued transactions that failed recheck", "count", len(recheckDrops))
-		queuedRecheckDropMeter.Add(context.Background(),int64(len(recheckDrops)))
+		queuedRecheckDropMeter.Add(context.Background(), int64(len(recheckDrops)))
 		queuedRecheckDurationTimer.Record(context.Background(), float64(time.Since(recheckStart).Milliseconds()))
 
 		// Gather all executable transactions and promote them
 		listLen := list.Len()
 		readies := list.Ready(pool.pendingNonces.get(addr))
-		queuedNonReadies.Add(context.Background(),int64(listLen - len(readies)))
+		queuedNonReadies.Add(context.Background(), int64(listLen-len(readies)))
 		for _, tx := range readies {
 			hash := tx.Hash()
 			if pool.promoteTx(addr, hash, tx) {
@@ -1901,10 +1902,10 @@ func (pool *LegacyPool) promoteExecutables(accounts []common.Address, cancelled 
 			hash := tx.Hash()
 			pool.all.Remove(hash)
 			pool.markTxRemoved(addr, tx, Queue)
-			queueRemovalMetric(RemovalReasonCapExceeded).Add(context.Background(),1)
+			queueRemovalMetric(RemovalReasonCapExceeded).Add(context.Background(), 1)
 			log.Trace("Removed cap-exceeding queued transaction", "hash", hash)
 		}
-		queuedRateLimitMeter.Add(context.Background(),int64(len(caps)))
+		queuedRateLimitMeter.Add(context.Background(), int64(len(caps)))
 
 		// Mark all the items dropped as removed
 		totalDropped := len(recheckDrops) + len(caps) + len(olds)
@@ -1970,7 +1971,7 @@ func (pool *LegacyPool) truncatePending() {
 						hash := tx.Hash()
 						pool.all.Remove(hash)
 						pool.markTxRemoved(offenders[i], tx, Pending)
-						pendingRemovalMetric(RemovalReasonCapExceeded).Add(context.Background(),1)
+						pendingRemovalMetric(RemovalReasonCapExceeded).Add(context.Background(), 1)
 
 						// Update the account nonce to the dropped transaction
 						pool.pendingNonces.setIfLower(offenders[i], tx.Nonce())
@@ -1997,7 +1998,7 @@ func (pool *LegacyPool) truncatePending() {
 					hash := tx.Hash()
 					pool.all.Remove(hash)
 					pool.markTxRemoved(addr, tx, Pending)
-					pendingRemovalMetric(RemovalReasonCapExceeded).Add(context.Background(),1)
+					pendingRemovalMetric(RemovalReasonCapExceeded).Add(context.Background(), 1)
 
 					// Update the account nonce to the dropped transaction
 					pool.pendingNonces.setIfLower(addr, tx.Nonce())
@@ -2009,7 +2010,7 @@ func (pool *LegacyPool) truncatePending() {
 			}
 		}
 	}
-	pendingRateLimitMeter.Add(context.Background(),int64(pendingBeforeCap - pending))
+	pendingRateLimitMeter.Add(context.Background(), int64(pendingBeforeCap-pending))
 }
 
 // truncateQueue drops the oldest transactions in the queue if the pool is above the global queue limit.
@@ -2042,7 +2043,7 @@ func (pool *LegacyPool) truncateQueue() {
 				pool.removeTx(tx.Hash(), true, true, RemovalReasonTruncatedOverflow)
 			}
 			drop -= size
-			queuedRateLimitMeter.Add(context.Background(),int64(size))
+			queuedRateLimitMeter.Add(context.Background(), int64(size))
 			continue
 		}
 		// Otherwise drop only last few transactions
@@ -2050,7 +2051,7 @@ func (pool *LegacyPool) truncateQueue() {
 		for i := len(txs) - 1; i >= 0 && drop > 0; i-- {
 			pool.removeTx(txs[i].Hash(), true, true, RemovalReasonTruncatedLast)
 			drop--
-			queuedRateLimitMeter.Add(context.Background(),1)
+			queuedRateLimitMeter.Add(context.Background(), 1)
 		}
 	}
 }
@@ -2070,7 +2071,7 @@ func (pool *LegacyPool) demoteUnexecutables(cancelled chan struct{}, reset *txpo
 	// Iterate over all accounts and demote any non-executable transactions
 	for addr, list := range pool.pending {
 		if isReorgCancelled(reset, cancelled) {
-			pendingDemotedCancelled.Add(context.Background(),1)
+			pendingDemotedCancelled.Add(context.Background(), 1)
 			return
 		}
 
@@ -2078,7 +2079,7 @@ func (pool *LegacyPool) demoteUnexecutables(cancelled chan struct{}, reset *txpo
 		// this account based on what we have seen during the latest block
 		// execution.
 		olds := pool.removeOlds(addr, list, Pending)
-		pendingRemovedOld.Add(context.Background(),int64(len(olds)))
+		pendingRemovedOld.Add(context.Background(), int64(len(olds)))
 
 		// Drop all transactions that now fail the pools RecheckTxFn
 		//
@@ -2105,8 +2106,8 @@ func (pool *LegacyPool) demoteUnexecutables(cancelled chan struct{}, reset *txpo
 			pool.markTxRemoved(addr, tx, Pending)
 			log.Trace("Removed pending transaction that failed recheck", "hash", hash)
 		}
-		pendingRecheckDropMeter.Add(context.Background(),int64(len(recheckDrops)))
-		pendingDemotedRecheck.Add(context.Background(),int64(len(recheckInvalids)))
+		pendingRecheckDropMeter.Add(context.Background(), int64(len(recheckDrops)))
+		pendingDemotedRecheck.Add(context.Background(), int64(len(recheckInvalids)))
 		pendingRecheckDurationTimer.Record(context.Background(), float64(time.Since(recheckStart).Milliseconds()))
 
 		invalids := recheckInvalids

--- a/mempool/txpool/legacypool/legacypool2_test.go
+++ b/mempool/txpool/legacypool/legacypool2_test.go
@@ -89,7 +89,7 @@ func TestTransactionFutureAttack(t *testing.T) {
 	config := testTxPoolConfig
 	config.GlobalQueue = 100
 	config.GlobalSlots = 100
-	pool := New(config, log.NewNopLogger(), blockchain, reaplist.New(testTxEncoder{}), txtracker.New())
+	pool := New(config, log.NewNopLogger(), blockchain, reaplist.New(testTxEncoder{}, reaplist.Unbounded, nil), txtracker.New())
 	pool.Init(config.PriceLimit, blockchain.CurrentBlock(), newReserver())
 	defer pool.Close()
 
@@ -124,7 +124,7 @@ func TestTransactionFuture1559(t *testing.T) {
 	// Create the pool to test the pricing enforcement with
 	statedb, _ := state.New(types.EmptyRootHash, state.NewDatabaseForTesting())
 	blockchain := newTestBlockChain(eip1559Config, 1000000, statedb, new(event.Feed))
-	pool := New(testTxPoolConfig, log.NewNopLogger(), blockchain, reaplist.New(testTxEncoder{}), txtracker.New())
+	pool := New(testTxPoolConfig, log.NewNopLogger(), blockchain, reaplist.New(testTxEncoder{}, reaplist.Unbounded, nil), txtracker.New())
 	pool.Init(testTxPoolConfig.PriceLimit, blockchain.CurrentBlock(), newReserver())
 	defer pool.Close()
 
@@ -157,7 +157,7 @@ func TestTransactionZAttack(t *testing.T) {
 	// Create the pool to test the pricing enforcement with
 	statedb, _ := state.New(types.EmptyRootHash, state.NewDatabaseForTesting())
 	blockchain := newTestBlockChain(eip1559Config, 1000000, statedb, new(event.Feed))
-	pool := New(testTxPoolConfig, log.NewNopLogger(), blockchain, reaplist.New(testTxEncoder{}), txtracker.New())
+	pool := New(testTxPoolConfig, log.NewNopLogger(), blockchain, reaplist.New(testTxEncoder{}, reaplist.Unbounded, nil), txtracker.New())
 	pool.Init(testTxPoolConfig.PriceLimit, blockchain.CurrentBlock(), newReserver())
 	defer pool.Close()
 	// Create a number of test accounts, fund them and make transactions
@@ -230,7 +230,7 @@ func BenchmarkFutureAttack(b *testing.B) {
 	config := testTxPoolConfig
 	config.GlobalQueue = 100
 	config.GlobalSlots = 100
-	pool := New(config, log.NewNopLogger(), blockchain, reaplist.New(testTxEncoder{}), txtracker.New())
+	pool := New(config, log.NewNopLogger(), blockchain, reaplist.New(testTxEncoder{}, reaplist.Unbounded, nil), txtracker.New())
 	pool.Init(testTxPoolConfig.PriceLimit, blockchain.CurrentBlock(), newReserver())
 	defer pool.Close()
 	fillPool(b, pool)

--- a/mempool/txpool/legacypool/legacypool_test.go
+++ b/mempool/txpool/legacypool/legacypool_test.go
@@ -261,7 +261,7 @@ func setupPoolWithConfig(config *params.ChainConfig) (*LegacyPool, *MockRechecke
 
 	key, _ := crypto.GenerateKey()
 	rechecker := &MockRechecker{}
-	pool := New(testTxPoolConfig, log.NewNopLogger(), blockchain, reaplist.New(testTxEncoder{}), txtracker.New(), WithRecheck(rechecker))
+	pool := New(testTxPoolConfig, log.NewNopLogger(), blockchain, reaplist.New(testTxEncoder{}, reaplist.Unbounded, nil), txtracker.New(), WithRecheck(rechecker))
 	if err := pool.Init(testTxPoolConfig.PriceLimit, blockchain.CurrentBlock(), newReserver()); err != nil {
 		panic(err)
 	}
@@ -520,7 +520,7 @@ func TestStateChangeDuringReset(t *testing.T) {
 	tx0 := transaction(0, 100000, key)
 	tx1 := transaction(1, 100000, key)
 
-	pool := New(testTxPoolConfig, log.NewNopLogger(), blockchain, reaplist.New(testTxEncoder{}), txtracker.New())
+	pool := New(testTxPoolConfig, log.NewNopLogger(), blockchain, reaplist.New(testTxEncoder{}, reaplist.Unbounded, nil), txtracker.New())
 	pool.Init(testTxPoolConfig.PriceLimit, blockchain.CurrentBlock(), newReserver())
 	defer pool.Close()
 
@@ -1007,7 +1007,7 @@ func TestPostponing(t *testing.T) {
 	blockchain := newTestBlockChain(params.TestChainConfig, 1000000, statedb, new(event.Feed))
 
 	rechecker := &MockRechecker{}
-	pool := New(testTxPoolConfig, log.NewNopLogger(), blockchain, reaplist.New(testTxEncoder{}), txtracker.New(), WithRecheck(rechecker))
+	pool := New(testTxPoolConfig, log.NewNopLogger(), blockchain, reaplist.New(testTxEncoder{}, reaplist.Unbounded, nil), txtracker.New(), WithRecheck(rechecker))
 	pool.Init(testTxPoolConfig.PriceLimit, blockchain.CurrentBlock(), newReserver())
 	defer pool.Close()
 
@@ -1219,7 +1219,7 @@ func TestQueueGlobalLimiting(t *testing.T) {
 	config.NoLocals = true
 	config.GlobalQueue = config.AccountQueue*3 - 1 // reduce the queue limits to shorten test time (-1 to make it non divisible)
 
-	pool := New(config, log.NewNopLogger(), blockchain, reaplist.New(testTxEncoder{}), txtracker.New())
+	pool := New(config, log.NewNopLogger(), blockchain, reaplist.New(testTxEncoder{}, reaplist.Unbounded, nil), txtracker.New())
 	pool.Init(testTxPoolConfig.PriceLimit, blockchain.CurrentBlock(), newReserver())
 	defer pool.Close()
 
@@ -1271,7 +1271,7 @@ func TestQueueTimeLimiting(t *testing.T) {
 	config := testTxPoolConfig
 	config.Lifetime = time.Second
 
-	pool := New(config, log.NewNopLogger(), blockchain, reaplist.New(testTxEncoder{}), txtracker.New())
+	pool := New(config, log.NewNopLogger(), blockchain, reaplist.New(testTxEncoder{}, reaplist.Unbounded, nil), txtracker.New())
 	pool.Init(config.PriceLimit, blockchain.CurrentBlock(), newReserver())
 	defer pool.Close()
 
@@ -1432,7 +1432,7 @@ func TestPendingGlobalLimiting(t *testing.T) {
 	config := testTxPoolConfig
 	config.GlobalSlots = config.AccountSlots * 10
 
-	pool := New(config, log.NewNopLogger(), blockchain, reaplist.New(testTxEncoder{}), txtracker.New())
+	pool := New(config, log.NewNopLogger(), blockchain, reaplist.New(testTxEncoder{}, reaplist.Unbounded, nil), txtracker.New())
 	pool.Init(config.PriceLimit, blockchain.CurrentBlock(), newReserver())
 	defer pool.Close()
 
@@ -1531,7 +1531,7 @@ func TestCapClearsFromAll(t *testing.T) {
 	config.AccountQueue = 2
 	config.GlobalSlots = 8
 
-	pool := New(config, log.NewNopLogger(), blockchain, reaplist.New(testTxEncoder{}), txtracker.New())
+	pool := New(config, log.NewNopLogger(), blockchain, reaplist.New(testTxEncoder{}, reaplist.Unbounded, nil), txtracker.New())
 	pool.Init(config.PriceLimit, blockchain.CurrentBlock(), newReserver())
 	defer pool.Close()
 
@@ -1564,7 +1564,7 @@ func TestPendingMinimumAllowance(t *testing.T) {
 	config := testTxPoolConfig
 	config.GlobalSlots = 1
 
-	pool := New(config, log.NewNopLogger(), blockchain, reaplist.New(testTxEncoder{}), txtracker.New())
+	pool := New(config, log.NewNopLogger(), blockchain, reaplist.New(testTxEncoder{}, reaplist.Unbounded, nil), txtracker.New())
 	pool.Init(config.PriceLimit, blockchain.CurrentBlock(), newReserver())
 	defer pool.Close()
 
@@ -1608,7 +1608,7 @@ func TestRepricing(t *testing.T) {
 	statedb, _ := state.New(types.EmptyRootHash, state.NewDatabaseForTesting())
 	blockchain := newTestBlockChain(params.TestChainConfig, 1000000, statedb, new(event.Feed))
 
-	pool := New(testTxPoolConfig, log.NewNopLogger(), blockchain, reaplist.New(testTxEncoder{}), txtracker.New())
+	pool := New(testTxPoolConfig, log.NewNopLogger(), blockchain, reaplist.New(testTxEncoder{}, reaplist.Unbounded, nil), txtracker.New())
 	pool.Init(testTxPoolConfig.PriceLimit, blockchain.CurrentBlock(), newReserver())
 	defer pool.Close()
 
@@ -1713,7 +1713,7 @@ func TestMinGasPriceEnforced(t *testing.T) {
 
 	txPoolConfig := DefaultConfig
 	txPoolConfig.NoLocals = true
-	pool := New(txPoolConfig, log.NewNopLogger(), blockchain, reaplist.New(testTxEncoder{}), txtracker.New())
+	pool := New(txPoolConfig, log.NewNopLogger(), blockchain, reaplist.New(testTxEncoder{}, reaplist.Unbounded, nil), txtracker.New())
 	pool.Init(txPoolConfig.PriceLimit, blockchain.CurrentBlock(), newReserver())
 	defer pool.Close()
 
@@ -1862,7 +1862,7 @@ func TestUnderpricing(t *testing.T) {
 	config.GlobalSlots = 2
 	config.GlobalQueue = 2
 
-	pool := New(config, log.NewNopLogger(), blockchain, reaplist.New(testTxEncoder{}), txtracker.New())
+	pool := New(config, log.NewNopLogger(), blockchain, reaplist.New(testTxEncoder{}, reaplist.Unbounded, nil), txtracker.New())
 	pool.Init(config.PriceLimit, blockchain.CurrentBlock(), newReserver())
 	defer pool.Close()
 
@@ -1952,7 +1952,7 @@ func TestStableUnderpricing(t *testing.T) {
 	config.GlobalSlots = 128
 	config.GlobalQueue = 0
 
-	pool := New(config, log.NewNopLogger(), blockchain, reaplist.New(testTxEncoder{}), txtracker.New())
+	pool := New(config, log.NewNopLogger(), blockchain, reaplist.New(testTxEncoder{}, reaplist.Unbounded, nil), txtracker.New())
 	pool.Init(config.PriceLimit, blockchain.CurrentBlock(), newReserver())
 	defer pool.Close()
 
@@ -2155,7 +2155,7 @@ func TestDeduplication(t *testing.T) {
 	statedb, _ := state.New(types.EmptyRootHash, state.NewDatabaseForTesting())
 	blockchain := newTestBlockChain(params.TestChainConfig, 1000000, statedb, new(event.Feed))
 
-	pool := New(testTxPoolConfig, log.NewNopLogger(), blockchain, reaplist.New(testTxEncoder{}), txtracker.New())
+	pool := New(testTxPoolConfig, log.NewNopLogger(), blockchain, reaplist.New(testTxEncoder{}, reaplist.Unbounded, nil), txtracker.New())
 	pool.Init(testTxPoolConfig.PriceLimit, blockchain.CurrentBlock(), newReserver())
 	defer pool.Close()
 
@@ -2222,7 +2222,7 @@ func TestReplacement(t *testing.T) {
 	statedb, _ := state.New(types.EmptyRootHash, state.NewDatabaseForTesting())
 	blockchain := newTestBlockChain(params.TestChainConfig, 1000000, statedb, new(event.Feed))
 
-	pool := New(testTxPoolConfig, log.NewNopLogger(), blockchain, reaplist.New(testTxEncoder{}), txtracker.New())
+	pool := New(testTxPoolConfig, log.NewNopLogger(), blockchain, reaplist.New(testTxEncoder{}, reaplist.Unbounded, nil), txtracker.New())
 	pool.Init(testTxPoolConfig.PriceLimit, blockchain.CurrentBlock(), newReserver())
 	defer pool.Close()
 
@@ -2414,7 +2414,7 @@ func TestStatusCheck(t *testing.T) {
 	statedb, _ := state.New(types.EmptyRootHash, state.NewDatabaseForTesting())
 	blockchain := newTestBlockChain(params.TestChainConfig, 1000000, statedb, new(event.Feed))
 
-	pool := New(testTxPoolConfig, log.NewNopLogger(), blockchain, reaplist.New(testTxEncoder{}), txtracker.New())
+	pool := New(testTxPoolConfig, log.NewNopLogger(), blockchain, reaplist.New(testTxEncoder{}, reaplist.Unbounded, nil), txtracker.New())
 	pool.Init(testTxPoolConfig.PriceLimit, blockchain.CurrentBlock(), newReserver())
 	defer pool.Close()
 
@@ -2487,7 +2487,7 @@ func TestSetCodeTransactions(t *testing.T) {
 	statedb, _ := state.New(types.EmptyRootHash, state.NewDatabaseForTesting())
 	blockchain := newTestBlockChain(params.MergedTestChainConfig, 1000000, statedb, new(event.Feed))
 
-	pool := New(testTxPoolConfig, log.NewNopLogger(), blockchain, reaplist.New(testTxEncoder{}), txtracker.New())
+	pool := New(testTxPoolConfig, log.NewNopLogger(), blockchain, reaplist.New(testTxEncoder{}, reaplist.Unbounded, nil), txtracker.New())
 	pool.Init(testTxPoolConfig.PriceLimit, blockchain.CurrentBlock(), newReserver())
 	defer pool.Close()
 
@@ -2786,7 +2786,7 @@ func TestSetCodeTransactionsReorg(t *testing.T) {
 	blockchain := newTestBlockChain(params.MergedTestChainConfig, 1000000, statedb, new(event.Feed))
 
 	rechecker := &MockRechecker{}
-	pool := New(testTxPoolConfig, log.NewNopLogger(), blockchain, reaplist.New(testTxEncoder{}), txtracker.New(), WithRecheck(rechecker))
+	pool := New(testTxPoolConfig, log.NewNopLogger(), blockchain, reaplist.New(testTxEncoder{}, reaplist.Unbounded, nil), txtracker.New(), WithRecheck(rechecker))
 	pool.Init(testTxPoolConfig.PriceLimit, blockchain.CurrentBlock(), newReserver())
 	defer pool.Close()
 
@@ -2945,7 +2945,7 @@ func TestRemoveTxTruncatePoolRace(t *testing.T) {
 	statedb, _ := state.New(types.EmptyRootHash, state.NewDatabaseForTesting())
 	blockchain := newTestBlockChain(params.MergedTestChainConfig, 1000000, statedb, new(event.Feed))
 
-	pool := New(testTxPoolConfig, log.NewNopLogger(), blockchain, reaplist.New(testTxEncoder{}), txtracker.New())
+	pool := New(testTxPoolConfig, log.NewNopLogger(), blockchain, reaplist.New(testTxEncoder{}, reaplist.Unbounded, nil), txtracker.New())
 	err := pool.Init(testTxPoolConfig.PriceLimit, blockchain.CurrentBlock(), newReserver())
 	if err != nil {
 		t.Fatalf("failed to init pool: %v", err)

--- a/mempool/txpool/txpool_test.go
+++ b/mempool/txpool/txpool_test.go
@@ -89,7 +89,7 @@ func TestTxPoolCosmosReorg(t *testing.T) {
 	genesisState.On("GetCodeHash", mock.Anything).Return(types.EmptyCodeHash)
 
 	recheckGuard := make(chan struct{})
-	legacyPool := legacypool.New(legacypool.DefaultConfig, log.NewNopLogger(), legacyChain, reaplist.New(stubTxEncoder{}), txtracker.New(), legacypool.WithRecheck(&BlockingRechecker{guard: recheckGuard}))
+	legacyPool := legacypool.New(legacypool.DefaultConfig, log.NewNopLogger(), legacyChain, reaplist.New(stubTxEncoder{}, reaplist.Unbounded, nil), txtracker.New(), legacypool.WithRecheck(&BlockingRechecker{guard: recheckGuard}))
 
 	// handle txpool subscribing to new head events from the chain. grab the
 	// reference to the chan that it is going to wait on so we can push mock
@@ -265,6 +265,7 @@ func TestTxPoolContent_EmptySubpools(t *testing.T) {
 	require.Empty(t, runnable)
 	require.Empty(t, blocked)
 }
+
 // minimal tx encoder to construct a testing reaplist
 type stubTxEncoder struct{}
 


### PR DESCRIPTION
Closes STACK-2669, STACK-2670.

This PR fixes a few things:
- The reap list such that a tx that exceeds absolute per-block max would wedge the reaping. Now, if the tx is oversized, we tombstone the slot and notify the owning subpool via a drop callback. If it's over budget, we keep it for the next block.
  - Also adds a callback that fires after the lock is released so sub-pool drops can re-enter the reap list safely.
- Adds a maxSize cap on the reaplist, defaulting to `cosmosPoolMaxTx` + `GlobalSlots` + `GlobalQueue`. Pushes past the cap return ErrReapListFull.
- New metric: `reap_list.evicted_txs` with reason label.

Realistically, there are mitigations for this upstream in our default config. LegacyPool gas check at insertion, cosmos RecheckCosmos runs ante's gas check. Real exposure is non-standard ante chains, bytes-oversized cosmos txs without MaxTxBytes, or runtime gov change to block.MaxGas. All pretty uncommon cases, but this could serve as a DOD for them.

This PR closes the bug regardless and removes the dependency on those upstream mitigations.