### PR TITLE
fix: Move tests to use eoa instead of module account as deployer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@
 - [\#1164](https://github.com/cosmos/evm/pull/1164) Remove zero gas config from `ics20.transferWithStateDB` so inner KV ops in ICS20 transfer execution are metered, mirroring [\#1103](https://github.com/cosmos/evm/pull/1103).
 - [\#1220](https://github.com/cosmos/evm/pull/1220) Use latest block for setting txn defaults in rpc call.
 - [\#1232](https://github.com/cosmos/evm/pull/1232) Validate ICS-20 acknowledgement encoding in the erc20 IBC v2 middleware.
-- [\#XXXX](https://github.com/cosmos/evm/pull/XXXX) Deploy contracts from an EOA rather than a module account in the test helpers. It is also now required: contract creation bumps the sender's nonce, `SetAccount` persists nonce and balance together, and the EVM commit path may not write a module account's balance.
+- [\#1243](https://github.com/cosmos/evm/pull/1243) Deploy contracts from an EOA rather than a module account in the test helpers. It is also now required: contract creation bumps the sender's nonce, `SetAccount` persists nonce and balance together, and the EVM commit path may not write a module account's balance.
 
 ### FEATURES
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - [\#1164](https://github.com/cosmos/evm/pull/1164) Remove zero gas config from `ics20.transferWithStateDB` so inner KV ops in ICS20 transfer execution are metered, mirroring [\#1103](https://github.com/cosmos/evm/pull/1103).
 - [\#1220](https://github.com/cosmos/evm/pull/1220) Use latest block for setting txn defaults in rpc call.
 - [\#1232](https://github.com/cosmos/evm/pull/1232) Validate ICS-20 acknowledgement encoding in the erc20 IBC v2 middleware.
+- [\#XXXX](https://github.com/cosmos/evm/pull/XXXX) Deploy contracts from an EOA rather than a module account in the test helpers. It is also now required: contract creation bumps the sender's nonce, `SetAccount` persists nonce and balance together, and the EVM commit path may not write a module account's balance.
 
 ### FEATURES
 

--- a/evmd/tests/ibc/helper.go
+++ b/evmd/tests/ibc/helper.go
@@ -51,7 +51,14 @@ func SetupNativeErc20(t *testing.T, chain *evmibctesting.TestChain, senderAcc ev
 	evmApp := chain.App.(evm.EvmApp)
 	ctx := chain.GetContext()
 
-	// Deploy new ERC20 contract with default metadata
+	// Deploy new ERC20 contract with default metadata.
+	// The deployer is a dedicated EOA.
+	deployer := common.BytesToAddress([]byte("erc20-test-deployer"))
+	deployerAccAddr := sdk.AccAddress(deployer.Bytes())
+	if evmApp.GetAccountKeeper().GetAccount(ctx, deployerAccAddr) == nil {
+		evmApp.GetAccountKeeper().SetAccount(ctx, evmApp.GetAccountKeeper().NewAccountWithAddress(ctx, deployerAccAddr))
+	}
+
 	stateDB := statedb.New(ctx, evmApp.GetEVMKeeper(), statedb.NewEmptyTxConfig())
 	contractAddr, err := DeployERC20Contract(ctx, stateDB, evmApp.GetAccountKeeper(), evmApp.GetEVMKeeper(), banktypes.Metadata{
 		DenomUnits: []*banktypes.DenomUnit{
@@ -59,7 +66,7 @@ func SetupNativeErc20(t *testing.T, chain *evmibctesting.TestChain, senderAcc ev
 		},
 		Name:   "Example",
 		Symbol: "Ex",
-	})
+	}, deployer)
 	if err != nil {
 		t.Fatalf("ERC20 deployment failed: %v", err)
 	}
@@ -84,7 +91,7 @@ func SetupNativeErc20(t *testing.T, chain *evmibctesting.TestChain, senderAcc ev
 		ctx,
 		stateDB,
 		contractAbi,
-		erc20types.ModuleAddress,
+		deployer,
 		contractAddr,
 		true,
 		false,
@@ -133,7 +140,8 @@ func SetupNativeErc20(t *testing.T, chain *evmibctesting.TestChain, senderAcc ev
 	}
 }
 
-// SetupNativeErc20 deploys, registers, and mints a native ERC20 token on an EVM-based chain.
+// DeployContract deploys an arbitrary contract on an EVM-based chain.
+// Like DeployERC20Contract, the sender is an EOA rather than a module account.
 func DeployContract(t *testing.T, chain *evmibctesting.TestChain, deploymentData testutiltypes.ContractDeploymentData) (common.Address, error) {
 	t.Helper()
 
@@ -163,14 +171,20 @@ func DeployContract(t *testing.T, chain *evmibctesting.TestChain, deploymentData
 	return crypto.CreateAddress(from, nonce), nil
 }
 
-// DeployERC20Contract creates and deploys an ERC20 contract on the EVM with the
-// erc20 module account as owner.
+// DeployERC20Contract creates and deploys an ERC20 contract on the EVM with
+// deployer as owner.
+//
+// deployer must be an EOA. Do not pass a module account.
+// It is also required in practice. Contract creation bumps the sender's nonce,
+// SetAccount persists nonce and balance together, and the EVM commit path is
+// not allowed to write a module account's balance.
 func DeployERC20Contract(
 	ctx sdk.Context,
 	stateDB *statedb.StateDB,
 	accountKeeper erc20types.AccountKeeper,
 	evmKeeper erc20types.EVMKeeper,
 	coinMetadata banktypes.Metadata,
+	deployer common.Address,
 ) (common.Address, error) {
 	decimals := uint8(0)
 	if len(coinMetadata.DenomUnits) > 0 {
@@ -191,13 +205,13 @@ func DeployERC20Contract(
 	copy(data[:len(contracts.ERC20MinterBurnerDecimalsContract.Bin)], contracts.ERC20MinterBurnerDecimalsContract.Bin)
 	copy(data[len(contracts.ERC20MinterBurnerDecimalsContract.Bin):], ctorArgs)
 
-	nonce, err := accountKeeper.GetSequence(ctx, erc20types.ModuleAddress.Bytes())
+	nonce, err := accountKeeper.GetSequence(ctx, deployer.Bytes())
 	if err != nil {
 		return common.Address{}, err
 	}
 
-	contractAddr := crypto.CreateAddress(erc20types.ModuleAddress, nonce)
-	_, err = evmKeeper.CallEVMWithData(ctx, stateDB, erc20types.ModuleAddress, nil, data, true, false, nil)
+	contractAddr := crypto.CreateAddress(deployer, nonce)
+	_, err = evmKeeper.CallEVMWithData(ctx, stateDB, deployer, nil, data, true, false, nil)
 	if err != nil {
 		return common.Address{}, errorsmod.Wrapf(err, "failed to deploy contract for %s", coinMetadata.Name)
 	}

--- a/tests/integration/precompiles/staking/test_integration.go
+++ b/tests/integration/precompiles/staking/test_integration.go
@@ -2243,10 +2243,11 @@ func TestPrecompileIntegrationTestSuite(t *testing.T, create network.CreateEvmAp
 
 					DescribeTable("should not delegate and update balances accordingly across orderings - internal transfer to tokens pool",
 						func(tc struct {
-							before  bool
-							after   bool
-							msgAmt  *big.Int
-						}) {
+							before bool
+							after  bool
+							msgAmt *big.Int
+						},
+						) {
 							args.MethodName = "testDelegateWithTransfer"
 							args.Args = []interface{}{
 								common.BytesToAddress(bondedTokensPoolAccAddr),

--- a/tests/integration/x/vm/test_call_evm.go
+++ b/tests/integration/x/vm/test_call_evm.go
@@ -11,6 +11,8 @@ import (
 	"github.com/cosmos/evm/x/erc20/types"
 	"github.com/cosmos/evm/x/vm/statedb"
 	evmtypes "github.com/cosmos/evm/x/vm/types"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 func (s *KeeperTestSuite) TestCallEVM() {
@@ -73,6 +75,22 @@ func (s *KeeperTestSuite) TestCallEVM() {
 func (s *KeeperTestSuite) TestCallEVMWithData() {
 	erc20 := contracts.ERC20MinterBurnerDecimalsContract.ABI
 	wcosmosEVMContract := common.HexToAddress(testconstants.WEVMOSContractMainnet)
+
+	// Deployments run from a dedicated EOA rather than a module account.
+	// It also fails in practice: contract creation bumps the sender's nonce,
+	// SetAccount writes nonce and balance together, and the EVM commit path may
+	// not write a module account's balance.
+	deployer := common.BytesToAddress([]byte("vm-test-deployer"))
+	// The sender's sequence is read before the message runs, so the account has to exist.
+	ensureDeployer := func() {
+		ctx := s.Network.GetContext()
+		ak := s.Network.App.GetAccountKeeper()
+		accAddr := sdk.AccAddress(deployer.Bytes())
+		if ak.GetAccount(ctx, accAddr) == nil {
+			ak.SetAccount(ctx, ak.NewAccountWithAddress(ctx, accAddr))
+		}
+	}
+
 	testCases := []struct {
 		name     string
 		from     common.Address
@@ -145,8 +163,9 @@ func (s *KeeperTestSuite) TestCallEVMWithData() {
 		},
 		{
 			name: "deploy",
-			from: types.ModuleAddress,
+			from: deployer,
 			malleate: func() []byte {
+				ensureDeployer()
 				ctorArgs, _ := contracts.ERC20MinterBurnerDecimalsContract.ABI.Pack("", "test", "test", uint8(18))
 				data := append(contracts.ERC20MinterBurnerDecimalsContract.Bin, ctorArgs...) //nolint:gocritic
 				return data
@@ -158,8 +177,9 @@ func (s *KeeperTestSuite) TestCallEVMWithData() {
 		},
 		{
 			name: "fail deploy",
-			from: types.ModuleAddress,
+			from: deployer,
 			malleate: func() []byte {
+				ensureDeployer()
 				params := s.Network.App.GetEVMKeeper().GetParams(s.Network.GetContext())
 				params.AccessControl.Create = evmtypes.AccessControlType{
 					AccessType: evmtypes.AccessTypeRestricted,
@@ -172,12 +192,13 @@ func (s *KeeperTestSuite) TestCallEVMWithData() {
 			deploy:   true,
 			useNilDB: false,
 			expPass:  false,
-			expError: "",
+			expError: "does not have permission to deploy contracts",
 		},
 		{
 			name: "fail deploy with nil statedb",
-			from: types.ModuleAddress,
+			from: deployer,
 			malleate: func() []byte {
+				ensureDeployer()
 				ctorArgs, _ := contracts.ERC20MinterBurnerDecimalsContract.ABI.Pack("", "test", "test", uint8(18))
 				data := append(contracts.ERC20MinterBurnerDecimalsContract.Bin, ctorArgs...) //nolint:gocritic
 				return data

--- a/tests/integration/x/vm/test_statedb.go
+++ b/tests/integration/x/vm/test_statedb.go
@@ -1113,8 +1113,8 @@ func (s *KeeperTestSuite) TestSetBalance() {
 
 func (s *KeeperTestSuite) TestSetBalanceRejectsModuleAccounts() {
 	type setup struct {
-		addr     common.Address
-		current  *uint256.Int
+		addr    common.Address
+		current *uint256.Int
 	}
 
 	cases := []struct {


### PR DESCRIPTION
# Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

<!-- Please keep your PR as draft until it's ready for review -->

<!-- Pull requests that sit inactive for longer than 30 days will be closed.  -->

Closes: https://linear.app/cosmoslabs/issue/FOU-1020/move-tests-to-use-eoa-instead-of-module-account-as-deployer

---

## Author Checklist

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.

I have...

- [x] tackled an existing issue or discussed with a team member
- [x] left instructions on how to review the changes
- [x] targeted the `main` branch
