### PR TITLE
fix(mempool): Cosmos noop removals & keep future txs after parent's wrong sequence

### DIFF
--- a/mempool/mempool_test.go
+++ b/mempool/mempool_test.go
@@ -435,7 +435,7 @@ func TestMempool_CosmosNonceAdvanceDropsStaleEVM(t *testing.T) {
 	err := mp.RemoveWithReason(context.Background(), cosmosTx, mempooltypes.RemoveReason{
 		Caller: mempooltypes.CallerRunTxFinalize,
 	})
-	require.ErrorIs(t, err, mempooltypes.ErrTxNotFound)
+	require.NoError(t, err)
 
 	// after we finish finalizing the above block, the chain will advance and
 	// the pool will reset

--- a/mempool/recheck_pool.go
+++ b/mempool/recheck_pool.go
@@ -236,12 +236,12 @@ func (m *RecheckMempool) Insert(_ context.Context, tx sdk.Tx) (err error) {
 func (m *RecheckMempool) Remove(tx sdk.Tx) error {
 	// NOTE: processing the removal here produces a subtle bug for cosmos txs
 	// with multiple signers. the underlying mempool here (priority nonce
-	// mempool) identifies txs by only the first signer of mutli signer txs. so
+	// mempool) identifies txs by only the first signer of multi signer txs. so
 	// when we see a tx included in a block (currently the only spot where we
 	// care about remove being called for this mempool) with for example,
 	// signer A at nonce 0, and we have a different tx in the mempool with
 	// signer A at nonce 0 and signer B at nonce 0, removing the tx in the
-	// block with only signer A will remove the tx in the mempool with bother
+	// block with only signer A will remove the tx in the mempool with both
 	// signers A and B. the priority nonce mempool gives us no hook to see what
 	// tx was actually removed. to account for this, we must not remove during
 	// FinalizeBlock, and process the removal during recheck where the multi
@@ -488,10 +488,10 @@ func (m *RecheckMempool) runRecheck(done chan struct{}, newHead *ethtypes.Header
 			// nonce of this tx became too low compared to the chain state. we
 			// rerun ante handlers on insert to this pool, so at insert time,
 			// we know the nonce of the tx was not too high. since nonces only
-			// increase, ErrWrongSequence seen here must mean that the txs
-			// nonce became too low. we do not want to remove this since this
-			// singers tx at nonce+1 may still be valid and at the correct
-			// nonce now.
+			// increase, ErrWrongSequence seen here must mean that the tx's
+			// nonce became too low. we still remove this tx, but we do not
+			// want to cascade and evict the signer's tx at nonce+1 since
+			// that may still be valid at the correct nonce.
 			if errors.Is(err, sdkerrors.ErrWrongSequence) {
 				dropFuturesOnError = false
 			}

--- a/mempool/recheck_pool.go
+++ b/mempool/recheck_pool.go
@@ -2,11 +2,13 @@ package mempool
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/big"
 	"sync"
 	"time"
 
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/ethereum/go-ethereum/common"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/holiman/uint256"
@@ -229,17 +231,29 @@ func (m *RecheckMempool) Insert(_ context.Context, tx sdk.Tx) (err error) {
 	return nil
 }
 
-// Remove removes a transaction from the pool.
+// Remove is a noop for this pool. All removals are processed during the async
+// recheck loop.
 func (m *RecheckMempool) Remove(tx sdk.Tx) error {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	return m.removeLocked(tx)
+	// NOTE: processing the removal here produces a subtle bug for cosmos txs
+	// with multiple signers. the underlying mempool here (priority nonce
+	// mempool) identifies txs by only the first signer of mutli signer txs. so
+	// when we see a tx included in a block (currently the only spot where we
+	// care about remove being called for this mempool) with for example,
+	// signer A at nonce 0, and we have a different tx in the mempool with
+	// signer A at nonce 0 and signer B at nonce 0, removing the tx in the
+	// block with only signer A will remove the tx in the mempool with bother
+	// signers A and B. the priority nonce mempool gives us no hook to see what
+	// tx was actually removed. to account for this, we must not remove during
+	// FinalizeBlock, and process the removal during recheck where the multi
+	// signer tx will be dropped due to a nonce too low error on signer A.
+	// during recheck we know exactly which tx we are removing and why, and can
+	// properly unreserve the signer A's and signer B's address reservations.
+	return nil
 }
 
-// RemoveWithReason removes a transaction from the pool. This must be
-// explicitly defined to prevent Go from promoting the embedded ExtMempool's
-// RemoveWithReason, which would bypass the reserver release logic.
+// RemoveWithReason is a noop for this pool. All removals are processed during
+// the async recheck loop. This must be explicitly defined to prevent Go from
+// promoting the embedded ExtMempool's RemoveWithReason.
 func (m *RecheckMempool) RemoveWithReason(_ context.Context, tx sdk.Tx, _ sdkmempool.RemoveReason) error {
 	return m.Remove(tx)
 }
@@ -272,22 +286,6 @@ func (m *RecheckMempool) unreserveTx(tx sdk.Tx) error {
 	if err := m.reserver.Release(addrs...); err != nil {
 		m.logger.Error("Failed to release reservations (unreserveTx)", "err", err, "addrs", addrs)
 	}
-
-	return nil
-}
-
-// removeLocked removes a tx from the underlying pool and releases the
-// reserver. Caller must hold m.mu.
-func (m *RecheckMempool) removeLocked(tx sdk.Tx) error {
-	if err := m.ExtMempool.Remove(tx); err != nil {
-		return fmt.Errorf("failed to remove tx from mempool: %w", err)
-	}
-
-	if err := m.unreserveTx(tx); err != nil {
-		m.logger.Error("failed to release reservations", "err", err)
-	}
-
-	m.reapList.DropCosmosTx(tx)
 
 	return nil
 }
@@ -474,17 +472,40 @@ func (m *RecheckMempool) runRecheck(done chan struct{}, newHead *ethtypes.Header
 			}
 		}
 
+		dropFuturesOnError := true
 		if !invalidTx {
 			ctx, write := m.rechecker.GetContext()
-			if _, err := m.rechecker.RecheckCosmos(ctx, txn); err == nil {
+			_, err := m.rechecker.RecheckCosmos(ctx, txn)
+			if err == nil {
 				write()
 				m.markTxRechecked(txn)
 				iter = iter.Next()
 				continue
 			}
+
+			// we do not want to drop future txs for a signer if it had a tx
+			// fail due sequence mismatch. a sequence mismatch here means the
+			// nonce of this tx became too low compared to the chain state. we
+			// rerun ante handlers on insert to this pool, so at insert time,
+			// we know the nonce of the tx was not too high. since nonces only
+			// increase, ErrWrongSequence seen here must mean that the txs
+			// nonce became too low. we do not want to remove this since this
+			// singers tx at nonce+1 may still be valid and at the correct
+			// nonce now.
+			if errors.Is(err, sdkerrors.ErrWrongSequence) {
+				dropFuturesOnError = false
+			}
 		}
 
 		removeTxs = append(removeTxs, txn)
+
+		if !dropFuturesOnError {
+			iter = iter.Next()
+			continue
+		}
+
+		// marks all future txs for this txs signers as invalid and we will
+		// drop them before they are even rechecked
 		for _, s := range signers {
 			key := string(s.Signer)
 			if existing, ok := failedAtSequence[key]; !ok || existing > s.Sequence {

--- a/mempool/recheck_pool.go
+++ b/mempool/recheck_pool.go
@@ -8,7 +8,6 @@ import (
 	"sync"
 	"time"
 
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/ethereum/go-ethereum/common"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/holiman/uint256"
@@ -22,6 +21,7 @@ import (
 	"cosmossdk.io/math"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	sdkmempool "github.com/cosmos/cosmos-sdk/types/mempool"
 )
 

--- a/mempool/recheck_pool.go
+++ b/mempool/recheck_pool.go
@@ -472,7 +472,7 @@ func (m *RecheckMempool) runRecheck(done chan struct{}, newHead *ethtypes.Header
 			}
 		}
 
-		dropFuturesOnError := true
+		keepFuturesOnError := false
 		if !invalidTx {
 			ctx, write := m.rechecker.GetContext()
 			_, err := m.rechecker.RecheckCosmos(ctx, txn)
@@ -493,13 +493,13 @@ func (m *RecheckMempool) runRecheck(done chan struct{}, newHead *ethtypes.Header
 			// want to cascade and evict the signer's tx at nonce+1 since
 			// that may still be valid at the correct nonce.
 			if errors.Is(err, sdkerrors.ErrWrongSequence) {
-				dropFuturesOnError = false
+				keepFuturesOnError = true
 			}
 		}
 
 		removeTxs = append(removeTxs, txn)
 
-		if !dropFuturesOnError {
+		if keepFuturesOnError {
 			iter = iter.Next()
 			continue
 		}

--- a/mempool/recheck_pool_test.go
+++ b/mempool/recheck_pool_test.go
@@ -126,7 +126,7 @@ func testHeader(height int64) *ethtypes.Header {
 }
 
 // ----------------------------------------------------------------------------
-// Insert/Remove
+// Insert
 // ----------------------------------------------------------------------------
 
 func TestRecheckMempool_Insert(t *testing.T) {
@@ -237,51 +237,6 @@ func TestRecheckMempool_Insert_PoolCapacity(t *testing.T) {
 	otherHandle := tracker.NewHandle(2)
 	require.False(t, otherHandle.Has(secondAcc.address))
 	require.True(t, otherHandle.Has(firstAcc.address))
-}
-
-func TestRecheckMempool_Remove(t *testing.T) {
-	acc := newRecheckTestAccount(t)
-	tracker := reserver.NewReservationTracker()
-	handle := tracker.NewHandle(1)
-
-	ctx := newRecheckTestContext()
-	bc := newTestBlockchain(t, ctx)
-	rc := newMockRechecker(ctx, noopAnteHandler)
-
-	mp := mempool.NewRecheckMempool(
-		nil, 0, handle, rc,
-		newTestRecheckedTxs(), newTestReapList(), bc, log.NewNopLogger(),
-	)
-
-	tx := newRecheckTestTx(t, acc.key)
-	require.NoError(t, mp.Insert(ctx, tx))
-
-	otherHandle := tracker.NewHandle(2)
-	require.True(t, otherHandle.Has(acc.address), "address should be reserved after insert")
-
-	require.NoError(t, mp.Remove(tx))
-	require.False(t, otherHandle.Has(acc.address), "address should not be reserved after remove")
-}
-
-func TestRecheckMempool_Remove_NotInPool(t *testing.T) {
-	acc := newRecheckTestAccount(t)
-	tracker := reserver.NewReservationTracker()
-	handle := tracker.NewHandle(1)
-
-	ctx := newRecheckTestContext()
-	bc := newTestBlockchain(t, ctx)
-	rc := newMockRechecker(ctx, noopAnteHandler)
-
-	mp := mempool.NewRecheckMempool(
-		nil, 0, handle, rc,
-		newTestRecheckedTxs(), newTestReapList(), bc, log.NewNopLogger(),
-	)
-
-	err := mp.Remove(newRecheckTestTx(t, acc.key))
-	require.Error(t, err)
-
-	otherHandle := tracker.NewHandle(2)
-	require.False(t, otherHandle.Has(acc.address))
 }
 
 // ----------------------------------------------------------------------------
@@ -765,77 +720,6 @@ func TestRecheckMempool_RecheckedTxs(t *testing.T) {
 					require.NotContains(t, rechecked, tx, "failed tx %d should not be in rechecked store", i)
 				} else {
 					require.Contains(t, rechecked, tx, "passing tx %d should be in rechecked store", i)
-				}
-			}
-		})
-	}
-}
-
-func TestRecheckMempool_RecheckedTxsReset(t *testing.T) {
-	tests := []struct {
-		name                 string
-		numInitialTxs        int
-		removeBetweenHeights []int // indices of txs to remove between height 1 and height 2
-	}{
-		{
-			name:                 "remove one tx between heights",
-			numInitialTxs:        3,
-			removeBetweenHeights: []int{2},
-		},
-		{
-			name:                 "remove all txs between heights",
-			numInitialTxs:        2,
-			removeBetweenHeights: []int{0, 1},
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			tracker := reserver.NewReservationTracker()
-			handle := tracker.NewHandle(1)
-			ctx := newRecheckTestContext()
-			bc := newTestBlockchain(t, ctx)
-			recheckedTxs := newTestRecheckedTxs()
-			rc := newMockRechecker(ctx, noopAnteHandler)
-
-			mp := mempool.NewRecheckMempool(
-				nil, 0, handle, rc,
-				recheckedTxs, newTestReapList(), bc, log.NewNopLogger(),
-			)
-			mp.Start(testHeader(0))
-			defer mp.Close()
-
-			txs := make([]sdk.Tx, tc.numInitialTxs)
-			for i := range tc.numInitialTxs {
-				key, _ := crypto.GenerateKey()
-				txs[i] = newRecheckTestTx(t, key)
-				require.NoError(t, mp.Insert(ctx, txs[i]))
-			}
-
-			// Recheck at height 1 - all txs pass
-			mp.TriggerRecheckSync(testHeader(1))
-			iter1 := mp.RecheckedTxs(context.Background(), big.NewInt(1))
-			rechecked1 := collectIteratorTxs(iter1)
-			require.Len(t, rechecked1, tc.numInitialTxs)
-
-			// Remove txs between heights (simulating block inclusion)
-			removed := make(map[int]bool)
-			for _, idx := range tc.removeBetweenHeights {
-				require.NoError(t, mp.Remove(txs[idx]))
-				removed[idx] = true
-			}
-
-			// Recheck at height 2 - store should be fresh
-			mp.TriggerRecheckSync(testHeader(2))
-			iter2 := mp.RecheckedTxs(context.Background(), big.NewInt(2))
-			rechecked2 := collectIteratorTxs(iter2)
-			require.Len(t, rechecked2, tc.numInitialTxs-len(tc.removeBetweenHeights))
-
-			for i, tx := range txs {
-				if removed[i] {
-					require.NotContains(t, rechecked2, tx, "removed tx %d should not be in height 2 store", i)
-				} else {
-					require.Contains(t, rechecked2, tx, "tx %d should be in height 2 store", i)
 				}
 			}
 		})

--- a/tests/integration/mempool/test_helpers.go
+++ b/tests/integration/mempool/test_helpers.go
@@ -20,7 +20,8 @@ import (
 
 // Constants
 const (
-	TxGas = 100_000
+	TxGas    = 100_000
+	feeDenom = "aatom"
 )
 
 // createCosmosSendTransactionWithKey creates a simple bank send transaction
@@ -32,8 +33,6 @@ func (s *IntegrationTestSuite) createCosmosSendTx(key keyring.Key, gasPrice *big
 // createCosmosSendTransactionWithKey creates a simple bank send transaction
 // with the specified key and amount
 func (s *IntegrationTestSuite) createCosmosSendTxWithAmount(key keyring.Key, amt *big.Int, gasPrice *big.Int) sdk.Tx {
-	feeDenom := "aatom"
-
 	fromAddr := key.AccAddr
 	toAddr := s.keyring.GetKey(1).AccAddr
 	amount := sdk.NewCoins(sdk.NewCoin(feeDenom, sdkmath.NewIntFromBigInt(amt)))
@@ -58,8 +57,6 @@ func (s *IntegrationTestSuite) createCosmosSendTxWithAmount(key keyring.Key, amt
 // Requires a custom gasLimit to be set to prevent simulation of the tx in
 // order to fetch the gas limit (since this will fail due to a nonce mismatch).
 func (s *IntegrationTestSuite) createCosmosSendTxWithNonceAndGas(key keyring.Key, nonce uint64, amt *big.Int, gasLimit uint64, gasPrice *big.Int) sdk.Tx {
-	feeDenom := "aatom"
-
 	fromAddr := key.AccAddr
 	toAddr := s.keyring.GetKey(1).AccAddr
 	amount := sdk.NewCoins(sdk.NewCoin(feeDenom, sdkmath.NewIntFromBigInt(amt)))
@@ -89,7 +86,6 @@ func (s *IntegrationTestSuite) createMultiSignerCosmosSendTxWithAmount(amt *big.
 		panic("no keys provided")
 	}
 
-	feeDenom := "aatom"
 	toAddr := s.keyring.GetKey(9).AccAddr
 	amount := sdk.NewCoins(sdk.NewCoin(feeDenom, sdkmath.NewIntFromBigInt(amt)))
 

--- a/tests/integration/mempool/test_helpers.go
+++ b/tests/integration/mempool/test_helpers.go
@@ -13,6 +13,7 @@ import (
 
 	sdkmath "cosmossdk.io/math"
 
+	"github.com/cosmos/cosmos-sdk/crypto/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 )
@@ -46,6 +47,68 @@ func (s *IntegrationTestSuite) createCosmosSendTxWithAmount(key keyring.Key, amt
 		GasPrice: &gasPriceConverted,
 	}
 	tx, err := s.factory.BuildCosmosTx(key.Priv, txArgs)
+	s.Require().NoError(err)
+
+	return tx
+}
+
+// createCosmosSendTransactionWithKey creates a simple bank send transaction
+// with the specified key and amount. Uses a custom nonce for the sender that
+// may not match what is currently the next nonce on chain for this sender.
+// Requires a custom gasLimit to be set to prevent simulation of the tx in
+// order to fetch the gas limit (since this will fail due to a nonce mismatch).
+func (s *IntegrationTestSuite) createCosmosSendTxWithNonceAndGas(key keyring.Key, nonce uint64, amt *big.Int, gasLimit uint64, gasPrice *big.Int) sdk.Tx {
+	feeDenom := "aatom"
+
+	fromAddr := key.AccAddr
+	toAddr := s.keyring.GetKey(1).AccAddr
+	amount := sdk.NewCoins(sdk.NewCoin(feeDenom, sdkmath.NewIntFromBigInt(amt)))
+
+	bankMsg := banktypes.NewMsgSend(fromAddr, toAddr, amount)
+
+	gasPriceConverted := sdkmath.NewIntFromBigInt(gasPrice)
+
+	txArgs := factory.CosmosTxArgs{
+		Msgs:     []sdk.Msg{bankMsg},
+		GasPrice: &gasPriceConverted,
+		Nonce:    &nonce,
+		Gas:      &gasLimit,
+	}
+	tx, err := s.factory.BuildCosmosTx(key.Priv, txArgs)
+	s.Require().NoError(err)
+
+	return tx
+}
+
+func (s *IntegrationTestSuite) createMultiSignerCosmosSendTx(gasPrice *big.Int, keys ...keyring.Key) sdk.Tx {
+	return s.createMultiSignerCosmosSendTxWithAmount(big.NewInt(1000), gasPrice, keys...)
+}
+
+func (s *IntegrationTestSuite) createMultiSignerCosmosSendTxWithAmount(amt *big.Int, gasPrice *big.Int, keys ...keyring.Key) sdk.Tx {
+	if len(keys) == 0 {
+		panic("no keys provided")
+	}
+
+	feeDenom := "aatom"
+	toAddr := s.keyring.GetKey(9).AccAddr
+	amount := sdk.NewCoins(sdk.NewCoin(feeDenom, sdkmath.NewIntFromBigInt(amt)))
+
+	// one MsgSend per signer so the tx's aggregated GetSigners() returns one
+	// entry per provided key
+	msgs := make([]sdk.Msg, len(keys))
+	privs := make([]types.PrivKey, len(keys))
+	for i, key := range keys {
+		msgs[i] = banktypes.NewMsgSend(key.AccAddr, toAddr, amount)
+		privs[i] = key.Priv
+	}
+
+	gasPriceConverted := sdkmath.NewIntFromBigInt(gasPrice)
+
+	txArgs := factory.CosmosTxArgs{
+		Msgs:     msgs,
+		GasPrice: &gasPriceConverted,
+	}
+	tx, err := s.factory.BuildMultiSignerCosmosTx(txArgs, privs...)
 	s.Require().NoError(err)
 
 	return tx

--- a/tests/integration/mempool/test_mempool_integration.go
+++ b/tests/integration/mempool/test_mempool_integration.go
@@ -195,18 +195,6 @@ func (s *IntegrationTestSuite) TestMempoolRemove() {
 		verifyFunc    func()
 	}{
 		{
-			name: "remove cosmos transaction success",
-			setupTx: func() sdk.Tx {
-				return s.createCosmosSendTx(s.keyring.GetKey(0), big.NewInt(1000000000))
-			},
-			insertFirst: true,
-			wantError:   false,
-			verifyFunc: func() {
-				mpool := s.network.App.GetMempool()
-				s.Require().Equal(0, mpool.CountTx())
-			},
-		},
-		{
 			name: "remove EVM transaction fail",
 			setupTx: func() sdk.Tx {
 				return s.createEVMValueTransferTx(s.keyring.GetKey(0), 0, big.NewInt(1000000000))

--- a/tests/integration/mempool/test_mempool_integration.go
+++ b/tests/integration/mempool/test_mempool_integration.go
@@ -219,19 +219,6 @@ func (s *IntegrationTestSuite) TestMempoolRemove() {
 			verifyFunc: func() {
 			},
 		},
-		{
-			name: "remove non-existent transaction",
-			setupTx: func() sdk.Tx {
-				return s.createCosmosSendTx(s.keyring.GetKey(0), big.NewInt(1000000000))
-			},
-			insertFirst:   false,
-			wantError:     true, // Remove should error for non-existent transactions
-			errorContains: "tx not found in mempool",
-			verifyFunc: func() {
-				mpool := s.network.App.GetMempool()
-				s.Require().Equal(0, mpool.CountTx())
-			},
-		},
 	}
 
 	for _, tc := range testCases {

--- a/tests/integration/mempool/test_mempool_integration_abci.go
+++ b/tests/integration/mempool/test_mempool_integration_abci.go
@@ -8,8 +8,10 @@ import (
 	"github.com/cometbft/cometbft/crypto/tmhash"
 
 	evmmempool "github.com/cosmos/evm/mempool"
+	"github.com/cosmos/evm/mempool/reserver"
 	"github.com/cosmos/evm/mempool/txpool/legacypool"
 	"github.com/cosmos/evm/testutil/integration/evm/network"
+	"github.com/cosmos/evm/testutil/keyring"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/mempool"
@@ -747,6 +749,316 @@ func (s *IntegrationTestSuite) TestRechecking() {
 			// insert txs given by setup
 			err := s.insertTxs(txs)
 			s.Require().NoError(err)
+
+			// commit a block with network txs
+			networkTxs := tc.networkTxs()
+			s.T().Logf("including %d txs from the network", len(networkTxs))
+
+			var toFinalize [][]byte
+			for _, tx := range networkTxs {
+				encoded, err := s.factory.EncodeTx(tx)
+				s.Require().NoError(err)
+				toFinalize = append(toFinalize, encoded)
+			}
+			res, err := s.network.NextBlockWithTxs(toFinalize...)
+			s.Require().NoError(err)
+			for _, result := range res.GetTxResults() {
+				s.Require().Equal(uint32(0x0), result.GetCode())
+			}
+
+			// call PrepareProposal for the next block (H+1) after recheck at height H.
+			prepareProposalRes, err := s.network.App.PrepareProposal(&abci.RequestPrepareProposal{
+				MaxTxBytes: 1_000_000,
+				Height:     s.network.GetContext().BlockHeight() + 1,
+			})
+			s.Require().NoError(err)
+
+			// run custom verify func
+			tc.verifyFunc(s.network.App.GetMempool())
+
+			// check whether expected transactions are selected by PrepareProposal
+			txHashes := make([]string, 0)
+			for _, txBytes := range prepareProposalRes.Txs {
+				txHash := hex.EncodeToString(tmhash.Sum(txBytes))
+				txHashes = append(txHashes, txHash)
+			}
+			s.Require().Equal(expTxHashes, txHashes)
+		})
+	}
+}
+
+func (s *IntegrationTestSuite) TestMultiPoolInteractions() {
+	type insertWithResults struct {
+		tx  sdk.Tx
+		err error
+	}
+	testCases := []struct {
+		name       string
+		setupTxs   func() ([]insertWithResults, []string)
+		networkTxs func() []sdk.Tx
+		verifyFunc func(mpool mempool.Mempool)
+	}{
+		{
+			name: "same signer rejected from multi pool insert",
+			setupTxs: func() ([]insertWithResults, []string) {
+				key := s.keyring.GetKey(0)
+				var results []insertWithResults
+
+				// cosmos tx automatically created with nonce 0
+				results = append(results, insertWithResults{s.createCosmosSendTx(key, big.NewInt(5000000000)), nil})
+
+				// create two evm txs from the same key, both not allowed to be
+				// inserted according to reserver rules
+
+				// evm tx from same key at nonce 0, this is invalid if we take
+				// into account cosmos pending state, but valid if not
+				results = append(results, insertWithResults{s.createEVMValueTransferTx(key, 0, big.NewInt(1000000000)), reserver.ErrAlreadyReserved})
+
+				// evm tx from same key at nonce 1, this is valid if we take
+				// into account cosmos pending state, but invalid if not
+				results = append(results, insertWithResults{s.createEVMValueTransferTx(key, 1, big.NewInt(1000000000)), reserver.ErrAlreadyReserved})
+
+				return results, s.getTxHashes([]sdk.Tx{results[0].tx})
+			},
+			networkTxs: func() []sdk.Tx { return nil },
+			verifyFunc: func(mpool mempool.Mempool) {
+				mp := mpool.(*evmmempool.Mempool)
+				s.Require().Equal(1, mp.CountTx(), "expected only a single tx in the mempool")
+
+				legacyPool := mp.GetTxPool().Subpools[0].(*legacypool.LegacyPool)
+				pending, queued := legacyPool.Stats()
+
+				// no evm txs should be allowed since they were all from the
+				// same sender that has a cosmos tx in the pool already
+				s.Require().Equal(0, pending, "expected no pending txs")
+				s.Require().Equal(0, queued, "expected no queued txs")
+			},
+		},
+		{
+			name: "multi signer cosmos tx reserves all signers",
+			setupTxs: func() ([]insertWithResults, []string) {
+				var results []insertWithResults
+
+				// create multi signer cosmos tx to reserve keys 0,1,2 for the
+				// cosmos pool
+				signers := []keyring.Key{s.keyring.GetKey(0), s.keyring.GetKey(1), s.keyring.GetKey(2)}
+				results = append(results, insertWithResults{s.createMultiSignerCosmosSendTx(big.NewInt(5000000000), signers...), nil})
+
+				// all should fail since each signer is being held by the
+				// cosmos pool
+				results = append(results, insertWithResults{s.createEVMValueTransferTx(s.keyring.GetKey(0), 0, big.NewInt(1000000000)), reserver.ErrAlreadyReserved})
+				results = append(results, insertWithResults{s.createEVMValueTransferTx(s.keyring.GetKey(1), 0, big.NewInt(1000000000)), reserver.ErrAlreadyReserved})
+				results = append(results, insertWithResults{s.createEVMValueTransferTx(s.keyring.GetKey(2), 0, big.NewInt(1000000000)), reserver.ErrAlreadyReserved})
+
+				return results, s.getTxHashes([]sdk.Tx{results[0].tx})
+			},
+			networkTxs: func() []sdk.Tx { return nil },
+			verifyFunc: func(mpool mempool.Mempool) {
+				mp := mpool.(*evmmempool.Mempool)
+				s.Require().Equal(1, mp.CountTx(), "expected only a single tx in the mempool")
+
+				legacyPool := mp.GetTxPool().Subpools[0].(*legacypool.LegacyPool)
+				pending, queued := legacyPool.Stats()
+
+				// no evm txs should be allowed since they were all from a
+				// sender that already a cosmos tx in the pool already
+				s.Require().Equal(0, pending, "expected no pending txs")
+				s.Require().Equal(0, queued, "expected no queued txs")
+			},
+		},
+		{
+			name: "multi signer cosmos tx atomically fails reservations",
+			setupTxs: func() ([]insertWithResults, []string) {
+				var results []insertWithResults
+
+				// insert evm tx with key 0
+				results = append(results, insertWithResults{s.createEVMValueTransferTx(s.keyring.GetKey(0), 0, big.NewInt(1000000000)), nil})
+
+				// create multi signer cosmos tx to reserve keys 0,1,2 for the
+				// cosmos pool
+				signers := []keyring.Key{s.keyring.GetKey(0), s.keyring.GetKey(1), s.keyring.GetKey(2)}
+				results = append(results, insertWithResults{s.createMultiSignerCosmosSendTx(big.NewInt(5000000000), signers...), reserver.ErrAlreadyReserved})
+
+				// expecting the above tx to fail insert, make sure that after
+				// the failure it does not create any new reservations
+				results = append(results, insertWithResults{s.createEVMValueTransferTx(s.keyring.GetKey(0), 1, big.NewInt(1000000000)), nil})
+				results = append(results, insertWithResults{s.createEVMValueTransferTx(s.keyring.GetKey(1), 0, big.NewInt(1000000000)), nil})
+				results = append(results, insertWithResults{s.createEVMValueTransferTx(s.keyring.GetKey(2), 0, big.NewInt(1000000000)), nil})
+
+				return results, s.getTxHashes([]sdk.Tx{results[0].tx, results[2].tx, results[3].tx, results[4].tx})
+			},
+			networkTxs: func() []sdk.Tx { return nil },
+			verifyFunc: func(mpool mempool.Mempool) {
+				mp := mpool.(*evmmempool.Mempool)
+				s.Require().Equal(4, mp.CountTx(), "expected 4 txs in the mempool")
+
+				legacyPool := mp.GetTxPool().Subpools[0].(*legacypool.LegacyPool)
+				pending, queued := legacyPool.Stats()
+
+				// all txs should be in the evm tx pending pool
+				s.Require().Equal(4, pending, "expected 4 pending txs")
+				s.Require().Equal(0, queued, "expected no queued txs")
+			},
+		},
+		{
+			name: "same network tx properly releases reservations",
+			setupTxs: func() ([]insertWithResults, []string) {
+				var results []insertWithResults
+
+				signers := []keyring.Key{s.keyring.GetKey(0), s.keyring.GetKey(1), s.keyring.GetKey(2)}
+				results = append(results, insertWithResults{s.createMultiSignerCosmosSendTx(big.NewInt(5000000000), signers...), nil})
+
+				return results, s.getTxHashes(nil)
+			},
+			networkTxs: func() []sdk.Tx {
+				// same tx that is in our cosmos pool is included in a block
+				signers := []keyring.Key{s.keyring.GetKey(0), s.keyring.GetKey(1), s.keyring.GetKey(2)}
+				tx := s.createMultiSignerCosmosSendTx(big.NewInt(5000000000), signers...)
+				return []sdk.Tx{tx}
+			},
+			verifyFunc: func(mpool mempool.Mempool) {
+				mp := mpool.(*evmmempool.Mempool)
+
+				// expect a completely empty mempool
+				s.Require().Equal(0, mp.CountTx(), "expected no txs in the mempool")
+				legacyPool := mp.GetTxPool().Subpools[0].(*legacypool.LegacyPool)
+				pending, queued := legacyPool.Stats()
+				s.Require().Equal(0, pending, "expected no pending txs")
+				s.Require().Equal(0, queued, "expected no queued txs")
+
+				// ensure that we can insert txs for the signers that were
+				// evicted from the cosmos pool into the evm pool
+				var txs []sdk.Tx
+				txs = append(txs, s.createEVMValueTransferTx(s.keyring.GetKey(0), 0, big.NewInt(1000000000)))
+				txs = append(txs, s.createEVMValueTransferTx(s.keyring.GetKey(1), 0, big.NewInt(1000000000)))
+				txs = append(txs, s.createEVMValueTransferTx(s.keyring.GetKey(2), 0, big.NewInt(1000000000)))
+				s.Require().NoError(s.insertTxs(txs))
+
+				s.Require().Equal(3, mp.CountTx(), "expected 3 txs in the mempool")
+				pending, queued = legacyPool.Stats()
+				s.Require().Equal(3, pending, "expected 3 pending txs")
+				s.Require().Equal(0, queued, "expected no queued txs")
+			},
+		},
+		{
+			name: "cosmos multi signer recheck failure properly releases all reservations",
+			setupTxs: func() ([]insertWithResults, []string) {
+				var results []insertWithResults
+
+				signers := []keyring.Key{s.keyring.GetKey(0), s.keyring.GetKey(1), s.keyring.GetKey(2)}
+				results = append(results, insertWithResults{s.createMultiSignerCosmosSendTx(big.NewInt(5000000000), signers...), nil})
+
+				return results, s.getTxHashes(nil)
+			},
+			networkTxs: func() []sdk.Tx {
+				// include a tx from the network that will cause the tx in our
+				// cosmos pool to fail recheck (bumping key 0's nonce)
+
+				// NOTE: we are also testing an interesting property of how
+				// removals work for cosmos txs. the cosmos pool is built on
+				// top of the priority nonce mempool and that only looks at the
+				// first signer of mutli signer txs. so the tx below and the
+				// one already in the mempool look identical to it. so when
+				// including this tx from the network, it will remove the one
+				// in the mempool if we process the removal during finalize
+				// block. however, this gives us no way to determine that our
+				// original tx had multiple signers and we need to release all
+				// of those address reservations. so, we must not remove during
+				// finalize block, and process the removal during recheck where
+				// the tx will be dropped due to a nonce too low error on
+				// signer 0. during recheck we know exactly which tx we are
+				// removing and why, and can properly unreserve the signers
+				// reservations.
+				tx := s.createCosmosSendTx(s.keyring.GetKey(0), big.NewInt(5000000000))
+				return []sdk.Tx{tx}
+			},
+			verifyFunc: func(mpool mempool.Mempool) {
+				mp := mpool.(*evmmempool.Mempool)
+
+				// expect a completely empty mempool
+				s.Require().Equal(0, mp.CountTx(), "expected no txs in the mempool")
+				legacyPool := mp.GetTxPool().Subpools[0].(*legacypool.LegacyPool)
+				pending, queued := legacyPool.Stats()
+				s.Require().Equal(0, pending, "expected no pending txs")
+				s.Require().Equal(0, queued, "expected no queued txs")
+
+				// ensure that we can insert txs for the signers that were
+				// evicted from the cosmos pool into the evm pool
+				var txs []sdk.Tx
+				txs = append(txs, s.createEVMValueTransferTx(s.keyring.GetKey(0), 0, big.NewInt(1000000000)))
+				txs = append(txs, s.createEVMValueTransferTx(s.keyring.GetKey(1), 0, big.NewInt(1000000000)))
+				txs = append(txs, s.createEVMValueTransferTx(s.keyring.GetKey(2), 0, big.NewInt(1000000000)))
+				s.Require().NoError(s.insertTxs(txs))
+
+				s.Require().Equal(3, mp.CountTx(), "expected 3 txs in the mempool")
+				pending, queued = legacyPool.Stats()
+				s.Require().Equal(3, pending, "expected 3 pending txs")
+				s.Require().Equal(0, queued, "expected no queued txs")
+			},
+		},
+		{
+			name: "cosmos signer reserved twice is not unreserved on first removal",
+			setupTxs: func() ([]insertWithResults, []string) {
+				var results []insertWithResults
+
+				// create a multi signer tx that will be dropped
+				signers := []keyring.Key{s.keyring.GetKey(0), s.keyring.GetKey(1), s.keyring.GetKey(2)}
+				results = append(results, insertWithResults{s.createMultiSignerCosmosSendTx(big.NewInt(5000000000), signers...), nil})
+
+				// reserve signer 0 a second time with a new tx at its next
+				// nonce (given the above tx)
+				var nextNonce uint64 = 1
+				var gasLimit uint64 = 100000000
+				results = append(results, insertWithResults{
+					s.createCosmosSendTxWithNonceAndGas(s.keyring.GetKey(0), nextNonce, big.NewInt(1000), gasLimit, big.NewInt(5000000000)),
+					nil,
+				})
+
+				return results, s.getTxHashes([]sdk.Tx{results[1].tx})
+			},
+			networkTxs: func() []sdk.Tx {
+				// bump signer 0's nonce on chain so that the multi signer tx
+				// will be dropped, the single signer tx at nonce 1 will remain
+				tx := s.createCosmosSendTx(s.keyring.GetKey(0), big.NewInt(5000000000))
+				return []sdk.Tx{tx}
+			},
+			verifyFunc: func(mpool mempool.Mempool) {
+				mp := mpool.(*evmmempool.Mempool)
+
+				// expect a single tx in the mempool
+				s.Require().Equal(1, mp.CountTx(), "expected a single tx in the mempool")
+				legacyPool := mp.GetTxPool().Subpools[0].(*legacypool.LegacyPool)
+				pending, queued := legacyPool.Stats()
+				s.Require().Equal(0, pending, "expected no pending txs")
+				s.Require().Equal(0, queued, "expected no queued txs")
+
+				// ensure signers 1 and 2 were unreserved
+				var txs []sdk.Tx
+				txs = append(txs, s.createEVMValueTransferTx(s.keyring.GetKey(1), 0, big.NewInt(1000000000)))
+				txs = append(txs, s.createEVMValueTransferTx(s.keyring.GetKey(2), 0, big.NewInt(1000000000)))
+				s.Require().NoError(s.insertTxs(txs))
+
+				// ensure signer 0 remains reserved since it has another cosmos
+				// tx still in the pool
+				err := s.insertTx(s.createEVMValueTransferTx(s.keyring.GetKey(0), 0, big.NewInt(1000000000)))
+				s.Require().ErrorIs(err, reserver.ErrAlreadyReserved)
+			},
+		},
+	}
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			// clean up previous test's resources before resetting
+			s.TearDownTest()
+			s.SetupTest()
+
+			insertResults, expTxHashes := tc.setupTxs()
+			s.T().Logf("inserting %d txs into local mempool", len(insertResults))
+
+			// insert txs given by setup
+			for _, result := range insertResults {
+				err := s.insertTx(result.tx)
+				s.Require().ErrorIs(err, result.err)
+			}
 
 			// commit a block with network txs
 			networkTxs := tc.networkTxs()

--- a/testutil/integration/base/factory/base.go
+++ b/testutil/integration/base/factory/base.go
@@ -22,6 +22,9 @@ import (
 type BaseTxFactory interface {
 	// BuildCosmosTx builds a Cosmos tx with the provided private key and txArgs
 	BuildCosmosTx(privKey cryptotypes.PrivKey, txArgs CosmosTxArgs) (authsigning.Tx, error)
+	// BuildMultiSignerCosmosTx builds a Cosmos tx signed by multiple private
+	// keys. The first key is used as the fee payer.
+	BuildMultiSignerCosmosTx(txArgs CosmosTxArgs, privKeys ...cryptotypes.PrivKey) (authsigning.Tx, error)
 	// SignCosmosTx signs a Cosmos transaction with the provided
 	// private key and tx builder
 	SignCosmosTx(privKey cryptotypes.PrivKey, txBuilder client.TxBuilder) error
@@ -59,6 +62,21 @@ func (tf *baseTxFactory) BuildCosmosTx(privKey cryptotypes.PrivKey, txArgs Cosmo
 	txBuilder, err := tf.buildTx(privKey, txArgs)
 	if err != nil {
 		return nil, errorsmod.Wrap(err, "failed to build tx")
+	}
+	return txBuilder.GetTx(), nil
+}
+
+// BuildMultiSignerCosmosTx builds and signs a Cosmos tx with multiple signers.
+// The first private key is the fee payer. Each signer signs independently over
+// its own SignerData; the resulting tx carries one SignatureV2 per signer so
+// the default SDK signer extractor returns one entry per key.
+func (tf *baseTxFactory) BuildMultiSignerCosmosTx(txArgs CosmosTxArgs, privKeys ...cryptotypes.PrivKey) (authsigning.Tx, error) {
+	if len(privKeys) == 0 {
+		return nil, fmt.Errorf("at least one private key is required")
+	}
+	txBuilder, err := tf.buildMultiSignerTx(txArgs, privKeys)
+	if err != nil {
+		return nil, errorsmod.Wrap(err, "failed to build multi-signer tx")
 	}
 	return txBuilder.GetTx(), nil
 }
@@ -110,7 +128,7 @@ func (tf *baseTxFactory) SignCosmosTx(privKey cryptotypes.PrivKey, txBuilder cli
 	if err != nil {
 		return errorsmod.Wrap(err, "invalid sign mode")
 	}
-	signerData, err := tf.setSignatures(privKey, txBuilder, signMode)
+	signerData, err := tf.setSignatures(privKey, nil, txBuilder, signMode)
 	if err != nil {
 		return errorsmod.Wrap(err, "failed to set tx signatures")
 	}

--- a/testutil/integration/base/factory/helper.go
+++ b/testutil/integration/base/factory/helper.go
@@ -36,7 +36,6 @@ func (tf *baseTxFactory) buildTx(privKey cryptotypes.PrivKey, txArgs CosmosTxArg
 	}
 
 	senderAddress := sdktypes.AccAddress(privKey.PubKey().Address().Bytes())
-
 	if txArgs.FeeGranter != nil {
 		txBuilder.SetFeeGranter(txArgs.FeeGranter)
 	}
@@ -48,7 +47,7 @@ func (tf *baseTxFactory) buildTx(privKey cryptotypes.PrivKey, txArgs CosmosTxArg
 	if err != nil {
 		return nil, errorsmod.Wrap(err, "invalid sign mode")
 	}
-	signerData, err := tf.setSignatures(privKey, txBuilder, signMode)
+	signerData, err := tf.setSignatures(privKey, txArgs.Nonce, txBuilder, signMode)
 	if err != nil {
 		return nil, errorsmod.Wrap(err, "failed to set tx signatures")
 	}
@@ -69,6 +68,60 @@ func (tf *baseTxFactory) buildTx(privKey cryptotypes.PrivKey, txArgs CosmosTxArg
 	txBuilder.SetFeeAmount(fees)
 
 	if err := tf.signWithPrivKey(privKey, txBuilder, signerData, signMode); err != nil {
+		return nil, errorsmod.Wrap(err, "failed to sign Cosmos Tx")
+	}
+
+	return txBuilder, nil
+}
+
+// buildMultiSignerTx builds a tx signed by multiple private keys. The first
+// key in privKeys is set as the fee payer.
+func (tf *baseTxFactory) buildMultiSignerTx(txArgs CosmosTxArgs, privKeys []cryptotypes.PrivKey) (client.TxBuilder, error) {
+	txConfig := tf.ec.TxConfig
+	txBuilder := txConfig.NewTxBuilder()
+
+	if err := txBuilder.SetMsgs(txArgs.Msgs...); err != nil {
+		return nil, errorsmod.Wrap(err, "failed to set tx msgs")
+	}
+
+	if txArgs.FeeGranter != nil {
+		txBuilder.SetFeeGranter(txArgs.FeeGranter)
+	}
+
+	feePayer := sdktypes.AccAddress(privKeys[0].PubKey().Address().Bytes())
+	txBuilder.SetFeePayer(feePayer)
+
+	signMode, err := authsigning.APISignModeToInternal(txConfig.SignModeHandler().DefaultMode())
+	if err != nil {
+		return nil, errorsmod.Wrap(err, "invalid sign mode")
+	}
+
+	signerDatas, err := tf.setMultiSignerSignatures(privKeys, txBuilder, signMode)
+	if err != nil {
+		return nil, errorsmod.Wrap(err, "failed to set tx signatures")
+	}
+
+	var gasLimit uint64
+	if txArgs.Gas == nil {
+		gasLimit, err = tf.estimateGas(txArgs, txBuilder)
+		if err != nil {
+			return nil, errorsmod.Wrap(err, "failed to estimate gas")
+		}
+	} else {
+		gasLimit = *txArgs.Gas
+	}
+	txBuilder.SetGasLimit(gasLimit)
+
+	fees := txArgs.Fees
+	if fees.IsZero() {
+		fees, err = tf.calculateFees(txArgs.GasPrice, gasLimit)
+		if err != nil {
+			return nil, errorsmod.Wrap(err, "failed to calculate fees")
+		}
+	}
+	txBuilder.SetFeeAmount(fees)
+
+	if err := tf.signMultiSignerWithPrivKeys(privKeys, txBuilder, signerDatas, signMode); err != nil {
 		return nil, errorsmod.Wrap(err, "failed to sign Cosmos Tx")
 	}
 

--- a/testutil/integration/base/factory/sign.go
+++ b/testutil/integration/base/factory/sign.go
@@ -16,13 +16,17 @@ import (
 // setSignatures is a helper function that sets the signature for
 // the transaction in the tx builder. It returns the signerData to be used
 // when signing the transaction (e.g. when calling signWithPrivKey)
-func (tf *baseTxFactory) setSignatures(privKey cryptotypes.PrivKey, txBuilder client.TxBuilder, signMode signing.SignMode) (signerData authsigning.SignerData, err error) {
+func (tf *baseTxFactory) setSignatures(privKey cryptotypes.PrivKey, nonce *uint64, txBuilder client.TxBuilder, signMode signing.SignMode) (signerData authsigning.SignerData, err error) {
 	senderAddress := sdktypes.AccAddress(privKey.PubKey().Address().Bytes())
 	account, err := tf.grpcHandler.GetAccount(senderAddress.String())
 	if err != nil {
 		return signerData, err
 	}
 	sequence := account.GetSequence()
+	if nonce != nil {
+		sequence = *nonce
+	}
+
 	signerData = authsigning.SignerData{
 		ChainID:       tf.network.GetChainID(),
 		AccountNumber: account.GetAccountNumber(),
@@ -41,6 +45,56 @@ func (tf *baseTxFactory) setSignatures(privKey cryptotypes.PrivKey, txBuilder cl
 	}
 
 	return signerData, txBuilder.SetSignatures(sigsV2)
+}
+
+// setMultiSignerSignatures sets nil signatures for each provided signer in
+// order so the tx can be simulated, returning the per-signer SignerData used
+// during the actual signing pass.
+func (tf *baseTxFactory) setMultiSignerSignatures(privKeys []cryptotypes.PrivKey, txBuilder client.TxBuilder, signMode signing.SignMode) ([]authsigning.SignerData, error) {
+	signerDatas := make([]authsigning.SignerData, len(privKeys))
+	sigsV2 := make([]signing.SignatureV2, len(privKeys))
+	for i, privKey := range privKeys {
+		addr := sdktypes.AccAddress(privKey.PubKey().Address().Bytes())
+		account, err := tf.grpcHandler.GetAccount(addr.String())
+		if err != nil {
+			return nil, err
+		}
+		seq := account.GetSequence()
+		signerDatas[i] = authsigning.SignerData{
+			ChainID:       tf.network.GetChainID(),
+			AccountNumber: account.GetAccountNumber(),
+			Sequence:      seq,
+			Address:       addr.String(),
+			PubKey:        privKey.PubKey(),
+		}
+		sigsV2[i] = signing.SignatureV2{
+			PubKey: privKey.PubKey(),
+			Data: &signing.SingleSignatureData{
+				SignMode:  signMode,
+				Signature: nil,
+			},
+			Sequence: seq,
+		}
+	}
+	if err := txBuilder.SetSignatures(sigsV2...); err != nil {
+		return nil, err
+	}
+	return signerDatas, nil
+}
+
+// signMultiSignerWithPrivKeys produces a signature per signer and sets them
+// all on the tx builder in the same order as privKeys.
+func (tf *baseTxFactory) signMultiSignerWithPrivKeys(privKeys []cryptotypes.PrivKey, txBuilder client.TxBuilder, signerDatas []authsigning.SignerData, signMode signing.SignMode) error {
+	txConfig := tf.ec.TxConfig
+	sigs := make([]signing.SignatureV2, len(privKeys))
+	for i, privKey := range privKeys {
+		sig, err := cosmostx.SignWithPrivKey(context.TODO(), signMode, signerDatas[i], txBuilder, privKey, txConfig, signerDatas[i].Sequence)
+		if err != nil {
+			return errorsmod.Wrap(err, "failed to sign tx")
+		}
+		sigs[i] = sig
+	}
+	return txBuilder.SetSignatures(sigs...)
 }
 
 // signWithPrivKey is a helper function that signs a transaction

--- a/testutil/integration/base/factory/types.go
+++ b/testutil/integration/base/factory/types.go
@@ -16,6 +16,8 @@ type CosmosTxArgs struct {
 	GasPrice *sdkmath.Int
 	// Fees is the fee to be used on the tx (amount and denom)
 	Fees sdktypes.Coins
+	// Nonce is an optional custom nonce to use for the fee payer
+	Nonce *uint64
 	// FeeGranter is the account address of the fee granter
 	FeeGranter sdktypes.AccAddress
 	// Msgs slice of messages to include on the tx


### PR DESCRIPTION

# Description

Adds a number of integration tests for the cosmos recheck mempool and fix some subtle bugs related to the reserver and rechecking of cosmos txs.

- Changes removals in the cosmos pool to now be deferred to recheck. Not having this caused a subtle bug where if we had a mutli signer tx in the cosmos pool of signers A, B, C, then calling Remove on a different tx with signer A would then remove the multi signer tx of A, B, C. This gave us no opportunity to unreserve signers B and C, leaving them stuck with permanently reserved addresses. Instead, we just defer the removal to happen in the recheck loop instead. We only care about removals happening during FinalizeBlock, and all of those removals will be processed by the recheck loop evicting txs due to invalid sequence errors, except during recheck, we know exactly what txs are being removed.
- Does not invalidate future txs for a signer if the parent tx failed with an invalid sequence error during recheck. if a parent tx fails with this error, we know it must be a nonce too low situation (since we run recheck on insert, and that will catch all cases where nonce is too high). In this case, we do not want to invalidate future txs since they may still be valid. For example if we have txs for signer A in the mempool at nonce 0 and 1, and nonce 0 gets included on chain, we should remove tx for signer A with nonce 0, but keep nonce 1 if it is still valid on its own. Previously we would evict nonce 1 without even checking.

Closes: STACK-2593

---

## Author Checklist

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.

I have...

- [ ] tackled an existing issue or discussed with a team member
- [ ] left instructions on how to review the changes
- [ ] targeted the `main` branch
