### PR TITLE
fix(erc20): propagate conversion ack in v2 ibc OnRecvPacket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # CHANGELOG
 
+## UNRELEASED
+
+### DEPENDENCIES
+
+### API-BREAKING
+
+### IMPROVEMENTS
+
+### FEATURES
+
+### BUG FIXES
+- [\#1222](https://github.com/cosmos/evm/pull/1222) Propagate ERC20 conversion ack in IBC v2 `OnRecvPacket`.
+
 ## v0.6.0
 
 Follow the [migration document](docs/migrations/v0.5.x_to_v0.6.0.md) for upgrade instructions.

--- a/x/erc20/v2/ibc_middleware.go
+++ b/x/erc20/v2/ibc_middleware.go
@@ -89,9 +89,9 @@ func (im IBCMiddleware) OnRecvPacket(
 	modifiedAck := im.keeper.OnRecvPacket(ctx, packet, ack)
 	if !modifiedAck.Success() {
 		return channeltypesv2.RecvPacketResult{Status: channeltypesv2.PacketStatus_Failure}
-	} else if !bytes.Equal(modifiedAck.Acknowledgement(), ack.Acknowledgement()) {
-		ctx.Logger().Error("erc20 ibcv2 middleware keeper modified the application ack, original: %s modified: %s", ack.Acknowledgement(), modifiedAck.Acknowledgement())
-		return channeltypesv2.RecvPacketResult{Status: recvResult.Status, Acknowledgement: modifiedAck.Acknowledgement()}
+	}
+	if !bytes.Equal(modifiedAck.Acknowledgement(), ack.Acknowledgement()) {
+		ctx.Logger().Error("erc20 ibcv2 middleware keeper modified the application ack", "original", ack.Acknowledgement(), "modified", modifiedAck.Acknowledgement())
 	}
 	return channeltypesv2.RecvPacketResult{Status: recvResult.Status, Acknowledgement: modifiedAck.Acknowledgement()}
 }


### PR DESCRIPTION
# Description

align v2 with [main](https://github.com/cosmos/evm/blob/a739fe18f0854b137589e77aacf5c63da67527c8/x/erc20/v2/ibc_middleware.go#L89-L96) so failed native-ERC20 conversion surfaces as failure result

---

## Author Checklist

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.

I have...

- [ ] tackled an existing issue or discussed with a team member
- [ ] left instructions on how to review the changes
- [ ] targeted the `main` branch
