### PR TITLE
fix: avoid missed wakeups in rpc stream subscribe

### DIFF
--- a/rpc/stream/cond.go
+++ b/rpc/stream/cond.go
@@ -15,11 +15,19 @@ func NewCond() *Cond {
 	return &Cond{ch: make(chan struct{})}
 }
 
+func (c *Cond) Channel() <-chan struct{} {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	return c.ch
+}
+
 // Wait returns true if the condition is signaled, false if the context is canceled
 func (c *Cond) Wait(ctx context.Context) bool {
-	c.mu.Lock()
-	ch := c.ch
-	c.mu.Unlock()
+	return c.WaitChannel(ctx, c.Channel())
+}
+
+func (c *Cond) WaitChannel(ctx context.Context, ch <-chan struct{}) bool {
 
 	select {
 	case <-ch:

--- a/rpc/stream/stream.go
+++ b/rpc/stream/stream.go
@@ -71,8 +71,13 @@ func (s *Stream[V]) Add(vs ...V) int {
 func (s *Stream[V]) Subscribe(ctx context.Context, callback func([]V, int) error) error {
 	var (
 		items  []V
-		offset = -1
+		offset int
 	)
+
+	s.mutex.RLock()
+	offset = s.lastID()
+	s.mutex.RUnlock()
+
 	for {
 		items, offset = s.ReadBlocking(ctx, offset)
 		if len(items) == 0 {
@@ -130,8 +135,9 @@ func (s *Stream[V]) ReadBlocking(ctx context.Context, offset int) ([]V, int) {
 			return items, offset
 		}
 
+		ch := s.cond.Channel()
 		s.mutex.RUnlock()
-		r := s.cond.Wait(ctx)
+		r := s.cond.WaitChannel(ctx, ch)
 		s.mutex.RLock()
 
 		if !r {


### PR DESCRIPTION
## Description
Fix the rpc stream subscription race that could miss the final wakeup in blocking reads.
Initialize subscription offsets from the current tail so subscribers only receive new items.
Capture the cond channel before releasing the read lock to avoid dropped broadcasts.

## Verification
go test -count=20 -race -tags=test ./rpc/stream -run 'TestStream(ReadBlocking|Subscribe)'
go test -race -tags=test ./rpc/stream