### PR TITLE
fix: remove nonexistent vesting precompile address

### DIFF
--- a/x/vm/types/precompiles.go
+++ b/x/vm/types/precompiles.go
@@ -9,7 +9,6 @@ const (
 	StakingPrecompileAddress      = "0x0000000000000000000000000000000000000800"
 	DistributionPrecompileAddress = "0x0000000000000000000000000000000000000801"
 	ICS20PrecompileAddress        = "0x0000000000000000000000000000000000000802"
-	VestingPrecompileAddress      = "0x0000000000000000000000000000000000000803"
 	BankPrecompileAddress         = "0x0000000000000000000000000000000000000804"
 	GovPrecompileAddress          = "0x0000000000000000000000000000000000000805"
 	SlashingPrecompileAddress     = "0x0000000000000000000000000000000000000806"
@@ -26,7 +25,6 @@ var AvailableStaticPrecompiles = []string{
 	StakingPrecompileAddress,
 	DistributionPrecompileAddress,
 	ICS20PrecompileAddress,
-	VestingPrecompileAddress,
 	BankPrecompileAddress,
 	GovPrecompileAddress,
 	SlashingPrecompileAddress,


### PR DESCRIPTION
## Fix: Remove nonexistent vesting precompile address

Fixes #1192

### Problem

`0x0000000000000000000000000000000000000803` is included in `AvailableStaticPrecompiles`, but no vesting precompile implementation exists in the codebase. This causes:

1. Default params mark a nonexistent precompile as active
2. Calls to that address hit the missing registered precompile path

### Solution

Removed `VestingPrecompileAddress` constant and its reference from `AvailableStaticPrecompiles` in `x/vm/types/precompiles.go`.

### Changes

- Removed `VestingPrecompileAddress = "0x0000000000000000000000000000000000000803"` constant
- Removed `VestingPrecompileAddress` from `AvailableStaticPrecompiles` slice