### PR TITLE
chore(mempool): add systemtests demonstrating a same-nonce 7702 auth and cosmos tx

### DIFF
--- a/tests/systemtests/accountabstraction/test_eip7702_same_block.go
+++ b/tests/systemtests/accountabstraction/test_eip7702_same_block.go
@@ -88,10 +88,8 @@ func RunEIP7702SameBlock(t *testing.T, base *suite.BaseTestSuite) {
 				strings.Contains(strings.ToLower(bankRes.log), "nonce"),
 			"expected sequence/nonce error in bank log, got: %s", bankRes.log)
 
-		t.Logf("SetCode-first: block=%d delegation=installed bankCode=%d log=%q",
-			receipt.BlockNumber.Uint64(), bankRes.code, bankRes.log)
-	})
-
+		setCodeTip := uint256.MustFromBig(new(big.Int).Mul(baseFee, big.NewInt(1)))
+		setCodeFeeCap := uint256.MustFromBig(new(big.Int).Mul(baseFee, big.NewInt(10)))
 	// Bank-first: bias the bank tx's tip so the proposer iterator emits
 	// it before the SetCode tx inside the same block.
 	t.Run("Bank-first execution: bank commits, auth silently skipped, no delegation", func(t *testing.T) {

--- a/tests/systemtests/accountabstraction/test_eip7702_same_block.go
+++ b/tests/systemtests/accountabstraction/test_eip7702_same_block.go
@@ -88,8 +88,10 @@ func RunEIP7702SameBlock(t *testing.T, base *suite.BaseTestSuite) {
 				strings.Contains(strings.ToLower(bankRes.log), "nonce"),
 			"expected sequence/nonce error in bank log, got: %s", bankRes.log)
 
-		setCodeTip := uint256.MustFromBig(new(big.Int).Mul(baseFee, big.NewInt(1)))
-		setCodeFeeCap := uint256.MustFromBig(new(big.Int).Mul(baseFee, big.NewInt(10)))
+		t.Logf("SetCode-first: block=%d delegation=installed bankCode=%d log=%q",
+			receipt.BlockNumber.Uint64(), bankRes.code, bankRes.log)
+	})
+
 	// Bank-first: bias the bank tx's tip so the proposer iterator emits
 	// it before the SetCode tx inside the same block.
 	t.Run("Bank-first execution: bank commits, auth silently skipped, no delegation", func(t *testing.T) {
@@ -98,7 +100,10 @@ func RunEIP7702SameBlock(t *testing.T, base *suite.BaseTestSuite) {
 		counterAddr := s.GetCounterAddr()
 		baseFee := s.GasPriceMultiplier(1)
 		setCodeTip := uint256.MustFromBig(new(big.Int).Mul(baseFee, big.NewInt(1)))
-		setCodeFeeCap := uint256.MustFromBig(new(big.Int).Mul(baseFee, big.NewInt(2)))
+		// 10× base fee absorbs any drift between GetLatestBaseFee and inclusion
+		// so the SetCode tx still passes its fee cap check when the iterator
+		// emits it after the bank tx.
+		setCodeFeeCap := uint256.MustFromBig(new(big.Int).Mul(baseFee, big.NewInt(10)))
 		bankPrice := new(big.Int).Mul(baseFee, big.NewInt(100))
 
 		receipt, bankRes := submitSameBlock(t, s, relayerID, userID, counterAddr, setCodeTip, setCodeFeeCap, bankPrice)

--- a/tests/systemtests/accountabstraction/test_eip7702_same_block.go
+++ b/tests/systemtests/accountabstraction/test_eip7702_same_block.go
@@ -1,0 +1,206 @@
+//go:build system_test
+
+package accountabstraction
+
+import (
+	"context"
+	"math/big"
+	"strings"
+	"testing"
+	"time"
+
+	sdkmath "cosmossdk.io/math"
+
+	"github.com/ethereum/go-ethereum/common"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/holiman/uint256"
+
+	"github.com/onsi/gomega"
+	"github.com/stretchr/testify/require"
+
+	suite "github.com/cosmos/evm/tests/systemtests/suite"
+)
+
+// RunEIP7702SameBlock tests an EIP-7702 SetCode tx (relayer-sent, user as
+// authority at nonce N) and a user-signed Cosmos bank send at sequence N
+// landing in the same block. Both block-internal orderings are exercised:
+//
+//   - SetCode-first: delegation installed; bank included-as-failed.
+//   - Bank-first: bank commits; SetCode's auth silently skipped; no delegation.
+func RunEIP7702SameBlock(t *testing.T, base *suite.BaseTestSuite) {
+	gomega.RegisterTestingT(t)
+
+	s := NewTestSuite(base)
+	s.SetupTestWithTimeoutCommit(t, 8*time.Second)
+
+	relayer := s.BaseTestSuite.Acc(0)
+	user := s.BaseTestSuite.Acc(1)
+	s.SetPrimaryAccount(relayer)
+	relayerID := relayer.ID
+	userID := user.ID
+
+	fee, err := s.GetLatestBaseFee("node0")
+	require.NoError(t, err)
+	s.SetBaseFee(fee)
+
+	cleanupDelegation := func(t *testing.T) {
+		ctx := context.Background()
+		code, err := s.EthClient.Clients["node0"].CodeAt(ctx, s.GetAddr(userID), nil)
+		require.NoError(t, err)
+		if len(code) == 0 {
+			return
+		}
+		auth := createSetCodeAuthorization(s.GetChainID(), s.GetNonce(userID)+1, common.Address{})
+		signed, err := signSetCodeAuthorization(s.GetPrivKey(userID), auth)
+		require.NoError(t, err)
+		txHash, err := s.SendSetCodeTx(userID, signed)
+		require.NoError(t, err, "cleanup SetCode failed")
+		s.WaitForCommit(txHash)
+	}
+
+	// SetCode-first: bias the SetCode tx's tip so the proposer iterator
+	// emits it before the bank tx inside the same block.
+	t.Run("SetCode-first execution: delegation installed, bank included-as-failed", func(t *testing.T) {
+		t.Cleanup(func() { cleanupDelegation(t) })
+
+		counterAddr := s.GetCounterAddr()
+		baseFee := s.GasPriceMultiplier(1)
+		setCodeTip := uint256.MustFromBig(new(big.Int).Mul(baseFee, big.NewInt(100)))
+		setCodeFeeCap := new(uint256.Int).Mul(setCodeTip, uint256.NewInt(2))
+		bankPrice := new(big.Int).Mul(baseFee, big.NewInt(2))
+
+		receipt, bankRes := submitSameBlock(t, s, relayerID, userID, counterAddr, setCodeTip, setCodeFeeCap, bankPrice)
+
+		require.Equal(t, uint64(1), receipt.Status, "outer SetCode tx must be accepted")
+
+		ctx := context.Background()
+		code, err := s.EthClient.Clients["node0"].CodeAt(ctx, s.GetAddr(userID), nil)
+		require.NoError(t, err)
+		require.Equal(t, 23, len(code), "delegation must be installed; got code length %d", len(code))
+		resolved, ok := ethtypes.ParseDelegation(code)
+		require.True(t, ok)
+		require.Equal(t, counterAddr, resolved)
+
+		require.NotZero(t, bankRes.code,
+			"bank must be included-as-failed; got code=%d log=%q", bankRes.code, bankRes.log)
+		require.True(t,
+			strings.Contains(strings.ToLower(bankRes.log), "sequence") ||
+				strings.Contains(strings.ToLower(bankRes.log), "nonce"),
+			"expected sequence/nonce error in bank log, got: %s", bankRes.log)
+
+		t.Logf("SetCode-first: block=%d delegation=installed bankCode=%d log=%q",
+			receipt.BlockNumber.Uint64(), bankRes.code, bankRes.log)
+	})
+
+	// Bank-first: bias the bank tx's tip so the proposer iterator emits
+	// it before the SetCode tx inside the same block.
+	t.Run("Bank-first execution: bank commits, auth silently skipped, no delegation", func(t *testing.T) {
+		t.Cleanup(func() { cleanupDelegation(t) })
+
+		counterAddr := s.GetCounterAddr()
+		baseFee := s.GasPriceMultiplier(1)
+		setCodeTip := uint256.MustFromBig(new(big.Int).Mul(baseFee, big.NewInt(1)))
+		setCodeFeeCap := uint256.MustFromBig(new(big.Int).Mul(baseFee, big.NewInt(2)))
+		bankPrice := new(big.Int).Mul(baseFee, big.NewInt(100))
+
+		receipt, bankRes := submitSameBlock(t, s, relayerID, userID, counterAddr, setCodeTip, setCodeFeeCap, bankPrice)
+
+		require.Equal(t, uint64(1), receipt.Status, "outer SetCode tx must be accepted")
+
+		ctx := context.Background()
+		code, err := s.EthClient.Clients["node0"].CodeAt(ctx, s.GetAddr(userID), nil)
+		require.NoError(t, err)
+		require.Equal(t, 0, len(code), "no delegation should be installed when auth was silently skipped")
+
+		require.Zero(t, bankRes.code,
+			"bank must commit normally; got code=%d log=%q", bankRes.code, bankRes.log)
+
+		t.Logf("Bank-first: block=%d delegation=absent bankCode=%d", receipt.BlockNumber.Uint64(), bankRes.code)
+	})
+}
+
+type bankCommitResult struct {
+	height int64
+	code   uint32
+	log    string
+}
+
+// submitSameBlock submits a relayer-sent SetCode tx (user as authority at the
+// user's current nonce N), waits for it to reach every validator's legacypool
+// pending list, then submits a user-signed bank tx at the same sequence N.
+// Asserts both land in the same block.
+func submitSameBlock(
+	t *testing.T,
+	s *TestSuite,
+	relayerID, userID string,
+	counterAddr common.Address,
+	setCodeTip, setCodeFeeCap *uint256.Int,
+	bankPrice *big.Int,
+) (*ethtypes.Receipt, bankCommitResult) {
+	t.Helper()
+
+	contested := s.GetNonce(userID)
+
+	auth := createSetCodeAuthorization(s.GetChainID(), contested, counterAddr)
+	signedAuth, err := signSetCodeAuthorization(s.GetPrivKey(userID), auth)
+	require.NoError(t, err)
+
+	s.AwaitNBlocks(t, 1)
+
+	setCodeHash, err := s.SendSetCodeTxWithFees(relayerID, setCodeTip, setCodeFeeCap, signedAuth)
+	require.NoError(t, err, "failed to broadcast SetCode tx")
+
+	// Wait for SetCode to be in pending on every validator before submitting bank.
+	require.Eventually(t, func() bool {
+		for i := 0; i < 4; i++ {
+			pending, _, err := s.TxPoolContent(s.Node(i), suite.TxTypeEVM, 5*time.Second)
+			if err != nil {
+				return false
+			}
+			found := false
+			for _, h := range pending {
+				if h == setCodeHash.Hex() {
+					found = true
+					break
+				}
+			}
+			if !found {
+				return false
+			}
+		}
+		return true
+	}, 30*time.Second, 500*time.Millisecond,
+		"SetCode tx failed to gossip into every validator's legacypool pending")
+
+	// Bank at the same sequence as the auth.
+	userCosmosAcc := s.CosmosAccount(userID)
+	toAcc := s.CosmosAccount(s.AccID(2))
+	bankResp, err := s.CosmosClient.BankSend(
+		"node0",
+		userCosmosAcc,
+		userCosmosAcc.AccAddress,
+		toAcc.AccAddress,
+		sdkmath.NewInt(1000),
+		contested,
+		bankPrice,
+	)
+	require.NoError(t, err, "BankSend RPC call should not error")
+	require.NotNil(t, bankResp)
+	require.Zero(t, bankResp.Code,
+		"bank CheckTx must accept; got code=%d raw_log=%q", bankResp.Code, bankResp.RawLog)
+
+	receipt, err := s.EthClient.WaitForCommit("node0", setCodeHash.Hex(), 60*time.Second)
+	require.NoError(t, err, "SetCode never committed")
+	bankRes, err := s.CosmosClient.WaitForCommit("node0", bankResp.TxHash, 60*time.Second)
+	require.NoError(t, err, "bank never committed")
+
+	require.Equal(t, int64(receipt.BlockNumber.Uint64()), bankRes.Height,
+		"SetCode and bank must land in the same block; got SetCode=%d bank=%d",
+		receipt.BlockNumber.Uint64(), bankRes.Height)
+
+	return receipt, bankCommitResult{
+		height: bankRes.Height,
+		code:   bankRes.TxResult.Code,
+		log:    bankRes.TxResult.Log,
+	}
+}

--- a/tests/systemtests/accountabstraction/test_suite.go
+++ b/tests/systemtests/accountabstraction/test_suite.go
@@ -48,7 +48,18 @@ func (s *TestSuite) SetPrimaryAccount(acc *suite.TestAccount) {
 
 // SetupTest setup test suite and deploy test contracts
 func (s *TestSuite) SetupTest(t *testing.T) {
-	s.BaseTestSuite.SetupTest(t)
+	s.setupWithOpts(t)
+}
+
+// SetupTestWithTimeoutCommit is like SetupTest but configures the chain with the
+// supplied timeout_commit so the caller can widen the window for racing two txs
+// into the same block.
+func (s *TestSuite) SetupTestWithTimeoutCommit(t *testing.T, tc time.Duration) {
+	s.setupWithOpts(t, suite.WithTimeoutCommit(tc))
+}
+
+func (s *TestSuite) setupWithOpts(t *testing.T, opts ...suite.TestSetupConfigOption) {
+	s.BaseTestSuite.SetupTest(t, opts...)
 
 	if s.primaryAccountID == "" {
 		s.primaryAccountID = s.AccID(0)
@@ -109,8 +120,14 @@ func (s *TestSuite) GetCounterAddr() common.Address {
 	return s.counterAddress
 }
 
-// SendSetCodeTx sends SetCodeTx
+// SendSetCodeTx sends SetCodeTx with default fees.
 func (s *TestSuite) SendSetCodeTx(accID string, signedAuths ...ethtypes.SetCodeAuthorization) (common.Hash, error) {
+	return s.SendSetCodeTxWithFees(accID, uint256.NewInt(1_000_000), uint256.NewInt(1_000_000_000), signedAuths...)
+}
+
+// SendSetCodeTxWithFees sends a SetCodeTx with explicit fee caps so callers can
+// bias proposer ordering against competing txs.
+func (s *TestSuite) SendSetCodeTxWithFees(accID string, gasTipCap, gasFeeCap *uint256.Int, signedAuths ...ethtypes.SetCodeAuthorization) (common.Hash, error) {
 	ctx := context.Background()
 	ethCli := s.EthClient.Clients["node0"]
 	acc := s.EthAccount(accID)
@@ -133,8 +150,8 @@ func (s *TestSuite) SendSetCodeTx(accID string, signedAuths ...ethtypes.SetCodeA
 	txdata := &ethtypes.SetCodeTx{
 		ChainID:    uint256.MustFromBig(chainID),
 		Nonce:      nonce,
-		GasTipCap:  uint256.NewInt(1_000_000),
-		GasFeeCap:  uint256.NewInt(1_000_000_000),
+		GasTipCap:  gasTipCap,
+		GasFeeCap:  gasFeeCap,
 		Gas:        100_000,
 		To:         common.Address{},
 		Value:      uint256.NewInt(0),

--- a/tests/systemtests/main_test.go
+++ b/tests/systemtests/main_test.go
@@ -76,6 +76,10 @@ func TestAccountAbstractionEIP7702(t *testing.T) {
 	suite.RunWithSharedSuite(t, accountabstraction.RunEIP7702)
 }
 
+func TestAccountAbstractionEIP7702SameBlock(t *testing.T) {
+	suite.RunWithSharedSuite(t, accountabstraction.RunEIP7702SameBlock)
+}
+
 /*
 * Chain Upgrade Tests
  */


### PR DESCRIPTION
Adds test that ensures stability when a 7702 authorization and Cosmos transaction appear for the same nonce. Verifies both orders of inclusion (7702 first and Cosmos first).