### PR TITLE
test: remove dual-denom test paths and add invariants coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,18 @@ make test-unit-cover
 make test-fuzz
 ```
 
+Run a specific fuzz target locally (example for denom relabeling invariants):
+
+```bash
+go test -tags=test ./x/vm/types -run '^$' -fuzz FuzzConvertCoinsDenomToExtendedDenomWithEvmParams -fuzztime=30s
+```
+
+Re-run with a longer fuzz window:
+
+```bash
+go test -tags=test ./x/vm/types -run '^$' -fuzz FuzzConvertCoinsDenomToExtendedDenomWithEvmParams -fuzztime=5m
+```
+
 #### Solidity Tests
 
 ```bash

--- a/tests/integration/precompiles/werc20/test_events.go
+++ b/tests/integration/precompiles/werc20/test_events.go
@@ -101,9 +101,6 @@ func (s *PrecompileUnitTestSuite) TestEmitDepositEvent() {
 		{
 			name:    "mainnet",
 			chainID: testconstants.ExampleChainID,
-		}, {
-			name:    "six decimals",
-			chainID: testconstants.SixDecimalsChainID,
 		},
 	}
 
@@ -160,9 +157,6 @@ func (s *PrecompileUnitTestSuite) TestEmitWithdrawalEvent() {
 		{
 			name:    "mainnet",
 			chainID: testconstants.ExampleChainID,
-		}, {
-			name:    "six decimals",
-			chainID: testconstants.SixDecimalsChainID,
 		},
 	}
 

--- a/tests/integration/testutil/test_config.go
+++ b/tests/integration/testutil/test_config.go
@@ -17,7 +17,6 @@ import (
 
 func (s *TestSuite) TestWithChainID() {
 	eighteenDecimalsCoinInfo := testconstants.ExampleChainCoinInfo[testconstants.ExampleChainID]
-	sixDecimalsCoinInfo := testconstants.ExampleChainCoinInfo[testconstants.SixDecimalsChainID]
 
 	testCases := []struct {
 		name            string
@@ -33,13 +32,6 @@ func (s *TestSuite) TestWithChainID() {
 			coinInfo:        eighteenDecimalsCoinInfo,
 			expBaseFee:      math.LegacyNewDec(875_000_000),
 			expCosmosAmount: network.GetInitialAmount(evmtypes.EighteenDecimals),
-		},
-		{
-			name:            "6 decimals",
-			chainID:         testconstants.SixDecimalsChainID,
-			coinInfo:        sixDecimalsCoinInfo,
-			expBaseFee:      math.LegacyNewDecWithPrec(875, 6),
-			expCosmosAmount: network.GetInitialAmount(evmtypes.SixDecimals),
 		},
 	}
 

--- a/tests/integration/x/erc20/test_conversion_invariants_randomized.go
+++ b/tests/integration/x/erc20/test_conversion_invariants_randomized.go
@@ -62,16 +62,16 @@ func (s *KeeperTestSuite) TestRandomizedConvertRoundTripInvariant() {
 				}
 
 				if convertFromERC20 {
-					max := erc20Bal.Int64()
-					amount := int64(rng.Intn(int(max)) + 1)
+					maxAmount := erc20Bal.Int64()
+					amount := int64(rng.Intn(int(maxAmount)) + 1)
 					_, err = erc20Keeper.ConvertERC20(
 						ctx,
 						types.NewMsgConvertERC20(math.NewInt(amount), senderAcc, contractAddr, senderHex),
 					)
 					s.Require().NoError(err)
 				} else {
-					max := coinBal.Int64()
-					amount := int64(rng.Intn(int(max)) + 1)
+					maxAmount := coinBal.Int64()
+					amount := int64(rng.Intn(int(maxAmount)) + 1)
 					_, err = erc20Keeper.ConvertCoin(
 						ctx,
 						types.NewMsgConvertCoin(sdk.NewCoin(denom, math.NewInt(amount)), senderHex, senderAcc),

--- a/tests/integration/x/erc20/test_conversion_invariants_randomized.go
+++ b/tests/integration/x/erc20/test_conversion_invariants_randomized.go
@@ -1,0 +1,90 @@
+package erc20
+
+import (
+	"fmt"
+	"math/big"
+	"math/rand"
+
+	"github.com/cosmos/evm/contracts"
+	"github.com/cosmos/evm/x/erc20/types"
+
+	"cosmossdk.io/math"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+// TestRandomizedConvertRoundTripInvariant runs randomized convert sequences and
+// asserts that sender coin/token balances always conserve value.
+func (s *KeeperTestSuite) TestRandomizedConvertRoundTripInvariant() {
+	const (
+		initialMint = int64(5_000)
+		steps       = 50
+	)
+
+	for _, seed := range []int64{1, 7, 42, 777, 2026} {
+		s.Run(fmt.Sprintf("seed-%d", seed), func() {
+			s.mintFeeCollector = true
+			defer func() {
+				s.mintFeeCollector = false
+			}()
+			s.SetupTest()
+
+			contractAddr, err := s.setupRegisterERC20Pair(contractMinterBurner)
+			s.Require().NoError(err)
+
+			senderAcc := s.keyring.GetAccAddr(0)
+			senderHex := s.keyring.GetAddr(0)
+			denom := types.CreateDenom(contractAddr.String())
+			total := math.NewInt(initialMint)
+
+			_, err = s.MintERC20Token(contractAddr, senderHex, big.NewInt(initialMint))
+			s.Require().NoError(err)
+
+			rng := rand.New(rand.NewSource(seed))
+			erc20Keeper := s.network.App.GetErc20Keeper()
+			bankKeeper := s.network.App.GetBankKeeper()
+			erc20ABI := contracts.ERC20MinterBurnerDecimalsContract.ABI
+
+			for i := 0; i < steps; i++ {
+				ctx := s.network.GetContext()
+				erc20Bal := erc20Keeper.BalanceOf(ctx, erc20ABI, contractAddr, senderHex)
+				coinBal := bankKeeper.GetBalance(ctx, senderAcc, denom).Amount
+
+				combined := new(big.Int).Add(erc20Bal, coinBal.BigInt())
+				s.Require().Equal(total.String(), combined.String(), "value should be conserved before step")
+
+				convertFromERC20 := rng.Intn(2) == 0
+				if erc20Bal.Sign() == 0 {
+					convertFromERC20 = false
+				}
+				if coinBal.IsZero() {
+					convertFromERC20 = true
+				}
+
+				if convertFromERC20 {
+					max := erc20Bal.Int64()
+					amount := int64(rng.Intn(int(max)) + 1)
+					_, err = erc20Keeper.ConvertERC20(
+						ctx,
+						types.NewMsgConvertERC20(math.NewInt(amount), senderAcc, contractAddr, senderHex),
+					)
+					s.Require().NoError(err)
+				} else {
+					max := coinBal.Int64()
+					amount := int64(rng.Intn(int(max)) + 1)
+					_, err = erc20Keeper.ConvertCoin(
+						ctx,
+						types.NewMsgConvertCoin(sdk.NewCoin(denom, math.NewInt(amount)), senderHex, senderAcc),
+					)
+					s.Require().NoError(err)
+				}
+			}
+
+			ctx := s.network.GetContext()
+			finalERC20Bal := erc20Keeper.BalanceOf(ctx, erc20ABI, contractAddr, senderHex)
+			finalCoinBal := bankKeeper.GetBalance(ctx, senderAcc, denom).Amount
+			finalCombined := new(big.Int).Add(finalERC20Bal, finalCoinBal.BigInt())
+			s.Require().Equal(total.String(), finalCombined.String(), "value should be conserved after sequence")
+		})
+	}
+}

--- a/tests/integration/x/erc20/test_conversion_invariants_randomized.go
+++ b/tests/integration/x/erc20/test_conversion_invariants_randomized.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math/big"
 	"math/rand"
+	"strings"
 
 	"github.com/cosmos/evm/contracts"
 	"github.com/cosmos/evm/x/erc20/types"
@@ -45,13 +46,66 @@ func (s *KeeperTestSuite) TestRandomizedConvertRoundTripInvariant() {
 			bankKeeper := s.network.App.GetBankKeeper()
 			erc20ABI := contracts.ERC20MinterBurnerDecimalsContract.ABI
 
-			for i := 0; i < steps; i++ {
+			assertInvariants := func(phase string) {
 				ctx := s.network.GetContext()
 				erc20Bal := erc20Keeper.BalanceOf(ctx, erc20ABI, contractAddr, senderHex)
 				coinBal := bankKeeper.GetBalance(ctx, senderAcc, denom).Amount
 
 				combined := new(big.Int).Add(erc20Bal, coinBal.BigInt())
-				s.Require().Equal(total.String(), combined.String(), "value should be conserved before step")
+				s.Require().Equal(total.String(), combined.String(), "value should be conserved at %s", phase)
+
+				for _, bal := range bankKeeper.GetAllBalances(ctx, senderAcc) {
+					if strings.HasPrefix(bal.Denom, types.Erc20NativeCoinDenomPrefix) {
+						s.Require().Equal(denom, bal.Denom, "unexpected erc20 native denom at %s", phase)
+					}
+				}
+			}
+
+			// Deterministic edge sequence before random steps:
+			// smallest amount in/out, then full-balance in/out.
+			assertInvariants("initial")
+
+			_, err = erc20Keeper.ConvertERC20(
+				s.network.GetContext(),
+				types.NewMsgConvertERC20(math.NewInt(1), senderAcc, contractAddr, senderHex),
+			)
+			s.Require().NoError(err)
+			assertInvariants("after convertERC20(1)")
+
+			_, err = erc20Keeper.ConvertCoin(
+				s.network.GetContext(),
+				types.NewMsgConvertCoin(sdk.NewCoin(denom, math.NewInt(1)), senderHex, senderAcc),
+			)
+			s.Require().NoError(err)
+			assertInvariants("after convertCoin(1)")
+
+			ctx := s.network.GetContext()
+			allERC20 := erc20Keeper.BalanceOf(ctx, erc20ABI, contractAddr, senderHex)
+			if allERC20.Sign() > 0 {
+				_, err = erc20Keeper.ConvertERC20(
+					ctx,
+					types.NewMsgConvertERC20(math.NewIntFromBigInt(allERC20), senderAcc, contractAddr, senderHex),
+				)
+				s.Require().NoError(err)
+				assertInvariants("after full convertERC20")
+			}
+
+			allCoin := bankKeeper.GetBalance(s.network.GetContext(), senderAcc, denom).Amount
+			if !allCoin.IsZero() {
+				_, err = erc20Keeper.ConvertCoin(
+					s.network.GetContext(),
+					types.NewMsgConvertCoin(sdk.NewCoin(denom, allCoin), senderHex, senderAcc),
+				)
+				s.Require().NoError(err)
+				assertInvariants("after full convertCoin")
+			}
+
+			for i := 0; i < steps; i++ {
+				ctx := s.network.GetContext()
+				erc20Bal := erc20Keeper.BalanceOf(ctx, erc20ABI, contractAddr, senderHex)
+				coinBal := bankKeeper.GetBalance(ctx, senderAcc, denom).Amount
+
+				assertInvariants(fmt.Sprintf("before randomized step %d", i))
 
 				convertFromERC20 := rng.Intn(2) == 0
 				if erc20Bal.Sign() == 0 {
@@ -78,13 +132,10 @@ func (s *KeeperTestSuite) TestRandomizedConvertRoundTripInvariant() {
 					)
 					s.Require().NoError(err)
 				}
+				assertInvariants(fmt.Sprintf("after randomized step %d", i))
 			}
 
-			ctx := s.network.GetContext()
-			finalERC20Bal := erc20Keeper.BalanceOf(ctx, erc20ABI, contractAddr, senderHex)
-			finalCoinBal := bankKeeper.GetBalance(ctx, senderAcc, denom).Amount
-			finalCombined := new(big.Int).Add(finalERC20Bal, finalCoinBal.BigInt())
-			s.Require().Equal(total.String(), finalCombined.String(), "value should be conserved after sequence")
+			assertInvariants("final")
 		})
 	}
 }

--- a/testutil/constants/constants.go
+++ b/testutil/constants/constants.go
@@ -47,31 +47,12 @@ var ChainsCoinInfo = map[uint64]evmtypes.EvmCoinInfo{ // TODO:VLAD - deduplicate
 		DisplayDenom:  ExampleDisplayDenom,
 		Decimals:      evmtypes.EighteenDecimals.Uint32(),
 	},
-	// SixDecimalsChainID provides a chain ID which is being set up with 6 decimals
-	SixDecimalsChainID.EVMChainID: {
-		Denom:         "utest",
-		ExtendedDenom: "atest",
-		DisplayDenom:  "test",
-		Decimals:      evmtypes.SixDecimals.Uint32(),
-	},
 	// EVMChainID provides a chain ID used for internal testing
 	config.DefaultEVMChainID: {
 		Denom:         "atest",
 		ExtendedDenom: "atest",
 		DisplayDenom:  "test",
 		Decimals:      evmtypes.EighteenDecimals.Uint32(),
-	},
-	TwelveDecimalsChainID.EVMChainID: {
-		Denom:         "ptest2",
-		ExtendedDenom: "atest2",
-		DisplayDenom:  "test2",
-		Decimals:      evmtypes.TwelveDecimals.Uint32(),
-	},
-	TwoDecimalsChainID.EVMChainID: {
-		Denom:         "ctest3",
-		ExtendedDenom: "atest3",
-		DisplayDenom:  "test3",
-		Decimals:      evmtypes.TwoDecimals.Uint32(),
 	},
 }
 
@@ -90,24 +71,6 @@ var (
 		EVMChainID: 9001,
 	}
 
-	// SixDecimalsChainID provides a chain ID which is being set up with 6 decimals
-	SixDecimalsChainID = ChainID{
-		ChainID:    "ossix-2",
-		EVMChainID: 9002,
-	}
-
-	// TwelveDecimalsChainID provides a chain ID which is being set up with 12 decimals
-	TwelveDecimalsChainID = ChainID{
-		ChainID:    "ostwelve-3",
-		EVMChainID: 9003,
-	}
-
-	// TwoDecimalsChainID provides a chain ID which is being set up with 2 decimals
-	TwoDecimalsChainID = ChainID{
-		ChainID:    "ostwo-4",
-		EVMChainID: 9004,
-	}
-
 	// ExampleChainCoinInfo provides the coin info for the example chain
 	//
 	// It is a map of the chain id and its corresponding EvmCoinInfo
@@ -119,24 +82,6 @@ var (
 			ExtendedDenom: ExampleAttoDenom,
 			DisplayDenom:  ExampleDisplayDenom,
 			Decimals:      evmtypes.EighteenDecimals.Uint32(),
-		},
-		SixDecimalsChainID: {
-			Denom:         "utest",
-			ExtendedDenom: "atest",
-			DisplayDenom:  "test",
-			Decimals:      evmtypes.SixDecimals.Uint32(),
-		},
-		TwelveDecimalsChainID: {
-			Denom:         "ptest2",
-			ExtendedDenom: "atest2",
-			DisplayDenom:  "test2",
-			Decimals:      evmtypes.TwelveDecimals.Uint32(),
-		},
-		TwoDecimalsChainID: {
-			Denom:         "ctest3",
-			ExtendedDenom: "atest3",
-			DisplayDenom:  "test3",
-			Decimals:      evmtypes.TwoDecimals.Uint32(),
 		},
 	}
 

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -793,10 +793,21 @@ func TestCalcBaseFee(t *testing.T) {
 }
 
 func TestCalcBaseFeeRejectsUnsupportedDecimals(t *testing.T) {
-	for _, chainID := range []constants.ChainID{constants.TwelveDecimalsChainID, constants.SixDecimalsChainID} {
-		t.Run(chainID.ChainID, func(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		decimals uint32
+	}{
+		{name: "twelve", decimals: evmtypes.TwelveDecimals.Uint32()},
+		{name: "six", decimals: evmtypes.SixDecimals.Uint32()},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
 			evmConfigurator := evmtypes.NewEVMConfigurator().
-				WithEVMCoinInfo(constants.ExampleChainCoinInfo[chainID])
+				WithEVMCoinInfo(evmtypes.EvmCoinInfo{
+					Denom:         constants.ExampleAttoDenom,
+					ExtendedDenom: constants.ExampleAttoDenom,
+					DisplayDenom:  "custom",
+					Decimals:      tc.decimals,
+				})
 			evmConfigurator.ResetTestConfig()
 			err := evmConfigurator.Configure()
 			require.ErrorContains(t, err, "only 18 is supported")

--- a/x/vm/types/configurator_test.go
+++ b/x/vm/types/configurator_test.go
@@ -23,8 +23,18 @@ func TestEVMConfigurator(t *testing.T) {
 
 func TestEVMConfiguratorRejectsNon18Decimals(t *testing.T) {
 	for _, coinInfo := range []types.EvmCoinInfo{
-		testconstants.ExampleChainCoinInfo[testconstants.SixDecimalsChainID],
-		testconstants.ExampleChainCoinInfo[testconstants.TwelveDecimalsChainID],
+		{
+			Denom:         testconstants.ExampleAttoDenom,
+			ExtendedDenom: testconstants.ExampleAttoDenom,
+			DisplayDenom:  "custom6",
+			Decimals:      types.SixDecimals.Uint32(),
+		},
+		{
+			Denom:         testconstants.ExampleAttoDenom,
+			ExtendedDenom: testconstants.ExampleAttoDenom,
+			DisplayDenom:  "custom12",
+			Decimals:      types.TwelveDecimals.Uint32(),
+		},
 	} {
 		t.Run(coinInfo.DisplayDenom, func(t *testing.T) {
 			ec := types.NewEVMConfigurator().WithEVMCoinInfo(coinInfo)

--- a/x/vm/types/scaling_fuzz_test.go
+++ b/x/vm/types/scaling_fuzz_test.go
@@ -1,6 +1,7 @@
 package types_test
 
 import (
+	stdmath "math"
 	"testing"
 
 	testconstants "github.com/cosmos/evm/testutil/constants"
@@ -27,7 +28,7 @@ func FuzzConvertCoinsDenomToExtendedDenomWithEvmParams(f *testing.F) {
 
 	f.Fuzz(func(t *testing.T, amount uint64, includeOtherDenom bool) {
 		input := sdk.NewCoins(sdk.NewCoin(coinInfo.Denom, math.NewIntFromUint64(amount)))
-		if includeOtherDenom {
+		if includeOtherDenom && amount < stdmath.MaxUint64 {
 			input = input.Add(sdk.NewCoin("other", math.NewIntFromUint64(amount+1))).Sort()
 		}
 
@@ -45,7 +46,7 @@ func FuzzConvertCoinsDenomToExtendedDenomWithEvmParams(f *testing.F) {
 		}
 
 		// Non-EVM denoms should be preserved.
-		if includeOtherDenom && converted.AmountOf("other").String() != math.NewIntFromUint64(amount+1).String() {
+		if includeOtherDenom && amount < stdmath.MaxUint64 && converted.AmountOf("other").String() != math.NewIntFromUint64(amount+1).String() {
 			t.Fatalf("unexpected non-evm denom amount: %s", converted.AmountOf("other"))
 		}
 	})

--- a/x/vm/types/scaling_fuzz_test.go
+++ b/x/vm/types/scaling_fuzz_test.go
@@ -1,0 +1,52 @@
+package types_test
+
+import (
+	"testing"
+
+	testconstants "github.com/cosmos/evm/testutil/constants"
+	evmtypes "github.com/cosmos/evm/x/vm/types"
+
+	"cosmossdk.io/math"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+func FuzzConvertCoinsDenomToExtendedDenomWithEvmParams(f *testing.F) {
+	f.Add(uint64(0), false)
+	f.Add(uint64(1), false)
+	f.Add(uint64(1_000_000_000_000_000_000), true)
+	f.Add(uint64(42), true)
+
+	coinInfo := testconstants.ExampleChainCoinInfo[testconstants.ExampleChainID]
+	params := evmtypes.Params{
+		EvmDenom: coinInfo.Denom,
+		ExtendedDenomOptions: &evmtypes.ExtendedDenomOptions{
+			ExtendedDenom: coinInfo.ExtendedDenom,
+		},
+	}
+
+	f.Fuzz(func(t *testing.T, amount uint64, includeOtherDenom bool) {
+		input := sdk.NewCoins(sdk.NewCoin(coinInfo.Denom, math.NewIntFromUint64(amount)))
+		if includeOtherDenom {
+			input = input.Add(sdk.NewCoin("other", math.NewIntFromUint64(amount+1))).Sort()
+		}
+
+		converted := evmtypes.ConvertCoinsDenomToExtendedDenomWithEvmParams(input, params)
+		convertedAgain := evmtypes.ConvertCoinsDenomToExtendedDenomWithEvmParams(converted, params)
+
+		// Conversion should be idempotent.
+		if !convertedAgain.Equal(converted) {
+			t.Fatalf("expected idempotent conversion, got %s then %s", converted, convertedAgain)
+		}
+
+		// EVM coin amount should be preserved under denom relabeling.
+		if converted.AmountOf(coinInfo.ExtendedDenom).String() != math.NewIntFromUint64(amount).String() {
+			t.Fatalf("unexpected converted amount: %s", converted.AmountOf(coinInfo.ExtendedDenom))
+		}
+
+		// Non-EVM denoms should be preserved.
+		if includeOtherDenom && converted.AmountOf("other").String() != math.NewIntFromUint64(amount+1).String() {
+			t.Fatalf("unexpected non-evm denom amount: %s", converted.AmountOf("other"))
+		}
+	})
+}

--- a/x/vm/types/scaling_fuzz_test.go
+++ b/x/vm/types/scaling_fuzz_test.go
@@ -4,6 +4,8 @@ import (
 	stdmath "math"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	testconstants "github.com/cosmos/evm/testutil/constants"
 	evmtypes "github.com/cosmos/evm/x/vm/types"
 
@@ -11,6 +13,16 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
+
+func buildFuzzInputCoins(evmDenom string, amount uint64, includeOtherDenom bool) sdk.Coins {
+	input := sdk.NewCoins(sdk.NewCoin(evmDenom, math.NewIntFromUint64(amount)))
+	// Guard against uint64 wraparound for amount+1 when amount == MaxUint64.
+	if includeOtherDenom && amount < stdmath.MaxUint64 {
+		input = input.Add(sdk.NewCoin("other", math.NewIntFromUint64(amount+1))).Sort()
+	}
+
+	return input
+}
 
 func FuzzConvertCoinsDenomToExtendedDenomWithEvmParams(f *testing.F) {
 	f.Add(uint64(0), false)
@@ -27,10 +39,7 @@ func FuzzConvertCoinsDenomToExtendedDenomWithEvmParams(f *testing.F) {
 	}
 
 	f.Fuzz(func(t *testing.T, amount uint64, includeOtherDenom bool) {
-		input := sdk.NewCoins(sdk.NewCoin(coinInfo.Denom, math.NewIntFromUint64(amount)))
-		if includeOtherDenom && amount < stdmath.MaxUint64 {
-			input = input.Add(sdk.NewCoin("other", math.NewIntFromUint64(amount+1))).Sort()
-		}
+		input := buildFuzzInputCoins(coinInfo.Denom, amount, includeOtherDenom)
 
 		converted := evmtypes.ConvertCoinsDenomToExtendedDenomWithEvmParams(input, params)
 		convertedAgain := evmtypes.ConvertCoinsDenomToExtendedDenomWithEvmParams(converted, params)
@@ -50,4 +59,14 @@ func FuzzConvertCoinsDenomToExtendedDenomWithEvmParams(f *testing.F) {
 			t.Fatalf("unexpected non-evm denom amount: %s", converted.AmountOf("other"))
 		}
 	})
+}
+
+func TestBuildFuzzInputCoinsMaxUint64Guard(t *testing.T) {
+	coinInfo := testconstants.ExampleChainCoinInfo[testconstants.ExampleChainID]
+
+	inputAtMax := buildFuzzInputCoins(coinInfo.Denom, stdmath.MaxUint64, true)
+	require.Equal(t, "0", inputAtMax.AmountOf("other").String())
+
+	inputBelowMax := buildFuzzInputCoins(coinInfo.Denom, stdmath.MaxUint64-1, true)
+	require.Equal(t, math.NewIntFromUint64(stdmath.MaxUint64).String(), inputBelowMax.AmountOf("other").String())
 }


### PR DESCRIPTION
## Summary
- remove remaining dual-denom (6/12/2 decimal) support paths from test constants and test suites now that runtime enforces 18-decimal-only configuration
- update non-18 rejection tests to use inline custom coin-info fixtures instead of shared multi-decimal constants
- add randomized ERC20 convert round-trip invariant coverage and a Go fuzz target for scaling/denom conversion idempotence

## Test plan
- [x] `go test -tags=test ./x/vm/types ./utils`
- [x] `go test -tags=test ./tests/integration/testutil`
- [x] `go test -tags=test ./tests/integration -run 'TestERC20KeeperTestSuite|TestWERC20PrecompileUnitTestSuite'` (from `evmd/`)

Made with [Cursor](https://cursor.com)