### PR TITLE
fix: reject EVM txs below base fee at mempool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 
 ### BUG FIXES
 
+- [\#1223](https://github.com/cosmos/evm/pull/1223) Reject EVM txs below the base fee at mempool insert instead of silently queuing them.
 - [\#1047](https://github.com/cosmos/evm/pull/1047) Resolve EthTxIndex -1 sentinel before uint cast in ReceiptsFromCometBlock, preventing transactionIndex overflow to MaxUint64.
 - [\#965](https://github.com/cosmos/evm/pull/965) Fix gas double charging on EVM calls in IBCOnTimeoutPacketCallback.
 - [\#869](https://github.com/cosmos/evm/pull/869) Fix erc20 IBC callbacks to check for native token transfer before parsing recipient.

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -335,6 +335,14 @@ func (m *Mempool) insert(tx sdk.Tx) (<-chan error, error) {
 	case err == nil:
 		ethTx := ethMsg.AsTransaction()
 
+		// Reject txs below base fee up-front, which can never be included.
+		if baseFee := m.blockchain.CurrentBlock().BaseFee; baseFee != nil && ethTx.GasFeeCapIntCmp(baseFee) < 0 {
+			return nil, sdkerrors.ErrInsufficientFee.Wrapf(
+				"max fee per gas (%s) is lower than the base fee (%s)",
+				ethTx.GasFeeCap(), baseFee,
+			)
+		}
+
 		// we push the tx onto the evm insert queue so the tx will be inserted
 		// at a later point. We get back a subscription that the insert queue
 		// will use to notify the caller of any errors that occurred when

--- a/mempool/mempool_test.go
+++ b/mempool/mempool_test.go
@@ -455,6 +455,21 @@ func TestMempool_CosmosNonceAdvanceDropsStaleEVM(t *testing.T) {
 	}, time.Second, 10*time.Millisecond, "expected pending and queued pools to drain after stale txs dropped")
 }
 
+func TestMempool_InsertRejectsUnderpricedEVMTx(t *testing.T) {
+	mp, s := setupMempoolWithAccounts(t, 1)
+	txConfig, accounts := s.txConfig, s.accounts
+
+	// Base fee is mocked at 1e8 (see setupMempool). 1e7 is below it.
+	underpriced := createMsgEthereumTx(t, txConfig, accounts[0].key, 0, big.NewInt(1e7))
+	err := mp.Insert(context.Background(), underpriced)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "insufficient fee")
+
+	// A tx priced at the base fee is accepted.
+	priced := createMsgEthereumTx(t, txConfig, accounts[0].key, 0, big.NewInt(1e8))
+	require.NoError(t, mp.Insert(context.Background(), priced))
+}
+
 func TestMempool_InsertMultiMsgCosmosTx(t *testing.T) {
 	mp, s := setupMempoolWithAccounts(t, 3)
 	txConfig, bus := s.txConfig, s.eventBus
@@ -728,7 +743,8 @@ func setupMempool(t *testing.T, numAccounts, insertQueueSize int) (*mempool.Memp
 	mockFeeMarketKeeper := mocks.NewFeeMarketKeeper(t)
 
 	// Setup mock expectations
-	mockVMKeeper.On("GetBaseFee", mock.Anything).Return(big.NewInt(1e9)).Maybe()
+	// Base fee is set to 1e8 so the 1e8-priced txs used throughout these tests clear the insert-time fee gate.
+	mockVMKeeper.On("GetBaseFee", mock.Anything).Return(big.NewInt(1e8)).Maybe()
 	mockVMKeeper.On("GetParams", mock.Anything).Return(vmtypes.DefaultParams()).Maybe()
 	mockFeeMarketKeeper.On("GetBlockGasWanted", mock.Anything).Return(uint64(10000000)).Maybe()
 	mockVMKeeper.On("GetEvmCoinInfo", mock.Anything).Return(constants.ChainsCoinInfo[constants.EighteenDecimalsChainID]).Maybe()

--- a/tests/integration/mempool/test_mempool_integration.go
+++ b/tests/integration/mempool/test_mempool_integration.go
@@ -1064,7 +1064,8 @@ func (s *IntegrationTestSuite) TestEVMTransactionComprehensive() {
 			setupTx: func() sdk.Tx {
 				return s.createEVMValueTransferTx(s.keyring.GetKey(0), 0, big.NewInt(100000000)) // 0.1 gaatom
 			},
-			wantError: false,
+			wantError:     true,
+			errorContains: "insufficient fee",
 			verifyFunc: func() {
 				mpool := s.network.App.GetMempool()
 				s.Require().Equal(0, mpool.CountTx())


### PR DESCRIPTION
# Description

to avoid underpriced evm tx pass pool's default 0 min-tip gate, silently queued but never included

---

## Author Checklist

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.

I have...

- [ ] tackled an existing issue or discussed with a team member
- [ ] left instructions on how to review the changes
- [ ] targeted the `main` branch
