### PR TITLE
chore: remove max bytes check on hotpath and instead fail on misconfigured reaplist on startup

### DIFF
--- a/evmd/mempool.go
+++ b/evmd/mempool.go
@@ -34,6 +34,10 @@ func (app *EVMD) configureEVMMempool(appOpts servertypes.AppOptions, logger log.
 		return nil
 	}
 
+	if err := server.ValidateReapBounds(appOpts, mpConfig.BlockGasLimit); err != nil {
+		return err
+	}
+
 	// create mempool
 	mempool := evmmempool.NewMempool(
 		app.CreateQueryContext,

--- a/mempool/internal/reaplist/reaplist.go
+++ b/mempool/internal/reaplist/reaplist.go
@@ -51,6 +51,11 @@ func New(txEncoder EVMCosmosTxEncoder) *ReapList {
 // Reap returns a list of the oldest to newest transactions bytes from the reap
 // list until either maxBytes or maxGas is reached for the list of transactions
 // being returned. If maxBytes and maxGas are both 0 all txs will be returned.
+//
+// Callers MUST pass maxBytes >= comet's mempool.max_tx_bytes and maxGas >=
+// consensus block.max_gas (or 0 for "no limit"). A tx larger than maxBytes/
+// maxGas wedges the head: Reap stops at it and returns nothing, even though
+// txs behind it would fit. server.ValidateReapBounds enforces this at boot.
 func (rl *ReapList) Reap(maxBytes uint64, maxGas uint64) [][]byte {
 	rl.txsLock.Lock()
 	defer rl.txsLock.Unlock()

--- a/mempool/internal/reaplist/reaplist_test.go
+++ b/mempool/internal/reaplist/reaplist_test.go
@@ -320,6 +320,43 @@ func TestExactGasLimit(t *testing.T) {
 	require.Len(t, result, 2, "should reap exactly 2 transactions with exact gas limit")
 }
 
+// A tx whose size exceeds Reap's maxBytes wedges the queue: Reap returns
+// nothing until that tx is dropped, even though smaller txs behind it fit.
+func TestReapWedgesOnOversizedHead_Bytes(t *testing.T) {
+	key, err := crypto.GenerateKey()
+	require.NoError(t, err)
+
+	const reapMaxBytes = uint64(500)
+
+	rl := New(newDeterministicEncoder(reapMaxBytes+1, 0))
+	require.NoError(t, rl.PushEVMTx(testEVMTx(t, key, 0, 21000)))
+
+	rl.txEncoder = newDeterministicEncoder(100, 0)
+	for i := uint64(1); i < 4; i++ {
+		require.NoError(t, rl.PushEVMTx(testEVMTx(t, key, i, 21000)))
+	}
+
+	require.Empty(t, rl.Reap(reapMaxBytes, 0))
+	require.Len(t, rl.Reap(0, 0), 4, "uncapped Reap returns all queued txs")
+}
+
+// Gas-axis counterpart to TestReapWedgesOnOversizedHead_Bytes.
+func TestReapWedgesOnOversizedHead_Gas(t *testing.T) {
+	key, err := crypto.GenerateKey()
+	require.NoError(t, err)
+
+	const reapMaxGas = uint64(50_000)
+
+	rl := New(newDeterministicEncoder(100, 0))
+	require.NoError(t, rl.PushEVMTx(testEVMTx(t, key, 0, reapMaxGas+1)))
+	for i := uint64(1); i < 4; i++ {
+		require.NoError(t, rl.PushEVMTx(testEVMTx(t, key, i, 21000)))
+	}
+
+	require.Empty(t, rl.Reap(0, reapMaxGas))
+	require.Len(t, rl.Reap(0, 0), 4, "uncapped Reap returns all queued txs")
+}
+
 func TestEncodingFailure(t *testing.T) {
 	key, err := crypto.GenerateKey()
 	require.NoError(t, err)

--- a/mempool/internal/reaplist/reaplist_test.go
+++ b/mempool/internal/reaplist/reaplist_test.go
@@ -320,43 +320,6 @@ func TestExactGasLimit(t *testing.T) {
 	require.Len(t, result, 2, "should reap exactly 2 transactions with exact gas limit")
 }
 
-// A tx whose size exceeds Reap's maxBytes wedges the queue: Reap returns
-// nothing until that tx is dropped, even though smaller txs behind it fit.
-func TestReapWedgesOnOversizedHead_Bytes(t *testing.T) {
-	key, err := crypto.GenerateKey()
-	require.NoError(t, err)
-
-	const reapMaxBytes = uint64(500)
-
-	rl := New(newDeterministicEncoder(reapMaxBytes+1, 0))
-	require.NoError(t, rl.PushEVMTx(testEVMTx(t, key, 0, 21000)))
-
-	rl.txEncoder = newDeterministicEncoder(100, 0)
-	for i := uint64(1); i < 4; i++ {
-		require.NoError(t, rl.PushEVMTx(testEVMTx(t, key, i, 21000)))
-	}
-
-	require.Empty(t, rl.Reap(reapMaxBytes, 0))
-	require.Len(t, rl.Reap(0, 0), 4, "uncapped Reap returns all queued txs")
-}
-
-// Gas-axis counterpart to TestReapWedgesOnOversizedHead_Bytes.
-func TestReapWedgesOnOversizedHead_Gas(t *testing.T) {
-	key, err := crypto.GenerateKey()
-	require.NoError(t, err)
-
-	const reapMaxGas = uint64(50_000)
-
-	rl := New(newDeterministicEncoder(100, 0))
-	require.NoError(t, rl.PushEVMTx(testEVMTx(t, key, 0, reapMaxGas+1)))
-	for i := uint64(1); i < 4; i++ {
-		require.NoError(t, rl.PushEVMTx(testEVMTx(t, key, i, 21000)))
-	}
-
-	require.Empty(t, rl.Reap(0, reapMaxGas))
-	require.Len(t, rl.Reap(0, 0), 4, "uncapped Reap returns all queued txs")
-}
-
 func TestEncodingFailure(t *testing.T) {
 	key, err := crypto.GenerateKey()
 	require.NoError(t, err)

--- a/mempool/rechecker.go
+++ b/mempool/rechecker.go
@@ -15,7 +15,6 @@ import (
 
 type TxConverter interface {
 	EVMTxToCosmosTx(tx *ethtypes.Transaction) (sdk.Tx, error)
-	CosmosTx(tx sdk.Tx) ([]byte, error)
 }
 
 // TxRechecker runs recheckFn on pending and queued txs in the pool, given an
@@ -68,9 +67,6 @@ func (r *TxRechecker) RecheckEVM(ctx sdk.Context, tx *ethtypes.Transaction) (sdk
 	if err != nil {
 		return sdk.Context{}, fmt.Errorf("converting evm tx %s to cosmos tx: %w", tx.Hash(), err)
 	}
-	if err := r.checkMaxBytes(ctx, cosmosTx); err != nil {
-		return ctx, err
-	}
 	return r.anteHandler(ctx, cosmosTx, false)
 }
 
@@ -79,32 +75,7 @@ func (r *TxRechecker) RecheckEVM(ctx sdk.Context, tx *ethtypes.Transaction) (sdk
 //
 // NOTE: This function is not thread safe with itself or any other Rechecker functions.
 func (r *TxRechecker) RecheckCosmos(ctx sdk.Context, tx sdk.Tx) (sdk.Context, error) {
-	if err := r.checkMaxBytes(ctx, tx); err != nil {
-		return ctx, err
-	}
 	return r.anteHandler(ctx, tx, false)
-}
-
-// checkMaxBytes rejects txs whose encoded size exceeds the current
-// consensus MaxBytes. Comet enforces this at admission, but pool txs are
-// not re-evaluated when gov lowers MaxBytes — without this check, an
-// oversized tx wedges the head of the reap list.
-//
-// TODO: belongs in the cosmos ante alongside the gas-wanted check; living
-// here for now to avoid the DeliverTx-skip gate the ante version needs.
-func (r *TxRechecker) checkMaxBytes(ctx sdk.Context, tx sdk.Tx) error {
-	cp := ctx.ConsensusParams()
-	if cp.Block == nil || cp.Block.MaxBytes <= 0 {
-		return nil
-	}
-	bz, err := r.txConverter.CosmosTx(tx)
-	if err != nil {
-		return fmt.Errorf("encoding tx for size check: %w", err)
-	}
-	if int64(len(bz)) > cp.Block.MaxBytes {
-		return fmt.Errorf("tx size %d exceeds block max bytes %d", len(bz), cp.Block.MaxBytes)
-	}
-	return nil
 }
 
 // Update updates the base context for rechecks based on the latest chain

--- a/mempool/txpool/legacypool/legacypool_test.go
+++ b/mempool/txpool/legacypool/legacypool_test.go
@@ -51,7 +51,9 @@ import (
 	"github.com/cosmos/evm/mempool/txpool"
 )
 
-// minimal tx encoder to construct a reap list during testing
+// testTxEncoder is a stub for legacypool tests that don't exercise size.
+// CosmosTx returns (nil, nil) — don't reuse for tests that exercise the
+// reaplist's bytes axis.
 type testTxEncoder struct{}
 
 func (testTxEncoder) EVMTx(tx *types.Transaction) ([]byte, error) {
@@ -59,19 +61,6 @@ func (testTxEncoder) EVMTx(tx *types.Transaction) ([]byte, error) {
 }
 
 func (testTxEncoder) CosmosTx(sdk.Tx) ([]byte, error) { return nil, nil }
-
-// realSizeTxEncoder produces a payload sized to match tx.Size().
-type realSizeTxEncoder struct{}
-
-func (realSizeTxEncoder) EVMTx(tx *types.Transaction) ([]byte, error) {
-	out := make([]byte, tx.Size())
-	copy(out, tx.Hash().Bytes())
-	return out, nil
-}
-
-func (realSizeTxEncoder) CosmosTx(sdk.Tx) ([]byte, error) {
-	return nil, errors.New("EVM-only test encoder")
-}
 
 var (
 	// testTxPoolConfig is a transaction pool configuration without stateful disk
@@ -1529,185 +1518,6 @@ func TestAllowedTxSize(t *testing.T) {
 	if err := validatePoolInternals(pool); err != nil {
 		t.Fatalf("pool internal state corrupted: %v", err)
 	}
-}
-
-// TestOversizedTxNotInReapList: txs rejected at validation (size > txMaxSize
-// or gas > head.GasLimit) never reach the reap list — the invariant that
-// lets us treat the reap list as bounded by upstream pool capacity.
-func TestOversizedTxNotInReapList(t *testing.T) {
-	t.Parallel()
-
-	const blockGasLimit = uint64(10_000_000)
-
-	statedb, _ := state.New(types.EmptyRootHash, state.NewDatabaseForTesting())
-	blockchain := newTestBlockChain(params.TestChainConfig, blockGasLimit, statedb, new(event.Feed))
-
-	rl := reaplist.New(testTxEncoder{})
-	rechecker := &MockRechecker{}
-	pool := New(testTxPoolConfig, log.NewNopLogger(), blockchain, rl, txtracker.New(), WithRecheck(rechecker))
-	if err := pool.Init(testTxPoolConfig.PriceLimit, blockchain.CurrentBlock(), newReserver()); err != nil {
-		t.Fatal(err)
-	}
-	<-pool.initDoneCh
-	defer pool.Close()
-
-	key, _ := crypto.GenerateKey()
-	account := crypto.PubkeyToAddress(key.PublicKey)
-	testAddBalance(pool, account, big.NewInt(1_000_000_000_000))
-
-	// Bytes axis: tx whose encoded size exceeds txMaxSize.
-	const oversizedDataLength = txMaxSize + 1
-	oversizedBytes := pricedDataTransaction(0, blockGasLimit, big.NewInt(1), key, oversizedDataLength)
-	if uint64(oversizedBytes.Size()) <= txMaxSize {
-		t.Fatalf("test setup: expected tx size > txMaxSize, got %d", oversizedBytes.Size())
-	}
-	if err := pool.addRemoteSync(oversizedBytes); err == nil {
-		t.Fatal("expected oversized-bytes tx to be rejected")
-	}
-
-	// Gas axis: tx whose gas exceeds head.GasLimit.
-	oversizedGas := pricedTransaction(0, blockGasLimit+1, big.NewInt(1), key)
-	if err := pool.addRemoteSync(oversizedGas); err == nil {
-		t.Fatal("expected oversized-gas tx to be rejected")
-	}
-
-	// Neither rejection should leak into the reap list.
-	if got := rl.Reap(0, 0); len(got) != 0 {
-		t.Fatalf("rejected tx leaked into reap list: got %d entries", len(got))
-	}
-}
-
-// TestGovMaxGasReductionWedgeAndHeal: a tx is admitted under high MaxGas;
-// gov reduces MaxGas below it; Reap wedges; the next runReorg re-runs the
-// ante (mocked here to fail on gas-over-limit, matching the production
-// ante's gas-wanted check), drops the tx, and clears the reap list.
-func TestGovMaxGasReductionWedgeAndHeal(t *testing.T) {
-	t.Parallel()
-
-	const initialGasLimit = uint64(10_000_000)
-	const reducedGasLimit = uint64(4_000_000)
-	const txGas = uint64(8_000_000) // valid initially, oversized after reduction
-
-	statedb, _ := state.New(types.EmptyRootHash, state.NewDatabaseForTesting())
-	blockchain := newTestBlockChain(params.TestChainConfig, initialGasLimit, statedb, new(event.Feed))
-
-	rl := reaplist.New(testTxEncoder{})
-	rechecker := &MockRechecker{}
-	rechecker.SetRecheck(func(ctx sdk.Context, tx *types.Transaction) (sdk.Context, error) {
-		if tx.Gas() > blockchain.gasLimit.Load() {
-			return ctx, fmt.Errorf("tx gas %d exceeds block max gas %d", tx.Gas(), blockchain.gasLimit.Load())
-		}
-		return ctx, nil
-	})
-
-	pool := New(testTxPoolConfig, log.NewNopLogger(), blockchain, rl, txtracker.New(), WithRecheck(rechecker))
-	if err := pool.Init(testTxPoolConfig.PriceLimit, blockchain.CurrentBlock(), newReserver()); err != nil {
-		t.Fatal(err)
-	}
-	<-pool.initDoneCh
-	defer pool.Close()
-
-	key, _ := crypto.GenerateKey()
-	addr := crypto.PubkeyToAddress(key.PublicKey)
-	testAddBalance(pool, addr, big.NewInt(1_000_000_000_000))
-
-	wedger := pricedTransaction(0, txGas, big.NewInt(1), key)
-	if err := pool.addRemoteSync(wedger); err != nil {
-		t.Fatalf("admit wedger: %v", err)
-	}
-	require.True(t, pool.Has(wedger.Hash()), "precondition: pool has wedger")
-
-	blockchain.gasLimit.Store(reducedGasLimit)
-
-	if got := rl.Reap(0, reducedGasLimit); len(got) != 0 {
-		t.Fatalf("expected wedge: Reap returned %d txs", len(got))
-	}
-	require.True(t, pool.Has(wedger.Hash()), "wedger still pool-resident pre-heal")
-
-	<-pool.requestReset(nil, nil)
-
-	require.False(t, pool.Has(wedger.Hash()), "wedger evicted from pool after reorg")
-	if got := rl.Reap(0, reducedGasLimit); len(got) != 0 {
-		t.Fatalf("self-heal incomplete: reap list still has %d entries", len(got))
-	}
-
-	// State nonce never advanced; reuse nonce 0 for the post-heal tx.
-	healthy := pricedTransaction(0, 3_000_000, big.NewInt(1), key)
-	if err := pool.addRemoteSync(healthy); err != nil {
-		t.Fatalf("admit healthy tx: %v", err)
-	}
-	require.Len(t, rl.Reap(0, reducedGasLimit), 1, "post-heal: healthy tx reaps under the new limit")
-}
-
-// TestGovMaxBytesReductionWedgeAndHeal: bytes-axis counterpart to the gas
-// test. Production size check lives in TxRechecker.checkMaxBytes; the
-// MockRechecker here mirrors the same condition.
-func TestGovMaxBytesReductionWedgeAndHeal(t *testing.T) {
-	t.Parallel()
-
-	const initialMaxBytes = uint64(100_000)
-	const reducedMaxBytes = uint64(1_000)
-	const wedgerDataLength = uint64(4_000) // tx.Size ~= 4_100 bytes
-
-	statedb, _ := state.New(types.EmptyRootHash, state.NewDatabaseForTesting())
-	blockchain := newTestBlockChain(params.TestChainConfig, 10_000_000, statedb, new(event.Feed))
-
-	// Stand-in for ctx.ConsensusParams().Block.MaxBytes that the production
-	// rechecker reads.
-	currentMaxBytes := atomic.Uint64{}
-	currentMaxBytes.Store(initialMaxBytes)
-
-	rl := reaplist.New(realSizeTxEncoder{})
-	rechecker := &MockRechecker{}
-	rechecker.SetRecheck(func(ctx sdk.Context, tx *types.Transaction) (sdk.Context, error) {
-		if uint64(tx.Size()) > currentMaxBytes.Load() {
-			return ctx, fmt.Errorf("tx size %d exceeds max bytes %d", tx.Size(), currentMaxBytes.Load())
-		}
-		return ctx, nil
-	})
-
-	pool := New(testTxPoolConfig, log.NewNopLogger(), blockchain, rl, txtracker.New(), WithRecheck(rechecker))
-	if err := pool.Init(testTxPoolConfig.PriceLimit, blockchain.CurrentBlock(), newReserver()); err != nil {
-		t.Fatal(err)
-	}
-	<-pool.initDoneCh
-	defer pool.Close()
-
-	key, _ := crypto.GenerateKey()
-	addr := crypto.PubkeyToAddress(key.PublicKey)
-	testAddBalance(pool, addr, big.NewInt(1_000_000_000_000))
-
-	wedger := pricedDataTransaction(0, blockchain.gasLimit.Load(), big.NewInt(1), key, wedgerDataLength)
-	if uint64(wedger.Size()) <= reducedMaxBytes {
-		t.Fatalf("test setup: wedger size %d must exceed reducedMaxBytes %d", wedger.Size(), reducedMaxBytes)
-	}
-	if err := pool.addRemoteSync(wedger); err != nil {
-		t.Fatalf("admit wedger: %v", err)
-	}
-	require.True(t, pool.Has(wedger.Hash()), "precondition: pool has wedger")
-
-	currentMaxBytes.Store(reducedMaxBytes)
-
-	if got := rl.Reap(reducedMaxBytes, 0); len(got) != 0 {
-		t.Fatalf("expected wedge: Reap returned %d txs", len(got))
-	}
-	require.True(t, pool.Has(wedger.Hash()), "wedger still pool-resident pre-heal")
-
-	<-pool.requestReset(nil, nil)
-
-	require.False(t, pool.Has(wedger.Hash()), "wedger evicted from pool after reorg")
-	if got := rl.Reap(reducedMaxBytes, 0); len(got) != 0 {
-		t.Fatalf("self-heal incomplete: reap list still has %d entries", len(got))
-	}
-
-	healthy := pricedTransaction(0, blockchain.gasLimit.Load(), big.NewInt(1), key)
-	if uint64(healthy.Size()) > reducedMaxBytes {
-		t.Fatalf("test setup: healthy size %d must fit reducedMaxBytes %d", healthy.Size(), reducedMaxBytes)
-	}
-	if err := pool.addRemoteSync(healthy); err != nil {
-		t.Fatalf("admit healthy tx: %v", err)
-	}
-	require.Len(t, rl.Reap(reducedMaxBytes, 0), 1, "post-heal: healthy tx reaps under the new limit")
 }
 
 // Tests that if transactions start being capped, transactions are also removed from 'all'

--- a/server/server_app_options.go
+++ b/server/server_app_options.go
@@ -9,11 +9,11 @@ import (
 	"github.com/holiman/uint256"
 	"github.com/spf13/cast"
 
+	cmtcfg "github.com/cometbft/cometbft/config"
+
 	evmmempool "github.com/cosmos/evm/mempool"
 	"github.com/cosmos/evm/mempool/txpool/legacypool"
 	srvflags "github.com/cosmos/evm/server/flags"
-
-	cmtcfg "github.com/cometbft/cometbft/config"
 
 	"cosmossdk.io/log/v2"
 
@@ -46,7 +46,7 @@ func ValidateReapBounds(appOpts servertypes.AppOptions, blockGasLimit uint64) er
 	// admission limit is 1 MiB.
 	maxTxBytes := cast.ToUint64(appOpts.Get(cmtMempoolMaxTxBytesKey))
 	if maxTxBytes == 0 {
-		maxTxBytes = uint64(cmtcfg.DefaultMempoolConfig().MaxTxBytes)
+		maxTxBytes = uint64(cmtcfg.DefaultMempoolConfig().MaxTxBytes) // #nosec G115 -- comet default is positive (1 MiB)
 	}
 	reapMaxBytes := cast.ToUint64(appOpts.Get(cmtMempoolReapMaxBytesKey))
 	reapMaxGas := cast.ToUint64(appOpts.Get(cmtMempoolReapMaxGasKey))

--- a/server/server_app_options.go
+++ b/server/server_app_options.go
@@ -13,6 +13,8 @@ import (
 	"github.com/cosmos/evm/mempool/txpool/legacypool"
 	srvflags "github.com/cosmos/evm/server/flags"
 
+	cmtcfg "github.com/cometbft/cometbft/config"
+
 	"cosmossdk.io/log/v2"
 
 	"github.com/cosmos/cosmos-sdk/client/flags"
@@ -38,7 +40,14 @@ func ValidateReapBounds(appOpts servertypes.AppOptions, blockGasLimit uint64) er
 		return nil
 	}
 
+	// Fall back to Comet's default when max_tx_bytes is missing or 0 — viper
+	// returns nil for an absent key, cast.ToUint64(nil) is 0, and a 0 cap
+	// would silently bypass the comparison even though Comet's effective
+	// admission limit is 1 MiB.
 	maxTxBytes := cast.ToUint64(appOpts.Get(cmtMempoolMaxTxBytesKey))
+	if maxTxBytes == 0 {
+		maxTxBytes = uint64(cmtcfg.DefaultMempoolConfig().MaxTxBytes)
+	}
 	reapMaxBytes := cast.ToUint64(appOpts.Get(cmtMempoolReapMaxBytesKey))
 	reapMaxGas := cast.ToUint64(appOpts.Get(cmtMempoolReapMaxGasKey))
 

--- a/server/server_app_options.go
+++ b/server/server_app_options.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"fmt"
 	"math"
 	"path/filepath"
 	"time"
@@ -21,6 +22,42 @@ import (
 	sdkmempool "github.com/cosmos/cosmos-sdk/types/mempool"
 	genutiltypes "github.com/cosmos/cosmos-sdk/x/genutil/types"
 )
+
+const (
+	cmtMempoolMaxTxBytesKey   = "mempool.max_tx_bytes"
+	cmtMempoolReapMaxBytesKey = "mempool.reap_max_bytes"
+	cmtMempoolReapMaxGasKey   = "mempool.reap_max_gas"
+)
+
+// ValidateReapBounds errors when an admission cap exceeds the matching reap
+// cap. A tx admitted via CheckTx that's larger than reap_max_bytes (or whose
+// gas exceeds reap_max_gas) would wedge the head of the reap list. A zero reap
+// cap means "no limit" on Comet's side — skip.
+func ValidateReapBounds(appOpts servertypes.AppOptions, blockGasLimit uint64) error {
+	if appOpts == nil {
+		return nil
+	}
+
+	maxTxBytes := cast.ToUint64(appOpts.Get(cmtMempoolMaxTxBytesKey))
+	reapMaxBytes := cast.ToUint64(appOpts.Get(cmtMempoolReapMaxBytesKey))
+	reapMaxGas := cast.ToUint64(appOpts.Get(cmtMempoolReapMaxGasKey))
+
+	if reapMaxBytes > 0 && maxTxBytes > reapMaxBytes {
+		return fmt.Errorf(
+			"mempool.max_tx_bytes (%d) must be <= mempool.reap_max_bytes (%d): "+
+				"a tx admitted via CheckTx that exceeds reap_max_bytes would wedge the reap list",
+			maxTxBytes, reapMaxBytes,
+		)
+	}
+	if reapMaxGas > 0 && blockGasLimit > reapMaxGas {
+		return fmt.Errorf(
+			"genesis consensus block.max_gas (%d) must be <= mempool.reap_max_gas (%d): "+
+				"a tx admitted with gas up to block.max_gas that exceeds reap_max_gas would wedge the reap list",
+			blockGasLimit, reapMaxGas,
+		)
+	}
+	return nil
+}
 
 // ResolveMempoolConfig resolves the mempool configuration from the app options.
 func ResolveMempoolConfig(anteHandler sdk.AnteHandler, appOpts servertypes.AppOptions, logger log.Logger) *evmmempool.Config {

--- a/server/server_app_options_test.go
+++ b/server/server_app_options_test.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	cmtcfg "github.com/cometbft/cometbft/config"
+
 	"cosmossdk.io/log/v2"
 	sdkmath "cosmossdk.io/math"
 
@@ -334,23 +336,26 @@ func createInvalidGenesis(t *testing.T) string {
 func TestValidateReapBounds(t *testing.T) {
 	t.Parallel()
 
+	cometDefaultMaxTxBytes := uint64(cmtcfg.DefaultMempoolConfig().MaxTxBytes)
+
 	tests := []struct {
-		name          string
-		maxTxBytes    uint64
-		reapMaxBytes  uint64
-		reapMaxGas    uint64
-		blockGasLimit uint64
-		wantErr       string
+		name             string
+		omitMaxTxBytes   bool
+		maxTxBytes       uint64
+		reapMaxBytes     uint64
+		reapMaxGas       uint64
+		blockGasLimit    uint64
+		nilOpts          bool
+		wantErr          string
 	}{
 		{
 			name:    "nil app options is a no-op",
-			wantErr: "",
+			nilOpts: true,
 		},
 		{
 			name:          "default reap caps (zero) accept any admission caps",
 			maxTxBytes:    1 << 20,
 			blockGasLimit: 100_000_000,
-			wantErr:       "",
 		},
 		{
 			name:          "max_tx_bytes equal to reap_max_bytes is allowed",
@@ -358,7 +363,6 @@ func TestValidateReapBounds(t *testing.T) {
 			reapMaxBytes:  500_000,
 			blockGasLimit: 100_000,
 			reapMaxGas:    100_000,
-			wantErr:       "",
 		},
 		{
 			name:         "max_tx_bytes above reap_max_bytes is rejected",
@@ -380,6 +384,13 @@ func TestValidateReapBounds(t *testing.T) {
 			reapMaxGas:    50_000_000,
 			wantErr:       "mempool.max_tx_bytes",
 		},
+		{
+			// Greptile P1: viper read returning 0 must not silently bypass the check.
+			name:           "missing max_tx_bytes falls back to comet default and is rejected against a smaller reap cap",
+			omitMaxTxBytes: true,
+			reapMaxBytes:   cometDefaultMaxTxBytes - 1,
+			wantErr:        fmt.Sprintf("mempool.max_tx_bytes (%d) must be", cometDefaultMaxTxBytes),
+		},
 	}
 
 	for _, tc := range tests {
@@ -387,9 +398,11 @@ func TestValidateReapBounds(t *testing.T) {
 			t.Parallel()
 
 			var opts servertypes.AppOptions
-			if tc.name != "nil app options is a no-op" {
+			if !tc.nilOpts {
 				m := newMockAppOptions()
-				m.Set(cmtMempoolMaxTxBytesKey, tc.maxTxBytes)
+				if !tc.omitMaxTxBytes {
+					m.Set(cmtMempoolMaxTxBytesKey, tc.maxTxBytes)
+				}
 				m.Set(cmtMempoolReapMaxBytesKey, tc.reapMaxBytes)
 				m.Set(cmtMempoolReapMaxGasKey, tc.reapMaxGas)
 				opts = m

--- a/server/server_app_options_test.go
+++ b/server/server_app_options_test.go
@@ -336,17 +336,17 @@ func createInvalidGenesis(t *testing.T) string {
 func TestValidateReapBounds(t *testing.T) {
 	t.Parallel()
 
-	cometDefaultMaxTxBytes := uint64(cmtcfg.DefaultMempoolConfig().MaxTxBytes)
+	cometDefaultMaxTxBytes := uint64(cmtcfg.DefaultMempoolConfig().MaxTxBytes) // #nosec G115 -- comet default is positive (1 MiB)
 
 	tests := []struct {
-		name             string
-		omitMaxTxBytes   bool
-		maxTxBytes       uint64
-		reapMaxBytes     uint64
-		reapMaxGas       uint64
-		blockGasLimit    uint64
-		nilOpts          bool
-		wantErr          string
+		name           string
+		omitMaxTxBytes bool
+		maxTxBytes     uint64
+		reapMaxBytes   uint64
+		reapMaxGas     uint64
+		blockGasLimit  uint64
+		nilOpts        bool
+		wantErr        string
 	}{
 		{
 			name:    "nil app options is a no-op",

--- a/server/server_app_options_test.go
+++ b/server/server_app_options_test.go
@@ -330,3 +330,78 @@ func createInvalidGenesis(t *testing.T) string {
 
 	return tempDir
 }
+
+func TestValidateReapBounds(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		maxTxBytes    uint64
+		reapMaxBytes  uint64
+		reapMaxGas    uint64
+		blockGasLimit uint64
+		wantErr       string
+	}{
+		{
+			name:    "nil app options is a no-op",
+			wantErr: "",
+		},
+		{
+			name:          "default reap caps (zero) accept any admission caps",
+			maxTxBytes:    1 << 20,
+			blockGasLimit: 100_000_000,
+			wantErr:       "",
+		},
+		{
+			name:          "max_tx_bytes equal to reap_max_bytes is allowed",
+			maxTxBytes:    500_000,
+			reapMaxBytes:  500_000,
+			blockGasLimit: 100_000,
+			reapMaxGas:    100_000,
+			wantErr:       "",
+		},
+		{
+			name:         "max_tx_bytes above reap_max_bytes is rejected",
+			maxTxBytes:   1 << 20,
+			reapMaxBytes: 500_000,
+			wantErr:      "mempool.max_tx_bytes (1048576) must be <= mempool.reap_max_bytes (500000)",
+		},
+		{
+			name:          "block_gas_limit above reap_max_gas is rejected",
+			blockGasLimit: 100_000_000,
+			reapMaxGas:    50_000_000,
+			wantErr:       "genesis consensus block.max_gas (100000000) must be <= mempool.reap_max_gas (50000000)",
+		},
+		{
+			name:          "bytes-axis fires before gas-axis when both are misconfigured",
+			maxTxBytes:    1 << 20,
+			reapMaxBytes:  500_000,
+			blockGasLimit: 100_000_000,
+			reapMaxGas:    50_000_000,
+			wantErr:       "mempool.max_tx_bytes",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var opts servertypes.AppOptions
+			if tc.name != "nil app options is a no-op" {
+				m := newMockAppOptions()
+				m.Set(cmtMempoolMaxTxBytesKey, tc.maxTxBytes)
+				m.Set(cmtMempoolReapMaxBytesKey, tc.reapMaxBytes)
+				m.Set(cmtMempoolReapMaxGasKey, tc.reapMaxGas)
+				opts = m
+			}
+
+			err := ValidateReapBounds(opts, tc.blockGasLimit)
+			if tc.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tc.wantErr)
+		})
+	}
+}


### PR DESCRIPTION
Removes max bytes check from the rechecker and instead checks for the misconfigured reaplist on startup. One caveat is that governance can potentially set the max gas to be higher than a node's reap max gas, but this is an edge case that we don't expect will be a problem. Can be resolved via a node restart with higher settings in that case.