### PR TITLE
fix: Update txn estimates to target latest block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - [\#1008](https://github.com/cosmos/evm/pull/1008) Stop enforcing JSON-RPC global filter cap and allow reclaim filters via configurable idle timeout.
 - [\#1130](https://github.com/cosmos/evm/pull/1130) Use `sdk.ValidateAuthority` in `x/vm`, `x/erc20`, and `x/feemarket` `MsgServer` handlers so authority can optionally be centralized via the consensus `AuthorityParams` introduced in cosmos-sdk v0.54.
 - [\#1164](https://github.com/cosmos/evm/pull/1164) Remove zero gas config from `ics20.transferWithStateDB` so inner KV ops in ICS20 transfer execution are metered, mirroring [\#1103](https://github.com/cosmos/evm/pull/1103).
+- [\#1220](https://github.com/cosmos/evm/pull/1220) Use latest block for setting txn defaults in rpc call.
 
 ### FEATURES
 

--- a/rpc/backend/call_tx.go
+++ b/rpc/backend/call_tx.go
@@ -279,7 +279,7 @@ func (b *Backend) SetTxDefaults(ctx context.Context, args evmtypes.TransactionAr
 			Nonce:                args.Nonce,
 		}
 
-		// Estimate against the "pending", or latest, block
+		// Estimate against the "pending", or latest, block by passing nil.
 		estimated, err := b.EstimateGas(ctx, callArgs, nil, nil)
 		if err != nil {
 			return args, err

--- a/rpc/backend/call_tx.go
+++ b/rpc/backend/call_tx.go
@@ -279,9 +279,8 @@ func (b *Backend) SetTxDefaults(ctx context.Context, args evmtypes.TransactionAr
 			Nonce:                args.Nonce,
 		}
 
-		blockNr := rpctypes.NewBlockNumber(big.NewInt(0))
-		blockNrOrHash := rpctypes.BlockNumberOrHash{BlockNumber: &blockNr}
-		estimated, err := b.EstimateGas(ctx, callArgs, &blockNrOrHash, nil)
+		// Estimate against the "pending", or latest, block
+		estimated, err := b.EstimateGas(ctx, callArgs, nil, nil)
 		if err != nil {
 			return args, err
 		}


### PR DESCRIPTION
# Description

Use the latest block for estimating txn gas defaults. 

The existing default of block `0` will always run against the genesis state because the `Int64` conversion in [EstimateGas](https://github.com/cosmos/evm/blob/7c492afda512f3720b2d387ac581a5658a8ae1fd/rpc/backend/call_tx.go#L349) converts `0` to `1` [see here](https://github.com/cosmos/evm/blob/7c492afda512f3720b2d387ac581a5658a8ae1fd/rpc/types/block.go#L110), moving the gas estimation to use the genesis block. Passing `nil` here fixes the behaviour.