### PR TITLE
chore(7702): authority-based nonce gap promotion testing

### DIFF
--- a/mempool/mempool_test.go
+++ b/mempool/mempool_test.go
@@ -865,7 +865,6 @@ func createMsgEthereum7702Tx(
 	t *testing.T,
 	txConfig client.TxConfig,
 	senderKey *ecdsa.PrivateKey,
-	txNonce uint64,
 	auths []types.SetCodeAuthorization,
 ) sdk.Tx {
 	t.Helper()
@@ -874,7 +873,7 @@ func createMsgEthereum7702Tx(
 	to := common.Address{0x55}
 	signedTx := types.MustSignNewTx(senderKey, types.LatestSignerForChainID(chainID), &types.SetCodeTx{
 		ChainID:   uint256.MustFromBig(chainID),
-		Nonce:     txNonce,
+		Nonce:     0,
 		GasTipCap: uint256.NewInt(1),
 		GasFeeCap: uint256.NewInt(1e9),
 		Gas:       250000,
@@ -954,7 +953,7 @@ func TestStaleNonceHandling(t *testing.T) {
 			finalize7702: func(t *testing.T, mp *mempool.Mempool, txConfig client.TxConfig, accs []testAccount) {
 				t.Helper()
 				auths := []types.SetCodeAuthorization{signSetCodeAuth(t, accs[1].key, 1)}
-				cosmosTx := createMsgEthereum7702Tx(t, txConfig, accs[0].key, 0, auths)
+				cosmosTx := createMsgEthereum7702Tx(t, txConfig, accs[0].key, auths)
 				require.NoError(t, mp.RemoveWithReason(context.Background(), cosmosTx, mempooltypes.RemoveReason{
 					Caller: mempooltypes.CallerRunTxFinalize,
 				}))
@@ -972,7 +971,7 @@ func TestStaleNonceHandling(t *testing.T) {
 			finalize7702: func(t *testing.T, mp *mempool.Mempool, txConfig client.TxConfig, accs []testAccount) {
 				t.Helper()
 				auths := []types.SetCodeAuthorization{signSetCodeAuth(t, accs[0].key, 1)}
-				cosmosTx := createMsgEthereum7702Tx(t, txConfig, accs[0].key, 0, auths)
+				cosmosTx := createMsgEthereum7702Tx(t, txConfig, accs[0].key, auths)
 				require.NoError(t, mp.RemoveWithReason(context.Background(), cosmosTx, mempooltypes.RemoveReason{
 					Caller: mempooltypes.CallerRunTxFinalize,
 				}))
@@ -1001,7 +1000,7 @@ func TestStaleNonceHandling(t *testing.T) {
 					signSetCodeAuth(t, accs[0].key, 3),
 					signSetCodeAuth(t, accs[0].key, 4),
 				}
-				cosmosTx := createMsgEthereum7702Tx(t, txConfig, accs[0].key, 0, auths)
+				cosmosTx := createMsgEthereum7702Tx(t, txConfig, accs[0].key, auths)
 				require.NoError(t, mp.RemoveWithReason(context.Background(), cosmosTx, mempooltypes.RemoveReason{
 					Caller: mempooltypes.CallerRunTxFinalize,
 				}))
@@ -1024,7 +1023,7 @@ func TestStaleNonceHandling(t *testing.T) {
 			finalize7702: func(t *testing.T, mp *mempool.Mempool, txConfig client.TxConfig, accs []testAccount) {
 				t.Helper()
 				auths := []types.SetCodeAuthorization{signSetCodeAuth(t, accs[1].key, 0)}
-				cosmosTx := createMsgEthereum7702Tx(t, txConfig, accs[0].key, 0, auths)
+				cosmosTx := createMsgEthereum7702Tx(t, txConfig, accs[0].key, auths)
 				require.NoError(t, mp.RemoveWithReason(context.Background(), cosmosTx, mempooltypes.RemoveReason{
 					Caller: mempooltypes.CallerRunTxFinalize,
 				}))

--- a/mempool/mempool_test.go
+++ b/mempool/mempool_test.go
@@ -920,6 +920,11 @@ func TestEvictsStaleTx(t *testing.T) {
 		seedNonces   []uint64 // nonces to pre-seed for accounts[targetIdx]
 		finalize7702 func(t *testing.T, mp *mempool.Mempool, txConfig client.TxConfig, accs []testAccount)
 		advanceTo    uint64 // chain nonce to set for accounts[targetIdx]
+		// Expected eager-cache state for accounts[targetIdx] AFTER the test:
+		// expectsEager=false when no SetLatestNonce was triggered for the target;
+		// expectsEager=true with eagerNonce set when the eager path fired.
+		expectsEager bool
+		eagerNonce   uint64
 	}
 
 	cases := []scenario{
@@ -929,6 +934,8 @@ func TestEvictsStaleTx(t *testing.T) {
 			targetIdx:   0,
 			seedNonces:  []uint64{0},
 			advanceTo:   1,
+			// no RemoveWithReason call → eager cache untouched.
+			expectsEager: false,
 		},
 		{
 			name:        "authority-after-cross-account-7702",
@@ -944,6 +951,8 @@ func TestEvictsStaleTx(t *testing.T) {
 				}))
 			},
 			advanceTo: 1,
+			// Eager fires for sender (idx 0); authority (idx 1, the target) is invisible.
+			expectsEager: false,
 		},
 		{
 			name:        "sender-+1-gap-after-self-sponsored-7702",
@@ -959,6 +968,9 @@ func TestEvictsStaleTx(t *testing.T) {
 				}))
 			},
 			advanceTo: 2,
+			// Eager fires for sender (== target) at tx.Nonce()=0; the +1 bump is reactive.
+			expectsEager: true,
+			eagerNonce:   0,
 		},
 	}
 
@@ -999,6 +1011,14 @@ func TestEvictsStaleTx(t *testing.T) {
 				p, q := legacyPool.ContentFrom(target.address)
 				return len(p) == 0 && len(q) == 0
 			}, time.Second, 10*time.Millisecond, "reset must evict stale tx")
+
+			got, ok := legacyPool.LatestNonce(target.address)
+			if tc.expectsEager {
+				require.True(t, ok, "eager cache should have an entry for target")
+				require.Equal(t, tc.eagerNonce, got)
+			} else {
+				require.False(t, ok, "no eager signal expected; eviction proves reactive path")
+			}
 		})
 	}
 }

--- a/mempool/mempool_test.go
+++ b/mempool/mempool_test.go
@@ -936,8 +936,9 @@ func TestEvictsStaleTx(t *testing.T) {
 			targetIdx:   1,
 			seedNonces:  []uint64{0},
 			finalize7702: func(t *testing.T, mp *mempool.Mempool, txConfig client.TxConfig, accs []testAccount) {
+				t.Helper()
 				auths := []types.SetCodeAuthorization{signSetCodeAuth(t, accs[1].key, 1)}
-				cosmosTx, _ := createMsgEthereum7702Tx(t, txConfig, accs[0].key, 0, auths)
+				cosmosTx := createMsgEthereum7702Tx(t, txConfig, accs[0].key, 0, auths)
 				require.NoError(t, mp.RemoveWithReason(context.Background(), cosmosTx, mempooltypes.RemoveReason{
 					Caller: mempooltypes.CallerRunTxFinalize,
 				}))
@@ -950,8 +951,9 @@ func TestEvictsStaleTx(t *testing.T) {
 			targetIdx:   0,
 			seedNonces:  []uint64{0, 1},
 			finalize7702: func(t *testing.T, mp *mempool.Mempool, txConfig client.TxConfig, accs []testAccount) {
+				t.Helper()
 				auths := []types.SetCodeAuthorization{signSetCodeAuth(t, accs[0].key, 1)}
-				cosmosTx, _ := createMsgEthereum7702Tx(t, txConfig, accs[0].key, 0, auths)
+				cosmosTx := createMsgEthereum7702Tx(t, txConfig, accs[0].key, 0, auths)
 				require.NoError(t, mp.RemoveWithReason(context.Background(), cosmosTx, mempooltypes.RemoveReason{
 					Caller: mempooltypes.CallerRunTxFinalize,
 				}))

--- a/mempool/mempool_test.go
+++ b/mempool/mempool_test.go
@@ -1013,6 +1013,28 @@ func TestStaleNonceHandling(t *testing.T) {
 			expectsEager:   true,
 			eagerNonce:     0,
 		},
+		{
+			// Cross-account: acc0 sends 7702 authorizing acc1; the auth
+			// bump closes acc1's queued tx gap. Extractor only sees acc0
+			// (sender), so acc1's eager LRU is never touched. tx1 promotes
+			// on first reset via the statedb fallback.
+			name:             "queued-promotes-after-cross-account-7702",
+			numAccounts:      2,
+			targetIdx:        1,
+			seedNonces:       nil,
+			seedQueuedNonces: []uint64{1},
+			finalize7702: func(t *testing.T, mp *mempool.Mempool, txConfig client.TxConfig, accs []testAccount) {
+				t.Helper()
+				auths := []types.SetCodeAuthorization{signSetCodeAuth(t, accs[1].key, 0)}
+				cosmosTx := createMsgEthereum7702Tx(t, txConfig, accs[0].key, 0, auths)
+				require.NoError(t, mp.RemoveWithReason(context.Background(), cosmosTx, mempooltypes.RemoveReason{
+					Caller: mempooltypes.CallerRunTxFinalize,
+				}))
+			},
+			advanceTo:      1,
+			wantAfterReset: expect{pending: 1, queued: 0},
+			expectsEager:   false,
+		},
 	}
 
 	for _, tc := range cases {

--- a/mempool/mempool_test.go
+++ b/mempool/mempool_test.go
@@ -909,18 +909,28 @@ func signSetCodeAuth(t *testing.T, key *ecdsa.PrivateKey, nonce uint64) types.Se
 	return auth
 }
 
-// TestEvictsStaleTx covers eviction of stale txs via demoteUnexecutables →
-// RecheckEVM during reset, across three scenarios where the eager mechanism
-// can't or doesn't catch the chain advance.
-func TestEvictsStaleTx(t *testing.T) {
+// TestStaleNonceHandling covers pool behavior on chain advance across
+// scenarios where the eager mechanism can't or doesn't catch the new
+// nonce. Most cases assert reactive eviction via demoteUnexecutables →
+// RecheckEVM. The queued-promotion-lag case asserts the accepted 1-block
+// delay when a 7702 authority bump closes a queued tx's gap.
+func TestStaleNonceHandling(t *testing.T) {
+	type expect struct {
+		pending int
+		queued  int
+	}
 	type scenario struct {
-		name         string
-		numAccounts  int
-		targetIdx    int      // account whose pool should drain
-		seedNonces   []uint64 // nonces to pre-seed for accounts[targetIdx]
-		finalize7702 func(t *testing.T, mp *mempool.Mempool, txConfig client.TxConfig, accs []testAccount)
-		advanceTo    uint64 // chain nonce to set for accounts[targetIdx]
-		// Expected eager-cache state for accounts[targetIdx] AFTER the test:
+		name             string
+		numAccounts      int
+		targetIdx        int      // account whose pool we observe
+		seedNonces       []uint64 // pending seeds (sequential, no gaps)
+		seedQueuedNonces []uint64 // queued seeds (gapped from chain nonce)
+		finalize7702     func(t *testing.T, mp *mempool.Mempool, txConfig client.TxConfig, accs []testAccount)
+		advanceTo        uint64 // chain nonce to set for accounts[targetIdx]
+		wantAfterReset   expect // expected counts after the first reset
+		secondReset      bool   // run a second reset and check wantAfterReset2
+		wantAfterReset2  expect
+		// Eager-cache state for accounts[targetIdx] AFTER the test:
 		// expectsEager=false when no SetLatestNonce was triggered for the target;
 		// expectsEager=true with eagerNonce set when the eager path fired.
 		expectsEager bool
@@ -929,11 +939,12 @@ func TestEvictsStaleTx(t *testing.T) {
 
 	cases := []scenario{
 		{
-			name:        "stale-sender-no-7702",
-			numAccounts: 1,
-			targetIdx:   0,
-			seedNonces:  []uint64{0},
-			advanceTo:   1,
+			name:           "stale-sender-no-7702",
+			numAccounts:    1,
+			targetIdx:      0,
+			seedNonces:     []uint64{0},
+			advanceTo:      1,
+			wantAfterReset: expect{pending: 0, queued: 0},
 			// no RemoveWithReason call → eager cache untouched.
 			expectsEager: false,
 		},
@@ -950,7 +961,8 @@ func TestEvictsStaleTx(t *testing.T) {
 					Caller: mempooltypes.CallerRunTxFinalize,
 				}))
 			},
-			advanceTo: 1,
+			advanceTo:      1,
+			wantAfterReset: expect{pending: 0, queued: 0},
 			// Eager fires for sender (idx 0); authority (idx 1, the target) is invisible.
 			expectsEager: false,
 		},
@@ -967,10 +979,39 @@ func TestEvictsStaleTx(t *testing.T) {
 					Caller: mempooltypes.CallerRunTxFinalize,
 				}))
 			},
-			advanceTo: 2,
+			advanceTo:      2,
+			wantAfterReset: expect{pending: 0, queued: 0},
 			// Eager fires for sender (== target) at tx.Nonce()=0; the +1 bump is reactive.
 			expectsEager: true,
 			eagerNonce:   0,
+		},
+		{
+			// Queued tx whose nonce gap is closed by a self-sponsored 7702.
+			// Sender +1 plus 4 self-auth bumps brings chain nonce 0 -> 5,
+			// matching tx5's nonce. With nothing else in pending, the
+			// noncer falls through to statedb on reset and tx5 promotes.
+			name:             "queued-promotes-after-self-sponsored-7702",
+			numAccounts:      1,
+			targetIdx:        0,
+			seedNonces:       nil,
+			seedQueuedNonces: []uint64{5},
+			finalize7702: func(t *testing.T, mp *mempool.Mempool, txConfig client.TxConfig, accs []testAccount) {
+				t.Helper()
+				auths := []types.SetCodeAuthorization{
+					signSetCodeAuth(t, accs[0].key, 1),
+					signSetCodeAuth(t, accs[0].key, 2),
+					signSetCodeAuth(t, accs[0].key, 3),
+					signSetCodeAuth(t, accs[0].key, 4),
+				}
+				cosmosTx := createMsgEthereum7702Tx(t, txConfig, accs[0].key, 0, auths)
+				require.NoError(t, mp.RemoveWithReason(context.Background(), cosmosTx, mempooltypes.RemoveReason{
+					Caller: mempooltypes.CallerRunTxFinalize,
+				}))
+			},
+			advanceTo:      5,
+			wantAfterReset: expect{pending: 1, queued: 0},
+			expectsEager:   true,
+			eagerNonce:     0,
 		},
 	}
 
@@ -989,11 +1030,16 @@ func TestEvictsStaleTx(t *testing.T) {
 				tx := createMsgEthereumTx(t, txConfig, target.key, n, big.NewInt(1e8))
 				require.NoError(t, mp.Insert(context.Background(), tx))
 			}
+			for _, n := range tc.seedQueuedNonces {
+				tx := createMsgEthereumTx(t, txConfig, target.key, n, big.NewInt(1e8))
+				require.NoError(t, mp.Insert(context.Background(), tx))
+			}
 			require.NoError(t, mp.GetTxPool().Sync())
 
 			legacyPool := mp.GetTxPool().Subpools[0].(*legacypool.LegacyPool)
-			pending, _ := legacyPool.ContentFrom(target.address)
+			pending, queued := legacyPool.ContentFrom(target.address)
 			require.Len(t, pending, len(tc.seedNonces))
+			require.Len(t, queued, len(tc.seedQueuedNonces))
 
 			if tc.finalize7702 != nil {
 				tc.finalize7702(t, mp, txConfig, accounts)
@@ -1009,8 +1055,20 @@ func TestEvictsStaleTx(t *testing.T) {
 
 			require.Eventually(t, func() bool {
 				p, q := legacyPool.ContentFrom(target.address)
-				return len(p) == 0 && len(q) == 0
-			}, time.Second, 10*time.Millisecond, "reset must evict stale tx")
+				return len(p) == tc.wantAfterReset.pending && len(q) == tc.wantAfterReset.queued
+			}, time.Second, 10*time.Millisecond, "first reset state mismatch")
+
+			if tc.secondReset {
+				require.NoError(t, bus.PublishEventNewBlockHeader(cmttypes.EventDataNewBlockHeader{
+					Header: cmttypes.Header{Height: 3, Time: time.Now(), ChainID: strconv.Itoa(constants.EighteenDecimalsChainID)},
+				}))
+				require.NoError(t, mp.GetTxPool().Sync())
+
+				require.Eventually(t, func() bool {
+					p, q := legacyPool.ContentFrom(target.address)
+					return len(p) == tc.wantAfterReset2.pending && len(q) == tc.wantAfterReset2.queued
+				}, time.Second, 10*time.Millisecond, "second reset state mismatch")
+			}
 
 			got, ok := legacyPool.LatestNonce(target.address)
 			if tc.expectsEager {

--- a/mempool/mempool_test.go
+++ b/mempool/mempool_test.go
@@ -920,11 +920,6 @@ func TestEvictsStaleTx(t *testing.T) {
 		seedNonces   []uint64 // nonces to pre-seed for accounts[targetIdx]
 		finalize7702 func(t *testing.T, mp *mempool.Mempool, txConfig client.TxConfig, accs []testAccount)
 		advanceTo    uint64 // chain nonce to set for accounts[targetIdx]
-		// Expected eager-cache state for accounts[targetIdx] AFTER the test:
-		// expectsEager=false when no SetLatestNonce was triggered for the target;
-		// expectsEager=true with eagerNonce set when the eager path fired.
-		expectsEager bool
-		eagerNonce   uint64
 	}
 
 	cases := []scenario{
@@ -934,8 +929,6 @@ func TestEvictsStaleTx(t *testing.T) {
 			targetIdx:   0,
 			seedNonces:  []uint64{0},
 			advanceTo:   1,
-			// no RemoveWithReason call → eager cache untouched.
-			expectsEager: false,
 		},
 		{
 			name:        "authority-after-cross-account-7702",
@@ -943,16 +936,13 @@ func TestEvictsStaleTx(t *testing.T) {
 			targetIdx:   1,
 			seedNonces:  []uint64{0},
 			finalize7702: func(t *testing.T, mp *mempool.Mempool, txConfig client.TxConfig, accs []testAccount) {
-				t.Helper()
 				auths := []types.SetCodeAuthorization{signSetCodeAuth(t, accs[1].key, 1)}
-				cosmosTx := createMsgEthereum7702Tx(t, txConfig, accs[0].key, 0, auths)
+				cosmosTx, _ := createMsgEthereum7702Tx(t, txConfig, accs[0].key, 0, auths)
 				require.NoError(t, mp.RemoveWithReason(context.Background(), cosmosTx, mempooltypes.RemoveReason{
 					Caller: mempooltypes.CallerRunTxFinalize,
 				}))
 			},
 			advanceTo: 1,
-			// Eager fires for sender (idx 0); authority (idx 1, the target) is invisible.
-			expectsEager: false,
 		},
 		{
 			name:        "sender-+1-gap-after-self-sponsored-7702",
@@ -960,17 +950,13 @@ func TestEvictsStaleTx(t *testing.T) {
 			targetIdx:   0,
 			seedNonces:  []uint64{0, 1},
 			finalize7702: func(t *testing.T, mp *mempool.Mempool, txConfig client.TxConfig, accs []testAccount) {
-				t.Helper()
 				auths := []types.SetCodeAuthorization{signSetCodeAuth(t, accs[0].key, 1)}
-				cosmosTx := createMsgEthereum7702Tx(t, txConfig, accs[0].key, 0, auths)
+				cosmosTx, _ := createMsgEthereum7702Tx(t, txConfig, accs[0].key, 0, auths)
 				require.NoError(t, mp.RemoveWithReason(context.Background(), cosmosTx, mempooltypes.RemoveReason{
 					Caller: mempooltypes.CallerRunTxFinalize,
 				}))
 			},
 			advanceTo: 2,
-			// Eager fires for sender (== target) at tx.Nonce()=0; the +1 bump is reactive.
-			expectsEager: true,
-			eagerNonce:   0,
 		},
 	}
 
@@ -1011,14 +997,6 @@ func TestEvictsStaleTx(t *testing.T) {
 				p, q := legacyPool.ContentFrom(target.address)
 				return len(p) == 0 && len(q) == 0
 			}, time.Second, 10*time.Millisecond, "reset must evict stale tx")
-
-			got, ok := legacyPool.LatestNonce(target.address)
-			if tc.expectsEager {
-				require.True(t, ok, "eager cache should have an entry for target")
-				require.Equal(t, tc.eagerNonce, got)
-			} else {
-				require.False(t, ok, "no eager signal expected; eviction proves reactive path")
-			}
 		})
 	}
 }

--- a/mempool/mempool_test.go
+++ b/mempool/mempool_test.go
@@ -911,9 +911,9 @@ func signSetCodeAuth(t *testing.T, key *ecdsa.PrivateKey, nonce uint64) types.Se
 
 // TestStaleNonceHandling covers pool behavior on chain advance across
 // scenarios where the eager mechanism can't or doesn't catch the new
-// nonce. Most cases assert reactive eviction via demoteUnexecutables →
-// RecheckEVM. The queued-promotion-lag case asserts the accepted 1-block
-// delay when a 7702 authority bump closes a queued tx's gap.
+// nonce. Cases assert reactive eviction via demoteUnexecutables →
+// RecheckEVM, or queued-tx promotion when a 7702 authority bump closes
+// a nonce gap.
 func TestStaleNonceHandling(t *testing.T) {
 	type expect struct {
 		pending int
@@ -927,9 +927,7 @@ func TestStaleNonceHandling(t *testing.T) {
 		seedQueuedNonces []uint64 // queued seeds (gapped from chain nonce)
 		finalize7702     func(t *testing.T, mp *mempool.Mempool, txConfig client.TxConfig, accs []testAccount)
 		advanceTo        uint64 // chain nonce to set for accounts[targetIdx]
-		wantAfterReset   expect // expected counts after the first reset
-		secondReset      bool   // run a second reset and check wantAfterReset2
-		wantAfterReset2  expect
+		wantAfterReset   expect // expected counts after the reset
 		// Eager-cache state for accounts[targetIdx] AFTER the test:
 		// expectsEager=false when no SetLatestNonce was triggered for the target;
 		// expectsEager=true with eagerNonce set when the eager path fired.
@@ -1078,19 +1076,7 @@ func TestStaleNonceHandling(t *testing.T) {
 			require.Eventually(t, func() bool {
 				p, q := legacyPool.ContentFrom(target.address)
 				return len(p) == tc.wantAfterReset.pending && len(q) == tc.wantAfterReset.queued
-			}, time.Second, 10*time.Millisecond, "first reset state mismatch")
-
-			if tc.secondReset {
-				require.NoError(t, bus.PublishEventNewBlockHeader(cmttypes.EventDataNewBlockHeader{
-					Header: cmttypes.Header{Height: 3, Time: time.Now(), ChainID: strconv.Itoa(constants.EighteenDecimalsChainID)},
-				}))
-				require.NoError(t, mp.GetTxPool().Sync())
-
-				require.Eventually(t, func() bool {
-					p, q := legacyPool.ContentFrom(target.address)
-					return len(p) == tc.wantAfterReset2.pending && len(q) == tc.wantAfterReset2.queued
-				}, time.Second, 10*time.Millisecond, "second reset state mismatch")
-			}
+			}, time.Second, 10*time.Millisecond, "reset state mismatch")
 
 			got, ok := legacyPool.LatestNonce(target.address)
 			if tc.expectsEager {

--- a/tests/systemtests/main_test.go
+++ b/tests/systemtests/main_test.go
@@ -50,6 +50,10 @@ func TestMempoolCosmosTxsCompatibility(t *testing.T) {
 	suite.RunWithSharedSuite(t, mempool.RunCosmosTxsCompatibility, suite.MempoolArgs()...)
 }
 
+func TestMempoolSetCode7702QueuedTxPromotion(t *testing.T) {
+	suite.RunWithSharedSuite(t, mempool.RunSetCode7702QueuedTxPromotion, suite.MempoolArgs()...)
+}
+
 // /*
 // * EIP-712 Tests
 // */

--- a/tests/systemtests/mempool/test_ordering.go
+++ b/tests/systemtests/mempool/test_ordering.go
@@ -3,12 +3,18 @@
 package mempool
 
 import (
+	"context"
 	"fmt"
 	"math/big"
 	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
 
 	"github.com/cosmos/evm/tests/systemtests/suite"
-	"github.com/stretchr/testify/require"
 )
 
 func RunTxsOrdering(t *testing.T, base *suite.BaseTestSuite) {
@@ -84,4 +90,157 @@ func RunTxsOrdering(t *testing.T, base *suite.BaseTestSuite) {
 			})
 		}
 	}
+}
+
+// RunSetCode7702QueuedTxPromotion proves that a queued tx whose nonce gap
+// is closed by a self-sponsored 7702 actually promotes and lands. Submits
+// tx5 (gap of 4 from chain head), then a self-sponsored 7702 with 4
+// self-auths to bump the sender's chain nonce by 5. Asserts both land.
+func RunSetCode7702QueuedTxPromotion(t *testing.T, base *suite.BaseTestSuite) {
+	s := NewTestSuite(base)
+	s.SetupTest(t)
+	s.SetOptions(&suite.TestOptions{
+		Description: "EVM SetCodeTx promotion lag",
+		TxType:      suite.TxTypeEVM,
+	})
+
+	t.Run("queued tx promotes after self-sponsored 7702 closes the gap", func(t *testing.T) {
+		ctx := NewTestContext()
+		s.BeforeEachCase(t, ctx)
+
+		signer := s.Acc(0)
+		nodeID := "node0"
+
+		startNonce, err := s.NonceAt(nodeID, signer.ID)
+		require.NoError(t, err)
+
+		// Queued tx with gap of 4 from chain head.
+		queuedTxInfo, err := s.SendTx(t, nodeID, signer.ID, 5, s.GasPriceMultiplier(10), big.NewInt(1))
+		require.NoError(t, err, "failed to send queued tx")
+		require.NoError(t, s.CheckTxsQueuedAsync([]*suite.TxInfo{queuedTxInfo}))
+
+		// Self-sponsored 7702 with 4 self-auths at startNonce+1..+4.
+		// Sender bump (+1) plus 4 auth bumps -> chain nonce += 5.
+		sevenSeven02Hash := sendSelfSponsored7702BulkAuths(t, s, nodeID, signer.ID, startNonce, 4)
+
+		require.NoError(t, s.WaitForCommit(nodeID, sevenSeven02Hash.Hex(), suite.TxTypeEVM, 60*time.Second))
+		require.NoError(t, s.WaitForCommit(nodeID, queuedTxInfo.TxHash, suite.TxTypeEVM, 60*time.Second))
+
+		// Chain nonce must reflect 7702 (+5) and queued tx (+1).
+		finalNonce, err := s.NonceAt(nodeID, signer.ID)
+		require.NoError(t, err)
+		require.GreaterOrEqual(t, finalNonce, startNonce+6)
+
+		// Clear delegation so subsequent shared-suite cases see acc0 clean.
+		clearDelegation(t, s, nodeID, signer.ID, finalNonce)
+	})
+}
+
+// sendSelfSponsored7702BulkAuths constructs and sends a SetCodeTx where
+// the sender is also the authority for `numAuths` consecutive auth slots
+// starting at startNonce+1. Returns the tx hash.
+func sendSelfSponsored7702BulkAuths(
+	t *testing.T,
+	s *TestSuite,
+	nodeID string,
+	accID string,
+	startNonce uint64,
+	numAuths uint64,
+) common.Hash {
+	t.Helper()
+
+	ctx := context.Background()
+	ethCli := s.EthClient.Clients[nodeID]
+	acc := s.EthAccount(accID)
+	require.NotNil(t, acc, "account %s not found", accID)
+
+	chainID, err := ethCli.ChainID(ctx)
+	require.NoError(t, err)
+
+	// Each auth points at a non-zero placeholder so the delegation
+	// actually applies (zero target is the "clear delegation" sentinel
+	// and would still bump the nonce, but using a real target keeps the
+	// test honest about a delegation actually being installed).
+	target := common.Address{0x42}
+
+	auths := make([]ethtypes.SetCodeAuthorization, numAuths)
+	for i := uint64(0); i < numAuths; i++ {
+		raw := ethtypes.SetCodeAuthorization{
+			ChainID: *uint256.MustFromBig(chainID),
+			Address: target,
+			Nonce:   startNonce + 1 + i,
+		}
+		signed, signErr := ethtypes.SignSetCode(acc.PrivKey, raw)
+		require.NoError(t, signErr, "failed to sign auth %d", i)
+		auths[i] = signed
+	}
+
+	txdata := &ethtypes.SetCodeTx{
+		ChainID:    uint256.MustFromBig(chainID),
+		Nonce:      startNonce,
+		GasTipCap:  uint256.NewInt(1_000_000),
+		GasFeeCap:  uint256.NewInt(1_000_000_000),
+		Gas:        200_000,
+		To:         common.Address{},
+		Value:      uint256.NewInt(0),
+		Data:       []byte{},
+		AccessList: ethtypes.AccessList{},
+		AuthList:   auths,
+	}
+
+	txSigner := ethtypes.LatestSignerForChainID(chainID)
+	signedTx := ethtypes.MustSignNewTx(acc.PrivKey, txSigner, txdata)
+
+	require.NoError(t, ethCli.SendTransaction(ctx, signedTx),
+		fmt.Sprintf("failed to broadcast 7702 tx (nonce=%d, %d auths)", startNonce, numAuths))
+
+	return signedTx.Hash()
+}
+
+// clearDelegation sends a self-sponsored 7702 with a single zero-address
+// auth to remove any code delegation on the sender.
+func clearDelegation(
+	t *testing.T,
+	s *TestSuite,
+	nodeID string,
+	accID string,
+	currentNonce uint64,
+) {
+	t.Helper()
+
+	ctx := context.Background()
+	ethCli := s.EthClient.Clients[nodeID]
+	acc := s.EthAccount(accID)
+	require.NotNil(t, acc)
+
+	chainID, err := ethCli.ChainID(ctx)
+	require.NoError(t, err)
+
+	clearAuth := ethtypes.SetCodeAuthorization{
+		ChainID: *uint256.MustFromBig(chainID),
+		Address: common.Address{},
+		Nonce:   currentNonce + 1,
+	}
+	signedClear, err := ethtypes.SignSetCode(acc.PrivKey, clearAuth)
+	require.NoError(t, err)
+
+	txdata := &ethtypes.SetCodeTx{
+		ChainID:    uint256.MustFromBig(chainID),
+		Nonce:      currentNonce,
+		GasTipCap:  uint256.NewInt(1_000_000),
+		GasFeeCap:  uint256.NewInt(1_000_000_000),
+		Gas:        100_000,
+		To:         common.Address{},
+		Value:      uint256.NewInt(0),
+		Data:       []byte{},
+		AccessList: ethtypes.AccessList{},
+		AuthList:   []ethtypes.SetCodeAuthorization{signedClear},
+	}
+
+	txSigner := ethtypes.LatestSignerForChainID(chainID)
+	signedTx := ethtypes.MustSignNewTx(acc.PrivKey, txSigner, txdata)
+
+	require.NoError(t, ethCli.SendTransaction(ctx, signedTx),
+		"failed to broadcast delegation-clear 7702")
+	require.NoError(t, s.WaitForCommit(nodeID, signedTx.Hash().Hex(), suite.TxTypeEVM, 60*time.Second))
 }

--- a/tests/systemtests/mempool/test_ordering.go
+++ b/tests/systemtests/mempool/test_ordering.go
@@ -94,7 +94,7 @@ func RunTxsOrdering(t *testing.T, base *suite.BaseTestSuite) {
 
 // RunSetCode7702QueuedTxPromotion proves that a queued tx whose nonce gap
 // is closed by a self-sponsored 7702 actually promotes and lands. Submits
-// tx5 (gap of 4 from chain head), then a self-sponsored 7702 with 4
+// tx5 (5 nonces ahead of chain head), then a self-sponsored 7702 with 4
 // self-auths to bump the sender's chain nonce by 5. Asserts both land.
 func RunSetCode7702QueuedTxPromotion(t *testing.T, base *suite.BaseTestSuite) {
 	s := NewTestSuite(base)
@@ -114,7 +114,7 @@ func RunSetCode7702QueuedTxPromotion(t *testing.T, base *suite.BaseTestSuite) {
 		startNonce, err := s.NonceAt(nodeID, signer.ID)
 		require.NoError(t, err)
 
-		// Queued tx with gap of 4 from chain head.
+		// Queued tx 5 nonces ahead of chain head.
 		queuedTxInfo, err := s.SendTx(t, nodeID, signer.ID, 5, s.GasPriceMultiplier(10), big.NewInt(1))
 		require.NoError(t, err, "failed to send queued tx")
 		require.NoError(t, s.CheckTxsQueuedAsync([]*suite.TxInfo{queuedTxInfo}))


### PR DESCRIPTION
Adds unit tests for nonce-gap closure promotions of queued txes for self and cross-account sponsored cases.

Adds systemtest for nonce-gap closure promotions of a self-sponsored 7702 case.