### PR TITLE
fix(mempool): defer reap of evm tx replacements until validation

### DIFF
--- a/mempool/txpool/legacypool/legacypool.go
+++ b/mempool/txpool/legacypool/legacypool.go
@@ -2071,6 +2071,11 @@ func (pool *LegacyPool) demoteUnexecutables(cancelled chan struct{}, reset *txpo
 	// Iterate over all accounts and demote any non-executable transactions
 	for addr, list := range pool.pending {
 		if isReorgCancelled(reset, cancelled) {
+			// NOTE: are explicitly not clearing the toReap lookup since that
+			// may contain txs that have not been rechecked yet and still need
+			// to be reaped that we did not reach during this call since we
+			// cancelled early. we will attempt to reap them next reset after
+			// verification.
 			pendingDemotedCancelled.Add(context.Background(), 1)
 			return
 		}

--- a/mempool/txpool/legacypool/legacypool.go
+++ b/mempool/txpool/legacypool/legacypool.go
@@ -2449,6 +2449,7 @@ func (pool *LegacyPool) Clear() {
 	pool.pending = make(map[common.Address]*list)
 	pool.queue = make(map[common.Address]*list)
 	pool.pendingNonces = newNoncer(pool.currentState)
+	pool.toReap = make(map[common.Hash]struct{})
 }
 
 // HasPendingAuth returns a flag indicating whether there are pending

--- a/mempool/txpool/legacypool/legacypool.go
+++ b/mempool/txpool/legacypool/legacypool.go
@@ -2477,8 +2477,8 @@ func (pool *LegacyPool) markTxReplaced(_ common.Address, tx *types.Transaction) 
 	// replacement tx has not been verified via the rechecker. thus we are
 	// deferring the reap to happen only after is has been verified during the
 	// next call to demoteUnexecutables.
-	pool.toReap[tx.Hash()] = struct{}{}
 	hash := tx.Hash()
+	pool.toReap[hash] = struct{}{}
 	_ = pool.tracker.ExitedQueued(hash)
 	_ = pool.tracker.EnteredPending(hash)
 }

--- a/mempool/txpool/legacypool/legacypool.go
+++ b/mempool/txpool/legacypool/legacypool.go
@@ -455,6 +455,7 @@ type LegacyPool struct {
 	rechecker           Rechecker                          // Checks a tx for validity against the current state
 
 	validPendingTxs *heightsync.HeightSync[TxStore] // Per height store of pending txs that have been validated
+	toReap          map[common.Hash]struct{}        // Transactions that should be reaped after their next recheck
 
 	pending map[common.Address]*list     // All currently processable transactions
 	queue   map[common.Address]*list     // Queued but non-processable transactions
@@ -529,6 +530,7 @@ func New(
 		reapList:            reapList,
 		tracker:             tracker,
 		validPendingTxs:     heightsync.New(chain.CurrentBlock().Number, NewTxStore, logger.With("pool", "legacypool")),
+		toReap:              make(map[common.Hash]struct{}),
 		reqResetCh:          make(chan *txpoolResetRequest),
 		reqPromoteCh:        make(chan *accountSet),
 		reqCancelResetCh:    make(chan struct{}),
@@ -2149,12 +2151,33 @@ func (pool *LegacyPool) demoteUnexecutables(cancelled chan struct{}, reset *txpo
 			if _, ok := pool.queue[addr]; !ok {
 				pool.reserver.Release(addr)
 			}
-		} else {
-			pool.validPendingTxs.Do(func(store *TxStore) {
-				store.AddTxs(addr, list.Flatten())
-			})
+			continue
+		}
+
+		// list now contains only validated txs (txs that failed recheck have
+		// been dropped, and those now gapped have been moved back to queued)
+		validated := list.Flatten()
+
+		// push validated txs into the validPendingTxs for this height
+		pool.validPendingTxs.Do(func(store *TxStore) { store.AddTxs(addr, validated) })
+
+		// if any of the validated txs are pending reap, reap them now
+		for _, tx := range validated {
+			hash := tx.Hash()
+			if _, ok := pool.toReap[hash]; !ok {
+				// tx does not need deferred reap, continue
+				continue
+			}
+			if err := pool.reapList.PushEVMTx(tx); err != nil {
+				log.Error("failed to push tx pending reap onto reap list", "err", err, "hash", hash)
+			}
+			delete(pool.toReap, hash)
 		}
 	}
+
+	// we have removed txs that we have reaped, but there may be stale entires
+	// in cases where we replace a tx multiple times, clean them up here.
+	pool.toReap = make(map[common.Hash]struct{})
 }
 
 // addressByHeartbeat is an account address tagged with its last activity timestamp.
@@ -2445,14 +2468,16 @@ func (pool *LegacyPool) markTxPromoted(addr common.Address, tx *types.Transactio
 	_ = pool.tracker.EnteredPending(hash)
 }
 
-// markTxReplaced runs the promotion side-effects for a tx that bypassed the
+// markTxReplaced runs the promotion side effects for a tx that bypassed the
 // queued pool (replaced an existing pending tx at the same nonce). It does
 // **not** include the tx in the valid pending txs set, since replacements
 // must be revalidated by the Rechecker before we rely on them.
 func (pool *LegacyPool) markTxReplaced(_ common.Address, tx *types.Transaction) {
-	if err := pool.reapList.PushEVMTx(tx); err != nil {
-		log.Error("could not push replaced evm tx to ReapList", "err", err, "hash", tx.Hash())
-	}
+	// we are explicitly not adding this tx to the reap list here. this
+	// replacement tx has not been verified via the rechecker. thus we are
+	// deferring the reap to happen only after is has been verified during the
+	// next call to demoteUnexecutables.
+	pool.toReap[tx.Hash()] = struct{}{}
 	hash := tx.Hash()
 	_ = pool.tracker.ExitedQueued(hash)
 	_ = pool.tracker.EnteredPending(hash)

--- a/mempool/txpool/legacypool/legacypool_test.go
+++ b/mempool/txpool/legacypool/legacypool_test.go
@@ -3265,6 +3265,184 @@ func TestRecheckedFutureHeight(t *testing.T) {
 	}
 }
 
+func TestReplacementReapDeferral(t *testing.T) {
+	gasP := func(g int64) *int64 { return &g }
+
+	cases := []struct {
+		name                string
+		replacements        func(key *ecdsa.PrivateKey) []*types.Transaction
+		failRecheckGasPrice *int64
+		presentGasPrice     *int64
+	}{
+		{
+			name: "replacement tx that fails recheck is never reaped",
+			replacements: func(key *ecdsa.PrivateKey) []*types.Transaction {
+				return []*types.Transaction{
+					pricedTransaction(0, 100000, big.NewInt(2), key),
+				}
+			},
+			failRecheckGasPrice: gasP(2),
+		},
+		{
+			name: "replacement tx that passes recheck is reaped",
+			replacements: func(key *ecdsa.PrivateKey) []*types.Transaction {
+				return []*types.Transaction{
+					pricedTransaction(0, 100000, big.NewInt(2), key),
+				}
+			},
+			presentGasPrice: gasP(2),
+		},
+		{
+			// Chain of replacements within one block: each supersedes the
+			// previous in pending. Exactly one push happens at demote
+			// time, for the latest hash; earlier hashes are silently
+			// discarded when toReap is cleared.
+			name: "multi replacement txs only reaps latest",
+			replacements: func(key *ecdsa.PrivateKey) []*types.Transaction {
+				return []*types.Transaction{
+					pricedTransaction(0, 100000, big.NewInt(2), key),
+					pricedTransaction(0, 100000, big.NewInt(3), key),
+					pricedTransaction(0, 100000, big.NewInt(4), key),
+					pricedTransaction(0, 100000, big.NewInt(5), key),
+				}
+			},
+			presentGasPrice: gasP(5),
+		},
+	}
+
+	// findByGasPrice returns the tx in txs whose gas price matches.
+	// Replacements within a chain have unique gas prices, so this picks
+	// out exactly one tx.
+	findByGasPrice := func(txs []*types.Transaction, gasPrice int64) *types.Transaction {
+		target := big.NewInt(gasPrice)
+		for _, tx := range txs {
+			if tx.GasPrice().Cmp(target) == 0 {
+				return tx
+			}
+		}
+		return nil
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			pool, rechecker, key := setupPool()
+			defer pool.Close()
+
+			addr := crypto.PubkeyToAddress(key.PublicKey)
+			testAddBalance(pool, addr, big.NewInt(100000000000000))
+
+			replacements := tc.replacements(key)
+
+			// base tx that replacements will be replacing
+			base := pricedTransaction(0, 100000, big.NewInt(1), key)
+			directPromoteToPending(t, pool, addr, base)
+			_ = reapAllHashes(pool) // drain initial promote push
+
+			if tc.failRecheckGasPrice != nil {
+				fail := big.NewInt(*tc.failRecheckGasPrice)
+				rechecker.SetRecheck(func(_ sdk.Context, tx *types.Transaction) (sdk.Context, error) {
+					if tx.GasPrice().Cmp(fail) == 0 {
+						return sdk.Context{}, errors.New("recheck fails for gas price")
+					}
+					return sdk.Context{}, nil
+				})
+			}
+
+			for _, r := range replacements {
+				replaced, err := pool.add(r)
+				require.NoError(t, err)
+				require.True(t, replaced)
+				require.Contains(t, pool.toReap, r.Hash())
+			}
+			require.Empty(t, reapAllHashes(pool), "replacements must be deferred until next demote")
+
+			pool.Reset(nil, nil)
+
+			reaped := reapAllHashes(pool)
+			require.Empty(t, pool.toReap)
+
+			if tc.presentGasPrice != nil {
+				want := findByGasPrice(replacements, *tc.presentGasPrice)
+				require.NotNil(t, pool.all.Get(want.Hash()), "tx at presentGasPrice should remain in pool.all")
+				require.Contains(t, reaped, want.Hash(), "tx at presentGasPrice should be on the reap list")
+			}
+
+			if tc.failRecheckGasPrice != nil {
+				want := findByGasPrice(replacements, *tc.failRecheckGasPrice)
+				require.Nil(t, pool.all.Get(want.Hash()), "tx at failRecheckGasPrice should be removed from pool.all")
+				require.NotContains(t, reaped, want.Hash(), "tx at failRecheckGasPrice should not be on the reap list")
+			}
+		})
+	}
+}
+
+func TestReplacementDemotedToQueueReapsViaPromote(t *testing.T) {
+	pool, rechecker, key := setupPool()
+	defer pool.Close()
+
+	addr := crypto.PubkeyToAddress(key.PublicKey)
+	testAddBalance(pool, addr, big.NewInt(100000000000000))
+
+	tx0 := pricedTransaction(0, 100000, big.NewInt(1), key)
+	tx1 := pricedTransaction(1, 100000, big.NewInt(1), key)
+	directPromoteToPending(t, pool, addr, tx0)
+	directPromoteToPending(t, pool, addr, tx1)
+	_ = reapAllHashes(pool)
+
+	replacement := pricedTransaction(1, 100000, big.NewInt(2), key)
+	replaced, err := pool.add(replacement)
+	require.NoError(t, err)
+	require.True(t, replaced)
+	require.Contains(t, pool.toReap, replacement.Hash())
+	require.Empty(t, reapAllHashes(pool))
+
+	rechecker.SetRecheck(func(_ sdk.Context, tx *types.Transaction) (sdk.Context, error) {
+		if tx.Hash() == tx0.Hash() {
+			return sdk.Context{}, errors.New("tx0 fails")
+		}
+		return sdk.Context{}, nil
+	})
+	pool.Reset(nil, nil)
+
+	require.Nil(t, pool.all.Get(tx0.Hash()))
+	require.NotNil(t, pool.all.Get(replacement.Hash()))
+	require.Nil(t, pool.pending[addr])
+	require.NotNil(t, pool.queue[addr])
+	require.Equal(t, 1, pool.queue[addr].Len())
+	require.Empty(t, pool.toReap)
+	require.Empty(t, reapAllHashes(pool), "replacement must not be reaped after demotion")
+
+	// advance state nonce so the replacement is ready on the next reset.
+	testSetNonce(pool, addr, 1)
+	rechecker.SetRecheck(nil)
+	pool.Reset(nil, nil)
+
+	// ensure we now reap the valid promoted tx
+	require.Equal(t, []common.Hash{replacement.Hash()}, reapAllHashes(pool))
+	require.Empty(t, pool.toReap)
+}
+
+func reapAllHashes(pool *LegacyPool) []common.Hash {
+	raw := pool.reapList.Reap(0, 0)
+	out := make([]common.Hash, 0, len(raw))
+	for _, b := range raw {
+		out = append(out, common.BytesToHash(b))
+	}
+	return out
+}
+
+func directPromoteToPending(t *testing.T, pool *LegacyPool, addr common.Address, tx *types.Transaction) {
+	t.Helper()
+	if _, hasPending := pool.pending[addr]; !hasPending {
+		if _, hasQueue := pool.queue[addr]; !hasQueue {
+			require.NoError(t, pool.reserver.Hold(addr))
+		}
+	}
+	pool.all.Add(tx)
+	pool.priced.Put(tx)
+	pool.promoteTx(addr, tx.Hash(), tx)
+}
+
 // Benchmarks the speed of validating the contents of the pending queue of the
 // transaction pool.
 func BenchmarkPendingDemotion100(b *testing.B)   { benchmarkPendingDemotion(b, 100) }


### PR DESCRIPTION
# Description

Previously, we were adding evm txs that replaced an existing tx in the pending pool directly to the reap list. An invariant of the reap list is that all txs have been validated via the recheckers. This was breaking that invariant. This could have led to honest nodes spamming invalid txs over p2p. To fix, we mark txs that are replacing txs in the pending pool in a `toReap` lookup in the legacypool, and then when we recheck txs in the pending pool. check if the validated txs need to still be reaped.

Closes: STACK-2687

---

## Author Checklist

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.

I have...

- [ ] tackled an existing issue or discussed with a team member
- [ ] left instructions on how to review the changes
- [ ] targeted the `main` branch
