### PR TITLE
fix: Enable otel during app start

### DIFF
--- a/server/start.go
+++ b/server/start.go
@@ -128,6 +128,11 @@ which accepts a path for the resulting pprof file.
 				return err
 			}
 
+			otelFile := filepath.Join(clientCtx.HomeDir, "config", telemetry.OtelFileName)
+			if err := telemetry.InitializeOpenTelemetry(otelFile); err != nil {
+				return fmt.Errorf("failed to initialize OpenTelemetry: %w", err)
+			}
+
 			withbft, _ := cmd.Flags().GetBool(srvflags.WithCometBFT)
 			if !withbft {
 				serverCtx.Logger.Info("starting ABCI without CometBFT")


### PR DESCRIPTION
# Description

Because the evm uses a custom start command it is not getting the otel initialized as it is [here](https://github.com/cosmos/cosmos-sdk/blob/e77c24c3eda790faf5f4ee4551323c0328b83457/server/start.go#L230)

Copy this over so that otel metrics work. Tested on local network and it produces metrics now.

---

## Author Checklist

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.

I have...

- [ ] tackled an existing issue or discussed with a team member
- [ ] left instructions on how to review the changes
- [ ] targeted the `main` branch
