### PR TITLE
perf(vm): avoid duplicate LockedCoins read in GetAccount

### DIFF
--- a/x/vm/keeper/keeper.go
+++ b/x/vm/keeper/keeper.go
@@ -337,16 +337,24 @@ func (k *Keeper) SpendableCoin(ctx sdk.Context, addr common.Address) *uint256.In
 	return result
 }
 
-// lockedCoin loads account's locked balance of the gas token.
-func (k *Keeper) lockedCoin(ctx sdk.Context, addr common.Address) *big.Int {
-	ctx, span := ctx.StartSpan(tracer, "LockedCoin", trace.WithAttributes(attribute.String("address", addr.Hex())))
-	defer span.End()
+// spendableAndLockedCoin reads balance and locked coins once and derives both
+// spendable and locked from a single LockedCoins read, avoiding the duplicate
+// read that occurred when they were fetched independently. Denom == ExtendedDenom
+// is enforced for 18-decimal chains, so a single denom lookup is correct.
+func (k *Keeper) spendableAndLockedCoin(ctx sdk.Context, addr common.Address) (*uint256.Int, *big.Int) {
 	cosmosAddr := sdk.AccAddress(addr.Bytes())
+	denom := types.GetEVMCoinDenom()
 
-	lockedCoins := k.bankWrapper.LockedCoins(ctx, cosmosAddr)
-	lockedGasCoin := lockedCoins.AmountOf(types.GetEVMCoinDenom())
+	balance := k.bankWrapper.GetBalance(ctx, cosmosAddr, denom)
+	locked := k.bankWrapper.LockedCoins(ctx, cosmosAddr)
+	lockedAmt := locked.AmountOf(denom)
 
-	return lockedGasCoin.BigInt()
+	spendableCoin := balance.SubAmount(lockedAmt)
+	spendable, err := utils.Uint256FromBigInt(spendableCoin.Amount.BigInt())
+	if err != nil {
+		return nil, lockedAmt.BigInt()
+	}
+	return spendable, lockedAmt.BigInt()
 }
 
 // GetBalance load account's balance of gas token.

--- a/x/vm/keeper/statedb.go
+++ b/x/vm/keeper/statedb.go
@@ -39,10 +39,11 @@ func (k *Keeper) GetAccount(ctx sdk.Context, addr common.Address) *statedb.Accou
 		return nil
 	}
 
+	spendable, locked := k.spendableAndLockedCoin(ctx, addr)
 	return statedb.NewAccount(
 		acct.GetSequence(),
-		k.SpendableCoin(ctx, addr),
-		k.lockedCoin(ctx, addr),
+		spendable,
+		locked,
 		k.GetCodeHash(ctx, addr).Bytes(),
 	)
 }


### PR DESCRIPTION
# Description

`GetAccount` computed spendable and locked via separate `SpendableCoin` and
`lockedCoin` calls, each reading `LockedCoins` from the bank store — so every
`GetAccount` read `LockedCoins` twice. This reads balance and `LockedCoins`
once in a new `spendableAndLockedCoin` helper and derives both; the now-unused
`lockedCoin` is removed.

### Equivalence
- **locked**: `LockedCoins(addr).AmountOf(evmDenom)` — unchanged.
- **spendable**: `balance.SubAmount(locked)` on the `sdk.Coin` from
  `bankWrapper.GetBalance`, identical to what `bankWrapper.SpendableCoin`
  computes (same `sdk.Coin.SubAmount`, same panic-on-negative).

`validateCoinInfo` enforces `Denom == ExtendedDenom` + 18 decimals, so
`AmountOf(evmDenom) == AmountOf(extendedDenom)`; the values and the #1187
locked-snapshot semantics are preserved.

### Benchmarks
Transfer-saturated block, local harness (not in-tree, happy to share),
2000 txs/block, `-benchtime=10x -count=6`, Ryzen 9 7900 (n=6):

| benchmark | sec/op | B/op | allocs/op |
|---|---|---|---|
| Sequential | 677.5m → 661.8m (−2.32%, p=0.004) | 393.3Mi → 380.5Mi (−3.26%) | 6.030M → 5.758M (−4.51%) |
| BlockSTM | 206.5m → 209.6m (~, p=0.82) | 464.5Mi → 452.3Mi (−2.63%) | 6.954M → 6.692M (−3.77%) |

p=0.002 unless noted. Allocations drop significantly on both paths; serial
wall-time −2.3%; Block-STM wall-time is within noise. Workload-dependent —
smaller for contract-heavy blocks.

### Tests
`TestKeeperTestSuite` (StateDB balance suite) and the staking-precompile suite
(#1187 locked-via-precompile guard) pass unchanged.

The merged helper no longer opens the `SpendableCoin`/`LockedCoin` tracing
sub-spans (the parent `GetAccount` span is unchanged).

Closes: #1202

---

## Author Checklist

I have...
- [x] tackled an existing issue or discussed with a team member — #1202
- [x] left instructions on how to review the changes — see **Equivalence** above
- [x] targeted the `main` branch