### PR TITLE
fix(statedb): snapshot locked balance on statedb account 

### DIFF
--- a/tests/integration/precompiles/staking/test_integration.go
+++ b/tests/integration/precompiles/staking/test_integration.go
@@ -35,7 +35,11 @@ import (
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/cosmos/cosmos-sdk/types/query"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	vestingtypes "github.com/cosmos/cosmos-sdk/x/auth/vesting/types"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+
+	basefactory "github.com/cosmos/evm/testutil/integration/base/factory"
 )
 
 var (
@@ -425,6 +429,90 @@ func TestPrecompileIntegrationTestSuite(t *testing.T, create network.CreateEvmAp
 						logCheckArgs,
 					)
 					Expect(err).To(BeNil(), "error while calling the smart contract: %v", err)
+				})
+			})
+
+			Context("from a vesting account", func() {
+				var (
+					vestAddr     sdk.AccAddress
+					vestPriv     *ethsecp256k1.PrivKey
+					amtLocked    math.Int
+					amtSpendable math.Int
+					preBal       math.Int
+					preSupply    math.Int
+				)
+
+				BeforeEach(func() {
+					// setup vesting account to delegate from
+					vestAddr, vestPriv = testutiltx.NewAccAddressAndKey()
+					amtLocked = math.NewInt(2e18)
+					amtSpendable = math.NewInt(2e18)
+
+					funder := s.keyring.GetKey(0)
+					startTime := s.network.GetContext().BlockTime().Unix()
+					createMsg := &vestingtypes.MsgCreateVestingAccount{
+						FromAddress: funder.AccAddr.String(),
+						ToAddress:   vestAddr.String(),
+						Amount:      sdk.NewCoins(sdk.NewCoin(s.bondDenom, amtLocked)),
+						EndTime:     startTime + 365*24*3600,
+						Delayed:     false,
+					}
+					sendMsg := banktypes.NewMsgSend(
+						funder.AccAddr, vestAddr,
+						sdk.NewCoins(sdk.NewCoin(s.bondDenom, amtSpendable)),
+					)
+					_, err := s.factory.CommitCosmosTx(funder.Priv, basefactory.CosmosTxArgs{
+						Msgs: []sdk.Msg{createMsg, sendMsg},
+					})
+					Expect(err).To(BeNil(), "error while submitting vesting setup tx")
+
+					ctx := s.network.GetContext()
+					_, ok := s.network.App.GetAccountKeeper().GetAccount(ctx, vestAddr).(*vestingtypes.ContinuousVestingAccount)
+					Expect(ok).To(BeTrue(), "expected vesting account to persist after tx commit")
+					spendable := s.network.App.GetBankKeeper().SpendableCoin(ctx, vestAddr, s.bondDenom).Amount
+					Expect(spendable).To(Equal(amtSpendable), "unexpected spendable balance after vesting setup")
+
+					preBalRes, err := s.grpcHandler.GetBalanceFromBank(vestAddr, s.bondDenom)
+					Expect(err).To(BeNil(), "error while getting pre balance")
+					preBal = preBalRes.Balance.Amount
+					Expect(preBal).To(Equal(amtLocked.Add(amtSpendable)), "expected vester pre bank balance to equal OV + extra")
+
+					preSupplyRes, err := s.grpcHandler.GetTotalSupply()
+					Expect(err).To(BeNil(), "error while getting pre supply")
+					preSupply = preSupplyRes.Supply.AmountOf(s.bondDenom)
+				})
+
+				It("should preserve bank balance and total supply when delegating within spendable", func() {
+					// delegating less than spendable balance and less than
+					// locked balance
+					delAmt := big.NewInt(1e18)
+					gasPrice := big.NewInt(1e9)
+
+					callArgs.Args = []interface{}{
+						common.BytesToAddress(vestAddr), valAddr.String(), delAmt,
+					}
+					delTxArgs := txArgs
+					delTxArgs.GasPrice = gasPrice
+
+					logCheckArgs := passCheck.WithExpEvents(staking.EventTypeDelegate)
+					res, _, err := s.factory.CallContractAndCheckLogs(
+						vestPriv, delTxArgs, callArgs, logCheckArgs,
+					)
+					Expect(err).To(BeNil(), "error while calling the smart contract: %v", err)
+					Expect(s.network.NextBlock()).To(BeNil())
+
+					postBalRes, err := s.grpcHandler.GetBalanceFromBank(vestAddr, s.bondDenom)
+					Expect(err).To(BeNil(), "error while getting post balance")
+					postSupplyRes, err := s.grpcHandler.GetTotalSupply()
+					Expect(err).To(BeNil(), "error while getting post supply")
+					postBal := postBalRes.Balance.Amount
+					postSupply := postSupplyRes.Supply.AmountOf(s.bondDenom)
+
+					gasCost := new(big.Int).Mul(gasPrice, big.NewInt(res.GasUsed))
+					expBalDrop := new(big.Int).Add(delAmt, gasCost)
+					actualBalDrop := preBal.Sub(postBal).BigInt()
+					Expect(actualBalDrop).To(Equal(expBalDrop), "vesting bank balance dropped by more than delegation amount + gas")
+					Expect(postSupply).To(Equal(preSupply), "unexpected total supply after delegating from vesting account")
 				})
 			})
 

--- a/tests/integration/precompiles/staking/test_integration.go
+++ b/tests/integration/precompiles/staking/test_integration.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cosmos/evm/precompiles/testutil"
 	"github.com/cosmos/evm/precompiles/testutil/contracts"
 	cosmosevmutil "github.com/cosmos/evm/testutil/constants"
+	basefactory "github.com/cosmos/evm/testutil/integration/base/factory"
 	"github.com/cosmos/evm/testutil/integration/evm/network"
 	"github.com/cosmos/evm/testutil/integration/evm/utils"
 	testutiltx "github.com/cosmos/evm/testutil/tx"
@@ -38,8 +39,6 @@ import (
 	vestingtypes "github.com/cosmos/cosmos-sdk/x/auth/vesting/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
-
-	basefactory "github.com/cosmos/evm/testutil/integration/base/factory"
 )
 
 var (

--- a/tests/integration/precompiles/staking/test_staking.go
+++ b/tests/integration/precompiles/staking/test_staking.go
@@ -393,7 +393,7 @@ func (s *PrecompileTestSuite) TestRun() {
 				s.Require().NoError(err, "failed to pack input")
 				return input
 			},
-			21559, // use enough gas to avoid out of gas error
+			25000, // use enough gas to avoid out of gas error
 			true,
 			false,
 			true,
@@ -404,7 +404,7 @@ func (s *PrecompileTestSuite) TestRun() {
 			func(_ keyring.Key) []byte {
 				return []byte("invalid")
 			},
-			21559, // use enough gas to avoid out of gas error
+			25000, // use enough gas to avoid out of gas error
 			false,
 			false,
 			true,

--- a/tests/integration/x/vm/test_statedb.go
+++ b/tests/integration/x/vm/test_statedb.go
@@ -911,6 +911,68 @@ func (s *KeeperTestSuite) TestAddSlotToAccessList() {
 // 	}
 // }
 
+// TestGetAccountLocked verifies Keeper.GetAccount snapshots LockedCoins for
+// the EVM denom into the Account at load time. The snapshot powers the commit
+// path's bank-balance reconstruction without re-reading LockedCoins after a
+// precompile may have mutated DelegatedVesting on a vesting account.
+func (s *KeeperTestSuite) TestGetAccountLocked() {
+	addr := utiltx.GenerateAddress()
+	bondDenom := s.Network.GetBaseDenom()
+
+	testCases := []struct {
+		name      string
+		malleate  func()
+		expLocked *big.Int
+	}{
+		{
+			"non-existent account returns nil",
+			func() {},
+			nil, // GetAccount returns nil entirely; checked separately
+		},
+		{
+			"base account has zero Locked snapshot",
+			func() {
+				ctx := s.Network.GetContext()
+				err := s.Network.App.GetBankKeeper().SendCoins(ctx, s.Keyring.GetAccAddr(0), addr.Bytes(), sdk.NewCoins(sdk.NewCoin(bondDenom, math.NewInt(100))))
+				s.Require().NoError(err)
+			},
+			big.NewInt(0),
+		},
+		{
+			"vesting account snapshots OriginalVesting at start time",
+			func() {
+				ctx := s.Network.GetContext()
+				accAddr := sdk.AccAddress(addr.Bytes())
+				err := s.Network.App.GetBankKeeper().SendCoins(ctx, s.Keyring.GetAccAddr(0), accAddr, sdk.NewCoins(sdk.NewCoin(bondDenom, math.NewInt(100))))
+				s.Require().NoError(err)
+
+				baseAccount := s.Network.App.GetAccountKeeper().GetAccount(ctx, accAddr).(*authtypes.BaseAccount)
+				currTime := ctx.BlockTime().Unix()
+				acc, err := vestingtypes.NewContinuousVestingAccount(baseAccount, sdk.NewCoins(sdk.NewCoin(bondDenom, math.NewInt(100))), currTime, currTime+100)
+				s.Require().NoError(err)
+				s.Network.App.GetAccountKeeper().SetAccount(ctx, acc)
+			},
+			big.NewInt(100),
+		},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			s.SetupTest()
+			tc.malleate()
+			acc := s.Network.App.GetEVMKeeper().GetAccount(s.Network.GetContext(), addr)
+			if tc.expLocked == nil {
+				s.Require().Nil(acc, "expected nil account")
+				return
+			}
+			s.Require().NotNil(acc, "expected non-nil account")
+			locked := acc.LockedBalanceSnapshot()
+			s.Require().NotNil(locked, "expected Locked snapshot to be populated")
+			s.Require().Zero(tc.expLocked.Cmp(locked), "Locked snapshot mismatch: want %s got %s", tc.expLocked, locked)
+		})
+	}
+}
+
 func (s *KeeperTestSuite) TestSetBalance() {
 	amount := common.U2560
 	totalBalance := common.U2560
@@ -1044,6 +1106,96 @@ func (s *KeeperTestSuite) TestSetBalance() {
 				spendable := s.Network.App.GetEVMKeeper().SpendableCoin(s.Network.GetContext(), tc.addr)
 				s.Require().Equal(amount, spendable)
 			}
+		})
+	}
+}
+
+func (s *KeeperTestSuite) TestSetBalanceWithLocked() {
+	amount := common.U2560
+	var locked *big.Int
+	addr := utiltx.GenerateAddress()
+
+	testCases := []struct {
+		name           string
+		addr           common.Address
+		malleate       func()
+		expErr         bool
+		expTotalAmount func() *uint256.Int
+		expSpendable   func() *uint256.Int
+	}{
+		{
+			"non vesting account: locked overrides reread",
+			addr,
+			func() {
+				amount = uint256.NewInt(100)
+				locked = big.NewInt(50)
+			},
+			false,
+			func() *uint256.Int {
+				return uint256.NewInt(150)
+			},
+			func() *uint256.Int {
+				// All funds are spendable on a non base account, the snapshot
+				// only inflates the bank balance reconstruction.
+				return uint256.NewInt(150)
+			},
+		},
+		{
+			"vesting account: locked snapshot beats current LockedCoins re-read",
+			addr,
+			func() {
+				ctx := s.Network.GetContext()
+				accAddr := sdk.AccAddress(addr.Bytes())
+				err := s.Network.App.GetBankKeeper().SendCoins(ctx, s.Keyring.GetAccAddr(0), accAddr, sdk.NewCoins(sdk.NewCoin(s.Network.GetBaseDenom(), math.NewInt(100))))
+				s.Require().NoError(err)
+
+				baseAccount := s.Network.App.GetAccountKeeper().GetAccount(ctx, accAddr).(*authtypes.BaseAccount)
+				baseDenom := s.Network.GetBaseDenom()
+				currTime := s.Network.GetContext().BlockTime().Unix()
+
+				// setup vesting account with 40 locked to simulate a spend
+				acc, err := vestingtypes.NewContinuousVestingAccount(
+					baseAccount,
+					sdk.NewCoins(sdk.NewCoin(baseDenom, math.NewInt(40))),
+					currTime, currTime+100,
+				)
+				s.Require().NoError(err)
+				s.Network.App.GetAccountKeeper().SetAccount(ctx, acc)
+
+				amount = uint256.NewInt(100)
+
+				// override locked to 100
+				locked = big.NewInt(100)
+			},
+			false,
+			func() *uint256.Int {
+				// ensure we used the override of 100
+				return uint256.NewInt(200)
+			},
+			func() *uint256.Int {
+				// spendable = bank balance − current LockedCoins = 200 − 40 = 160.
+				return uint256.NewInt(160)
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			s.SetupTest()
+
+			tc.malleate()
+			err := s.Network.App.GetEVMKeeper().SetBalanceWithLocked(s.Network.GetContext(), tc.addr, amount, locked)
+			if tc.expErr {
+				s.Require().Error(err)
+				return
+			}
+
+			balance := s.Network.App.GetEVMKeeper().GetBalance(s.Network.GetContext(), tc.addr)
+			s.Require().NoError(err)
+			s.Require().Equal(tc.expTotalAmount(), balance)
+
+			spendable := s.Network.App.GetEVMKeeper().SpendableCoin(s.Network.GetContext(), tc.addr)
+			s.Require().Equal(tc.expSpendable(), spendable)
 		})
 	}
 }

--- a/x/erc20/keeper/dynamic_precompiles.go
+++ b/x/erc20/keeper/dynamic_precompiles.go
@@ -45,21 +45,14 @@ func (k Keeper) RegisterERC20CodeHash(ctx sdk.Context, erc20Addr common.Address)
 		k.evmKeeper.SetCode(ctx, codeHash, bytecode)
 	}
 
-	var (
-		nonce   uint64
-		balance = common.U2560
-	)
-	// keep balance and nonce if account exists
-	if acc := k.evmKeeper.GetAccount(ctx, erc20Addr); acc != nil {
-		nonce = acc.Nonce
-		balance = acc.Balance
+	// reuse account with modified code hash if it already exists
+	acc := k.evmKeeper.GetAccount(ctx, erc20Addr)
+	if acc == nil {
+		acc = statedb.NewEmptyAccount()
 	}
+	acc.CodeHash = codeHash
 
-	return k.evmKeeper.SetAccount(ctx, erc20Addr, statedb.Account{
-		CodeHash: codeHash,
-		Nonce:    nonce,
-		Balance:  balance,
-	})
+	return k.evmKeeper.SetAccount(ctx, erc20Addr, *acc)
 }
 
 // UnRegisterERC20CodeHash sets the codehash for the account to an empty one

--- a/x/vm/keeper/keeper.go
+++ b/x/vm/keeper/keeper.go
@@ -343,7 +343,6 @@ func (k *Keeper) lockedCoin(ctx sdk.Context, addr common.Address) *big.Int {
 	defer span.End()
 	cosmosAddr := sdk.AccAddress(addr.Bytes())
 
-	// Get the balance via bank wrapper to convert it to 18 decimals if needed.
 	lockedCoins := k.bankWrapper.LockedCoins(ctx, cosmosAddr)
 	lockedGasCoin := lockedCoins.AmountOf(types.GetEVMCoinDenom())
 

--- a/x/vm/keeper/keeper.go
+++ b/x/vm/keeper/keeper.go
@@ -337,6 +337,19 @@ func (k *Keeper) SpendableCoin(ctx sdk.Context, addr common.Address) *uint256.In
 	return result
 }
 
+// lockedCoin loads account's locked balance of the gas token.
+func (k *Keeper) lockedCoin(ctx sdk.Context, addr common.Address) *big.Int {
+	ctx, span := ctx.StartSpan(tracer, "LockedCoin", trace.WithAttributes(attribute.String("address", addr.Hex())))
+	defer span.End()
+	cosmosAddr := sdk.AccAddress(addr.Bytes())
+
+	// Get the balance via bank wrapper to convert it to 18 decimals if needed.
+	lockedCoins := k.bankWrapper.LockedCoins(ctx, cosmosAddr)
+	lockedGasCoin := lockedCoins.AmountOf(types.GetEVMCoinDenom())
+
+	return lockedGasCoin.BigInt()
+}
+
 // GetBalance load account's balance of gas token.
 func (k *Keeper) GetBalance(ctx sdk.Context, addr common.Address) *uint256.Int {
 	ctx, span := ctx.StartSpan(tracer, "GetBalance", trace.WithAttributes(attribute.String("address", addr.Hex())))

--- a/x/vm/keeper/statedb.go
+++ b/x/vm/keeper/statedb.go
@@ -32,13 +32,19 @@ var _ statedb.Keeper = &Keeper{}
 func (k *Keeper) GetAccount(ctx sdk.Context, addr common.Address) *statedb.Account {
 	ctx, span := ctx.StartSpan(tracer, "GetAccount", trace.WithAttributes(attribute.String("address", addr.Hex())))
 	defer span.End()
-	acct := k.GetAccountWithoutBalance(ctx, addr)
+
+	cosmosAddr := sdk.AccAddress(addr.Bytes())
+	acct := k.accountKeeper.GetAccount(ctx, cosmosAddr)
 	if acct == nil {
 		return nil
 	}
 
-	acct.Balance = k.SpendableCoin(ctx, addr)
-	return acct
+	return statedb.NewAccount(
+		acct.GetSequence(),
+		k.SpendableCoin(ctx, addr),
+		k.lockedCoin(ctx, addr),
+		k.GetCodeHash(ctx, addr).Bytes(),
+	)
 }
 
 // GetState loads contract state from database.
@@ -135,12 +141,39 @@ func (k *Keeper) ForEachStorage(ctx sdk.Context, addr common.Address, cb func(ke
 	}
 }
 
-// SetBalance update account's balance, compare with current balance first, then decide to mint or burn.
+// SetBalance update account's balance, compare with current balance first,
+// then decide to mint or burn.
+//
+// If account has a Locked balance specified within it, that value is used in
+// order to compute the final balance. If Locked is nil, account's locked
+// balance is fetched from state first in order to compute the final balance.
+func (k *Keeper) SetAccountBalance(ctx sdk.Context, addr common.Address, account statedb.Account) error {
+	locked := account.LockedBalanceSnapshot()
+	if locked == nil {
+		return k.SetBalance(ctx, addr, account.Balance)
+	}
+	return k.SetBalanceWithLocked(ctx, addr, account.Balance, locked)
+}
+
+// SetBalance updates an account's balance, compare with current balance first,
+// then decide to mint or burn.
 func (k *Keeper) SetBalance(ctx sdk.Context, addr common.Address, amount *uint256.Int) (err error) {
+	cosmosAddr := sdk.AccAddress(addr.Bytes())
+	lockedCoin := k.bankWrapper.LockedCoins(ctx, cosmosAddr).AmountOf(types.GetEVMCoinDenom())
+	return k.SetBalanceWithLocked(ctx, addr, amount, lockedCoin.BigInt())
+}
+
+// SetBalance updates an account's balance, compare with current balance first,
+// then decide to mint or burn.
+//
+// Locked must be non nil and is used to compute the final balance instead of
+// looking it up from state at set time. If you do not know the locked balance
+// already, use SetBalance in order to look it up from state at set time.
+func (k *Keeper) SetBalanceWithLocked(ctx sdk.Context, addr common.Address, amount *uint256.Int, locked *big.Int) (err error) {
 	if amount == nil {
 		return nil
 	}
-	ctx, span := ctx.StartSpan(tracer, "SetBalance", trace.WithAttributes(attribute.String("address", addr.Hex()), attribute.String("amount", amount.String())))
+	ctx, span := ctx.StartSpan(tracer, "SetBalanceWithLocked", trace.WithAttributes(attribute.String("address", addr.Hex()), attribute.String("amount", amount.String())))
 	defer func() { evmtrace.EndSpanErr(span, err) }()
 	cosmosAddr := sdk.AccAddress(addr.Bytes())
 
@@ -150,9 +183,7 @@ func (k *Keeper) SetBalance(ctx sdk.Context, addr common.Address, amount *uint25
 		return errorsmod.Wrapf(errortypes.ErrUnauthorized, "%s is not allowed to receive funds", cosmosAddr)
 	}
 
-	locked := k.bankWrapper.LockedCoins(ctx, cosmosAddr)
-	newBalance := new(big.Int).Add(amount.ToBig(), locked.AmountOf(types.GetEVMCoinDenom()).BigInt())
-
+	newBalance := new(big.Int).Add(amount.ToBig(), locked)
 	return k.bankWrapper.SetBalance(ctx, cosmosAddr, newBalance)
 }
 
@@ -180,7 +211,7 @@ func (k *Keeper) SetAccount(ctx sdk.Context, addr common.Address, account stated
 	}
 	k.accountKeeper.SetAccount(ctx, acct)
 
-	if err := k.SetBalance(ctx, addr, account.Balance); err != nil {
+	if err := k.SetAccountBalance(ctx, addr, account); err != nil {
 		return err
 	}
 
@@ -190,6 +221,7 @@ func (k *Keeper) SetAccount(ctx sdk.Context, addr common.Address, account stated
 		"nonce", account.Nonce,
 		"codeHash", common.BytesToHash(account.CodeHash).Hex(),
 		"balance", account.Balance,
+		"locked-balance", account.LockedBalanceSnapshot(),
 	)
 	return nil
 }
@@ -314,8 +346,7 @@ func (k *Keeper) DeleteAccount(ctx sdk.Context, addr common.Address) error {
 	baseAccount := k.accountKeeper.GetAccount(ctx, cosmosAddr)
 	k.accountKeeper.SetAccount(ctx, authtypes.NewBaseAccount(cosmosAddr, baseAccount.GetPubKey(), baseAccount.GetAccountNumber(), baseAccount.GetSequence()))
 
-	// clear balance
-	if err := k.SetBalance(ctx, addr, new(uint256.Int)); err != nil {
+	if err := k.SetBalanceWithLocked(ctx, addr, new(uint256.Int), new(big.Int)); err != nil {
 		return err
 	}
 

--- a/x/vm/keeper/statedb.go
+++ b/x/vm/keeper/statedb.go
@@ -141,7 +141,7 @@ func (k *Keeper) ForEachStorage(ctx sdk.Context, addr common.Address, cb func(ke
 	}
 }
 
-// SetBalance update account's balance, compare with current balance first,
+// SetAccountBalance update account's balance, compare with current balance first,
 // then decide to mint or burn.
 //
 // If account has a Locked balance specified within it, that value is used in

--- a/x/vm/keeper/statedb.go
+++ b/x/vm/keeper/statedb.go
@@ -163,8 +163,8 @@ func (k *Keeper) SetBalance(ctx sdk.Context, addr common.Address, amount *uint25
 	return k.SetBalanceWithLocked(ctx, addr, amount, lockedCoin.BigInt())
 }
 
-// SetBalance updates an account's balance, compare with current balance first,
-// then decide to mint or burn.
+// SetBalanceWithLocked updates an account's balance, compare with current
+// balance first, then decide to mint or burn.
 //
 // Locked must be non nil and is used to compute the final balance instead of
 // looking it up from state at set time. If you do not know the locked balance
@@ -173,6 +173,7 @@ func (k *Keeper) SetBalanceWithLocked(ctx sdk.Context, addr common.Address, amou
 	if amount == nil {
 		return nil
 	}
+
 	ctx, span := ctx.StartSpan(tracer, "SetBalanceWithLocked", trace.WithAttributes(attribute.String("address", addr.Hex()), attribute.String("amount", amount.String())))
 	defer func() { evmtrace.EndSpanErr(span, err) }()
 	cosmosAddr := sdk.AccAddress(addr.Bytes())

--- a/x/vm/statedb/state_object.go
+++ b/x/vm/statedb/state_object.go
@@ -3,6 +3,7 @@ package statedb
 import (
 	"bytes"
 	"fmt"
+	"math/big"
 	"sort"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -17,6 +18,11 @@ type Account struct {
 	Nonce    uint64
 	Balance  *uint256.Int
 	CodeHash []byte
+
+	// lockedBalance is a snapshot of Account's LockedCoins at load time. Note
+	// that this is simply a constant offset to recover the full bank balance
+	// from spendable Balance at commit, not a live updating value.
+	lockedBalance *big.Int
 }
 
 // NewEmptyAccount returns an empty account.
@@ -27,9 +33,28 @@ func NewEmptyAccount() *Account {
 	}
 }
 
+// NewAccount returns a new account instance.
+func NewAccount(nonce uint64, balance *uint256.Int, lockedBalance *big.Int, codeHash []byte) *Account {
+	return &Account{
+		Nonce:         nonce,
+		Balance:       balance,
+		CodeHash:      codeHash,
+		lockedBalance: lockedBalance,
+	}
+}
+
 // IsContract returns if the account contains contract code.
 func (acct Account) HasCodeHash() bool {
 	return !types.IsEmptyCodeHash(acct.CodeHash)
+}
+
+// LockedBalanceSnapshot returns a copy of the LockedCoins value observed when
+// the account was loaded, or nil if no snapshot was recorded.
+func (acct Account) LockedBalanceSnapshot() *big.Int {
+	if acct.lockedBalance == nil {
+		return nil
+	}
+	return new(big.Int).Set(acct.lockedBalance)
 }
 
 // Storage represents in-memory cache/buffer of contract storage.


### PR DESCRIPTION
# Description

Snapshots accounts locked balance when EVM accounts are fetched from the keeper. This is to ensure that the accounts total bank balance is properly reconstructed when its locked balance has been modified via a precompile.

Closes: STACK-2786

---

## Author Checklist

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.

I have...

- [ ] tackled an existing issue or discussed with a team member
- [ ] left instructions on how to review the changes
- [ ] targeted the `main` branch
