### PR TITLE
fix(rpc): apply json-rpc.evm-timeout to eth_estimateGas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 
 ### BUG FIXES
 
+- [\#1265](https://github.com/cosmos/evm/pull/1265) Apply `json-rpc.evm-timeout` to `eth_estimateGas`, matching `eth_call`.
 - [\#1223](https://github.com/cosmos/evm/pull/1223) Reject EVM txs below the base fee at mempool insert instead of silently queuing them.
 - [\#1214](https://github.com/cosmos/evm/pull/1214) Emit the canonical CometBFT block hash in the `newHeads` subscription so it matches `eth_getBlockByNumber` (completes [\#725](https://github.com/cosmos/evm/pull/725)).
 - [\#1047](https://github.com/cosmos/evm/pull/1047) Resolve EthTxIndex -1 sentinel before uint cast in ReceiptsFromCometBlock, preventing transactionIndex overflow to MaxUint64.

--- a/rpc/backend/backend.go
+++ b/rpc/backend/backend.go
@@ -55,7 +55,7 @@ type EVMBackend interface {
 	NewMnemonic(uid string, language keyring.Language, hdPath, bip39Passphrase string, algo keyring.SignatureAlgo) (*keyring.Record, error)
 	UnprotectedAllowed() bool
 	RPCGasCap() uint64            // global gas cap for eth_call over rpc: DoS protection
-	RPCEVMTimeout() time.Duration // global timeout for eth_call over rpc: DoS protection
+	RPCEVMTimeout() time.Duration // global timeout for eth_call / eth_estimateGas over rpc: DoS protection
 	RPCTxFeeCap() float64         // RPCTxFeeCap is the global transaction fee(price * gaslimit) cap for send-transaction variants. The unit is ether.
 	RPCMinGasPrice() *big.Int
 

--- a/rpc/backend/call_tx.go
+++ b/rpc/backend/call_tx.go
@@ -346,6 +346,12 @@ func (b *Backend) EstimateGas(
 	// it will return an empty context and the gRPC query will use
 	// the latest block height for querying.
 	ctx = rpctypes.ContextWithHeight(ctx, blockNr.Int64())
+	if timeout := b.RPCEVMTimeout(); timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, timeout)
+		defer cancel()
+	}
+
 	res, err := b.QueryClient.EstimateGas(ctx, &req)
 	if err != nil {
 		return 0, err
@@ -398,20 +404,11 @@ func (b *Backend) DoCall(
 	// it will return an empty context and the gRPC query will use
 	// the latest block height for querying.
 	ctx = rpctypes.ContextWithHeight(ctx, blockNr.Int64())
-	timeout := b.RPCEVMTimeout()
-
-	// Setup context so it may be canceled the call has completed
-	// or, in case of unmetered gas, setup a context with a timeout.
-	var cancel context.CancelFunc
-	if timeout > 0 {
+	if timeout := b.RPCEVMTimeout(); timeout > 0 {
+		var cancel context.CancelFunc
 		ctx, cancel = context.WithTimeout(ctx, timeout)
-	} else {
-		ctx, cancel = context.WithCancel(ctx)
+		defer cancel()
 	}
-
-	// Make sure the context is canceled when the call has completed
-	// this makes sure resources are cleaned up.
-	defer cancel()
 
 	res, err := b.QueryClient.EthCall(ctx, &req)
 	if err != nil {

--- a/rpc/backend/call_tx_timeout_test.go
+++ b/rpc/backend/call_tx_timeout_test.go
@@ -1,0 +1,97 @@
+package backend
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+
+	cmtrpctypes "github.com/cometbft/cometbft/rpc/core/types"
+	tmtypes "github.com/cometbft/cometbft/types"
+
+	"github.com/cosmos/evm/rpc/backend/mocks"
+	rpctypes "github.com/cosmos/evm/rpc/types"
+	evmtypes "github.com/cosmos/evm/x/vm/types"
+)
+
+func TestEstimateGasAppliesEVMTimeout(t *testing.T) {
+	backend := setupMockBackend(t)
+	backend.Cfg.JSONRPC.EVMTimeout = 10 * time.Millisecond
+
+	client := backend.ClientCtx.Client.(*mocks.Client)
+	client.On("Header", mock.Anything, mock.Anything).Return(&cmtrpctypes.ResultHeader{
+		Header: &tmtypes.Header{Height: 1},
+	}, nil)
+
+	queryClient := backend.QueryClient.QueryClient.(*mocks.EVMQueryClient)
+	queryClient.On("EstimateGas", mock.Anything, mock.Anything).Return(
+		func(ctx context.Context, _ *evmtypes.EthCallRequest, _ ...grpc.CallOption) (*evmtypes.EstimateGasResponse, error) {
+			<-ctx.Done()
+			return nil, ctx.Err()
+		},
+		nil,
+	)
+
+	from := common.HexToAddress("0x1234567890abcdef1234567890abcdef12345678")
+	args := evmtypes.TransactionArgs{From: &from}
+	blockNum := rpctypes.BlockNumber(1)
+	_, err := backend.EstimateGas(context.Background(), args, &rpctypes.BlockNumberOrHash{BlockNumber: &blockNum}, nil)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
+func TestDoCallAppliesEVMTimeout(t *testing.T) {
+	backend := setupMockBackend(t)
+	backend.Cfg.JSONRPC.EVMTimeout = 10 * time.Millisecond
+
+	client := backend.ClientCtx.Client.(*mocks.Client)
+	client.On("Header", mock.Anything, mock.Anything).Return(&cmtrpctypes.ResultHeader{
+		Header: &tmtypes.Header{Height: 1},
+	}, nil)
+
+	queryClient := backend.QueryClient.QueryClient.(*mocks.EVMQueryClient)
+	queryClient.On("EthCall", mock.Anything, mock.Anything).Return(
+		func(ctx context.Context, _ *evmtypes.EthCallRequest, _ ...grpc.CallOption) (*evmtypes.MsgEthereumTxResponse, error) {
+			<-ctx.Done()
+			return nil, ctx.Err()
+		},
+		nil,
+	)
+
+	from := common.HexToAddress("0x1234567890abcdef1234567890abcdef12345678")
+	args := evmtypes.TransactionArgs{From: &from}
+	_, err := backend.DoCall(context.Background(), args, rpctypes.BlockNumber(1), nil)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
+func TestEstimateGasZeroTimeoutHasNoDeadline(t *testing.T) {
+	backend := setupMockBackend(t)
+	backend.Cfg.JSONRPC.EVMTimeout = 0
+
+	client := backend.ClientCtx.Client.(*mocks.Client)
+	client.On("Header", mock.Anything, mock.Anything).Return(&cmtrpctypes.ResultHeader{
+		Header: &tmtypes.Header{Height: 1},
+	}, nil)
+
+	queryClient := backend.QueryClient.QueryClient.(*mocks.EVMQueryClient)
+	queryClient.On("EstimateGas", mock.Anything, mock.Anything).Return(
+		func(ctx context.Context, _ *evmtypes.EthCallRequest, _ ...grpc.CallOption) (*evmtypes.EstimateGasResponse, error) {
+			require.NoError(t, ctx.Err())
+			_, ok := ctx.Deadline()
+			require.False(t, ok)
+			return &evmtypes.EstimateGasResponse{Gas: 21000}, nil
+		},
+		nil,
+	)
+
+	from := common.HexToAddress("0x1234567890abcdef1234567890abcdef12345678")
+	args := evmtypes.TransactionArgs{From: &from}
+	blockNum := rpctypes.BlockNumber(1)
+	result, err := backend.EstimateGas(context.Background(), args, &rpctypes.BlockNumberOrHash{BlockNumber: &blockNum}, nil)
+	require.NoError(t, err)
+	require.Equal(t, hexutil.Uint64(21000), result)
+}

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -92,7 +92,7 @@ const (
 	// DefaultBlockRangeCap is the default cap of block range allowed for 'eth_getLogs' query
 	DefaultBlockRangeCap int32 = 10000
 
-	// DefaultEVMTimeout is the default timeout for eth_call
+	// DefaultEVMTimeout is the default timeout for eth_call and eth_estimateGas
 	DefaultEVMTimeout = 5 * time.Second
 
 	// DefaultTxFeeCap is the default tx-fee cap for sending a transaction
@@ -259,7 +259,7 @@ type JSONRPCConfig struct {
 	GasCap uint64 `mapstructure:"gas-cap"`
 	// AllowInsecureUnlock toggles if account unlocking is enabled when account-related RPCs are exposed by http.
 	AllowInsecureUnlock bool `mapstructure:"allow-insecure-unlock"`
-	// EVMTimeout is the global timeout for eth-call.
+	// EVMTimeout is the global timeout for eth_call and eth_estimateGas.
 	EVMTimeout time.Duration `mapstructure:"evm-timeout"`
 	// TxFeeCap is the global tx-fee cap for send transaction
 	TxFeeCap float64 `mapstructure:"txfee-cap"`

--- a/server/config/migration/v0.50-app.toml
+++ b/server/config/migration/v0.50-app.toml
@@ -274,7 +274,7 @@ gas-cap = 25000000
 # Allow insecure account unlocking when account-related RPCs are exposed by http
 allow-insecure-unlock = true
 
-# EVMTimeout is the global timeout for eth_call. Default: 5s.
+# EVMTimeout is the global timeout for eth_call and eth_estimateGas. Default: 5s.
 evm-timeout = "5s"
 
 # TxFeeCap is the global tx-fee cap for send transaction. Default: 1eth.

--- a/server/config/toml.go
+++ b/server/config/toml.go
@@ -99,7 +99,7 @@ gas-cap = {{ .JSONRPC.GasCap }}
 # Allow insecure account unlocking when account-related RPCs are exposed by http
 allow-insecure-unlock = {{ .JSONRPC.AllowInsecureUnlock }}
 
-# EVMTimeout is the global timeout for eth_call. Default: 5s.
+# EVMTimeout is the global timeout for eth_call and eth_estimateGas. Default: 5s.
 evm-timeout = "{{ .JSONRPC.EVMTimeout }}"
 
 # TxFeeCap is the global tx-fee cap for send transaction. Default: 1eth.

--- a/server/start.go
+++ b/server/start.go
@@ -208,7 +208,7 @@ which accepts a path for the resulting pprof file.
 	cmd.Flags().Uint64(srvflags.JSONRPCGasCap, cosmosevmserverconfig.DefaultGasCap, "Sets a cap on gas that can be used in eth_call/estimateGas unit is aatom (0=infinite)")                         //nolint:lll
 	cmd.Flags().Bool(srvflags.JSONRPCAllowInsecureUnlock, cosmosevmserverconfig.DefaultJSONRPCAllowInsecureUnlock, "Allow insecure account unlocking when account-related RPCs are exposed by http") //nolint:lll
 	cmd.Flags().Float64(srvflags.JSONRPCTxFeeCap, cosmosevmserverconfig.DefaultTxFeeCap, "Sets a cap on transaction fee that can be sent via the RPC APIs (1 = default 1 evmos)")                    //nolint:lll
-	cmd.Flags().Duration(srvflags.JSONRPCEVMTimeout, cosmosevmserverconfig.DefaultEVMTimeout, "Sets a timeout used for eth_call (0=infinite)")
+	cmd.Flags().Duration(srvflags.JSONRPCEVMTimeout, cosmosevmserverconfig.DefaultEVMTimeout, "Sets a timeout used for eth_call and eth_estimateGas (0=infinite)")
 	cmd.Flags().Duration(srvflags.JSONRPCHTTPTimeout, cosmosevmserverconfig.DefaultHTTPTimeout, "Sets a read/write timeout for json-rpc http server (0=infinite)")
 	cmd.Flags().Duration(srvflags.JSONRPCHTTPIdleTimeout, cosmosevmserverconfig.DefaultHTTPIdleTimeout, "Sets a idle timeout for json-rpc http server (0=infinite)")
 	cmd.Flags().Int(srvflags.JSONRPCHTTPBodyLimit, cosmosevmserverconfig.DefaultHTTPBodyLimit, "Sets max request body size in bytes for json-rpc http server")


### PR DESCRIPTION
# Description

`json-rpc.evm-timeout` already cancelled `eth_call` (`DoCall`) but was not applied to `eth_estimateGas` (`EstimateGas`). Estimation is one gRPC round-trip that can binary-search for a long time, so it could outlive the timeout that already protects `eth_call`.

This PR wraps the `EstimateGas` query with `context.WithTimeout` when `RPCEVMTimeout() > 0`, matching `DoCall`. `evm-timeout = 0` still means infinite: we do not call `context.WithTimeout(ctx, 0)`, which would set an immediate deadline.

`DoCall` is simplified to the same branch (timeout only when `> 0`). The previous `WithCancel` fallback for timeout `0` is dropped; a finished unary gRPC call does not need an extra cancel.

Out of scope: `debug_trace*` (uses `TraceConfig.Timeout` / `defaultTraceTimeout`) and wrapping `eth_createAccessList` as a whole (inner `DoCall`s are already bounded per iteration).

Closes: #1264

## Review

- `rpc/backend/call_tx.go`: timeout wrap after `ContextWithHeight`, before `QueryClient.EstimateGas` / `EthCall`
- `rpc/backend/call_tx_timeout_test.go`: deadline on `EstimateGas` and `DoCall`; no deadline when timeout is `0`

```bash
go test -tags=test ./rpc/backend/ -run 'TestEstimateGasAppliesEVMTimeout|TestDoCallAppliesEVMTimeout|TestEstimateGasZeroTimeoutHasNoDeadline' -count=1
```

## Author Checklist

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.

I have...

- [x] tackled an existing issue or discussed with a team member
- [x] left instructions on how to review the changes
- [x] targeted the `main` branch