### PR TITLE
fix(vm): overflow-safe BinSearch midpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 
 ### BUG FIXES
 
+- [\#1267](https://github.com/cosmos/evm/pull/1267) Overflow-safe `BinSearch` midpoint so large gas caps cannot wrap uint64.
 - [\#1223](https://github.com/cosmos/evm/pull/1223) Reject EVM txs below the base fee at mempool insert instead of silently queuing them.
 - [\#1214](https://github.com/cosmos/evm/pull/1214) Emit the canonical CometBFT block hash in the `newHeads` subscription so it matches `eth_getBlockByNumber` (completes [\#725](https://github.com/cosmos/evm/pull/725)).
 - [\#1047](https://github.com/cosmos/evm/pull/1047) Resolve EthTxIndex -1 sentinel before uint cast in ReceiptsFromCometBlock, preventing transactionIndex overflow to MaxUint64.

--- a/x/vm/types/utils.go
+++ b/x/vm/types/utils.go
@@ -173,7 +173,7 @@ func UnpackEthMsg(msg sdk.Msg) (
 // BinSearch executes the binary search and hone in on an executable gas limit
 func BinSearch(lo, hi uint64, executable func(uint64) (bool, *MsgEthereumTxResponse, error)) (uint64, error) {
 	for lo+1 < hi {
-		mid := (hi + lo) / 2
+		mid := lo + (hi-lo)/2
 		failed, _, err := executable(mid)
 		// If the error is not nil(consensus error), it means the provided message
 		// call or transaction will never be accepted no matter how much gas it is

--- a/x/vm/types/utils_test.go
+++ b/x/vm/types/utils_test.go
@@ -2,6 +2,7 @@ package types_test
 
 import (
 	"errors"
+	"math"
 	"math/big"
 	"testing"
 
@@ -377,6 +378,51 @@ func TestBinSearch(t *testing.T) {
 	gas, err = evmtypes.BinSearch(20000, 21001, failedExecutable)
 	require.Error(t, err)
 	require.Equal(t, gas, uint64(0))
+
+	// EstimateGas starts lo at TxGas-1; a huge RPC/tx gas cap can set hi to MaxUint64.
+	// Old (hi+lo)/2 wraps on the first step and lo jumps downward.
+	t.Run("small lo and uint64 max hi does not wrap first midpoint", func(t *testing.T) {
+		const (
+			lo     = uint64(21000 - 1)
+			hi     = math.MaxUint64
+			target = uint64(21000)
+		)
+		calls := 0
+		executable := func(gas uint64) (bool, *evmtypes.MsgEthereumTxResponse, error) {
+			calls++
+			if calls > 128 {
+				return false, nil, errors.New("BinSearch did not converge")
+			}
+			require.Greater(t, gas, lo, "mid must not wrap below the original lo")
+			return gas < target, nil, nil
+		}
+
+		gas, err := evmtypes.BinSearch(lo, hi, executable)
+		require.NoError(t, err)
+		require.Equal(t, target, gas)
+		require.LessOrEqual(t, calls, 70)
+	})
+
+	t.Run("uint64 upper range converges without overflow", func(t *testing.T) {
+		const (
+			lo     = math.MaxUint64 - 100
+			hi     = math.MaxUint64
+			target = math.MaxUint64 - 10
+		)
+		calls := 0
+		executable := func(gas uint64) (bool, *evmtypes.MsgEthereumTxResponse, error) {
+			calls++
+			if calls > 128 {
+				return false, nil, errors.New("BinSearch did not converge")
+			}
+			return gas < target, nil, nil
+		}
+
+		gas, err := evmtypes.BinSearch(lo, hi, executable)
+		require.NoError(t, err)
+		require.Equal(t, uint64(target), gas)
+		require.LessOrEqual(t, calls, 64)
+	})
 }
 
 func TestTransactionLogsEncodeDecode(t *testing.T) {


### PR DESCRIPTION
# Description

`BinSearch` used `(hi + lo) / 2` to pick the next gas probe. For `uint64`, that addition wraps when `lo + hi` exceeds `2^64-1`, so `mid` can land below `lo` and the search diverges.

This is not an EVM gas-meter overflow. `EstimateGas` starts `lo` at `TxGas - 1` (20999) and sets `hi = min(tx.gas, block MaxGas, RPC gas cap, …)`. The wrap only happens once that **final `hi` is ≥ ~2⁶³** — typically a huge tx `gas` **and** a huge RPC cap (default cap is 25,000,000, so this does not fire on a normal node).

Switch the midpoint to the overflow-safe form used by go-ethereum:

```go
mid := lo + (hi-lo)/2
```

Loop structure, callback contract, and return values are unchanged.

Closes: #1266

---

## Author Checklist

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.

I have...

- [x] tackled an existing issue or discussed with a team member
- [x] left instructions on how to review the changes
- [x] targeted the `main` branch

### Review

Critical files:

- `x/vm/types/utils.go` — one-line midpoint change
- `x/vm/types/utils_test.go` — two cases that fail on `(hi+lo)/2` and pass on the new formula:
  1. `EstimateGas`-shaped bounds: `lo=20999`, `hi=MaxUint64`, expect `21000`; first `mid` must stay above `lo`
  2. Ceiling window: `[MaxUint64-100, MaxUint64]` converges to `MaxUint64-10` within 64 probes (128-call hang guard)

```bash
go test -tags=test ./x/vm/types/ -run TestBinSearch -count=1
```