### PR TITLE
chore: Fix goroutine leak in mempool event subscription

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 ### DEPENDENCIES
 
 ### API-BREAKING
-- [\#1146](https://github.com/cosmos/evm/pull/1146) Remove `EndBlocker` based mempool updates, use `PrepareCheckStater` instead. 
+
+- [\#1146](https://github.com/cosmos/evm/pull/1146) Remove `EndBlocker` based mempool updates, use `PrepareCheckStater` instead.
 
 ### IMPROVEMENTS
 
@@ -61,13 +62,14 @@
 - [\#1061](https://github.com/cosmos/evm/pull/1061) Block nested ICS20 forwarding in source callbacks.
 - [\#1050](https://github.com/cosmos/evm/pull/1050) Align precompile gas calculation with expected EVM gas semantics.
 - [\#1107](https://github.com/cosmos/evm/pull/1107) Skip StateDB commit error transactions during receipt conversion to prevent `invalid message index` errors in block RPCs.
-
+- [\#NNNN](https://github.com/cosmos/evm/pull/NNNN) Fix blocking on mempool event bus unsubscribe.
 
 ## v0.6.0
 
 Follow the [migration document](docs/migrations/v0.5.x_to_v0.6.0.md) for upgrade instructions.
 
 ### BREAKING CHANGES
+
 - Removed IBC Transfer wrapper. Users are now required to use the precompile to transfer ERC20 tokens.
 - Added StateDB as a parameter to internal EVM calls.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,7 +62,7 @@
 - [\#1061](https://github.com/cosmos/evm/pull/1061) Block nested ICS20 forwarding in source callbacks.
 - [\#1050](https://github.com/cosmos/evm/pull/1050) Align precompile gas calculation with expected EVM gas semantics.
 - [\#1107](https://github.com/cosmos/evm/pull/1107) Skip StateDB commit error transactions during receipt conversion to prevent `invalid message index` errors in block RPCs.
-- [\#NNNN](https://github.com/cosmos/evm/pull/NNNN) Fix blocking on mempool event bus unsubscribe.
+- [\#1216](https://github.com/cosmos/evm/pull/1216) Fix blocking on mempool event bus unsubscribe.
 
 ## v0.6.0
 

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -127,7 +127,8 @@ type Mempool struct {
 	blockGasLimit uint64 // Block gas limit from consensus parameters
 	minTip        *uint256.Int
 
-	eventBus *cmttypes.EventBus
+	eventBus   *cmttypes.EventBus
+	eventBusWG sync.WaitGroup // tracks the SetEventBus listener goroutine
 
 	/** Transaction Reaping **/
 	reapList *reaplist.ReapList
@@ -522,11 +523,18 @@ func (m *Mempool) SetEventBus(eventBus *cmttypes.EventBus) {
 	if err != nil {
 		panic(err)
 	}
-	go func() {
-		for range sub.Out() {
-			m.NotifyNewBlock()
+	m.eventBusWG.Go(func() {
+		for {
+			select {
+			case <-sub.Out():
+				m.NotifyNewBlock()
+			case <-sub.Canceled():
+				// Unsubscribe/Close cancels the subscription; Out() is never
+				// closed by CometBFT, so exit on cancellation to avoid leaking.
+				return
+			}
 		}
-	}()
+	})
 }
 
 // NotifyNewBlock manually notifies that there has been a new block produced
@@ -547,6 +555,7 @@ func (m *Mempool) Close() error {
 		if err := m.eventBus.Unsubscribe(context.Background(), SubscriberName, stream.NewBlockHeaderEvents); err != nil {
 			errs = append(errs, fmt.Errorf("failed to unsubscribe from event bus: %w", err))
 		}
+		m.eventBusWG.Wait()
 	}
 
 	if err := m.recheckCosmosPool.Close(); err != nil {

--- a/mempool/mempool_test.go
+++ b/mempool/mempool_test.go
@@ -819,6 +819,12 @@ func setupMempool(t *testing.T, numAccounts, insertQueueSize int) (*mempool.Memp
 	require.NoError(t, eventBus.Start())
 	mp.SetEventBus(eventBus)
 
+	// Close the mempool
+	t.Cleanup(func() {
+		require.NoError(t, mp.Close())
+		require.NoError(t, eventBus.Stop())
+	})
+
 	return mp, testMempoolDependencies{
 		vmKeeper:        mockVMKeeper,
 		txConfig:        txConfig,


### PR DESCRIPTION
# Description

Fixes a race condition which causes flaky tests. Cometbft never closes the subscription channel, instead choosing to close the Cancelled channel. By closing the goroutine on Cancelled and putting a waitgroup in place we now properly cleanup the goroutine when we add the Close call in our tests.

Example stack trace from a failing test
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x3d9c0e0]

goroutine 2295 [running]:
github.com/cosmos/evm/x/vm/types.GetEthChainConfig()
    /home/runner/work/evm/evm/x/vm/types/config_testing.go:104 +0xc0
github.com/cosmos/evm/mempool.(*Blockchain).CurrentBlock(0xc000e8d208)
    /home/runner/work/evm/evm/mempool/blockchain.go:114 +0x85a
github.com/cosmos/evm/mempool.(*Mempool).NotifyNewBlock(0xc001789088)
    /home/runner/work/evm/evm/mempool/mempool.go:536 +0xe6
github.com/cosmos/evm/mempool.(*Mempool).SetEventBus.func1()
    /home/runner/work/evm/evm/mempool/mempool.go:527 +0x98
created by github.com/cosmos/evm/mempool.(*Mempool).SetEventBus in goroutine 2242
    /home/runner/work/evm/evm/mempool/mempool.go:525 +0x33d
```