### PR TITLE
fix(rpc): return null receipt for unmined txs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 
 ### BUG FIXES
 
+- [\#1271](https://github.com/cosmos/evm/pull/1271) Return `null` from `eth_getTransactionReceipt` for unmined txs instead of retrying for up to ~51s, past `json-rpc.http-timeout`.
 - [\#1265](https://github.com/cosmos/evm/pull/1265) Apply `json-rpc.evm-timeout` to `eth_estimateGas`, matching `eth_call`.
 - [\#1223](https://github.com/cosmos/evm/pull/1223) Reject EVM txs below the base fee at mempool insert instead of silently queuing them.
 - [\#1214](https://github.com/cosmos/evm/pull/1214) Emit the canonical CometBFT block hash in the `newHeads` subscription so it matches `eth_getBlockByNumber` (completes [\#725](https://github.com/cosmos/evm/pull/725)).

--- a/rpc/backend/tx_info.go
+++ b/rpc/backend/tx_info.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/big"
-	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -20,7 +19,6 @@ import (
 	cmtrpcclient "github.com/cometbft/cometbft/rpc/client"
 	cmtrpctypes "github.com/cometbft/cometbft/rpc/core/types"
 
-	"github.com/cosmos/evm/mempool/txpool"
 	rpctypes "github.com/cosmos/evm/rpc/types"
 	servertypes "github.com/cosmos/evm/server/types"
 	evmtrace "github.com/cosmos/evm/trace"
@@ -144,35 +142,10 @@ func (b *Backend) GetTransactionReceipt(ctx context.Context, hash common.Hash) (
 	hexTx := hash.Hex()
 	b.Logger.Debug("eth_getTransactionReceipt", "hash", hexTx)
 
-	// Retry logic for transaction lookup with exponential backoff
-	maxRetries := 10
-	baseDelay := 50 * time.Millisecond
-
-	var res *servertypes.TxResult
-
-	for attempt := 0; attempt <= maxRetries; attempt++ {
-		res, err = b.GetTxByEthHash(ctx, hash)
-		if err == nil {
-			break // Found the transaction
-		}
-
-		if attempt == maxRetries/2 && b.Mempool != nil {
-			status := b.Mempool.GetTxPool().Status(hash)
-			if status == txpool.TxStatusUnknown {
-				break
-			}
-		}
-
-		if attempt < maxRetries {
-			// Exponential backoff: 50ms, 100ms, 200ms
-			delay := time.Duration(1<<attempt) * baseDelay
-			b.Logger.Debug("tx not found, retrying", "hash", hexTx, "attempt", attempt+1, "delay", delay)
-			time.Sleep(delay)
-		}
-	}
-
+	// an unmined tx has no receipt: answer null like geth and let the client poll
+	res, err := b.GetTxByEthHash(ctx, hash)
 	if err != nil {
-		b.Logger.Debug("tx not found after retries", "hash", hexTx, "error", err.Error())
+		b.Logger.Debug("tx not found", "hash", hexTx, "error", err.Error())
 		return nil, nil
 	}
 

--- a/rpc/backend/tx_info_test.go
+++ b/rpc/backend/tx_info_test.go
@@ -640,3 +640,15 @@ func TestEthMsgsFromCometBlockSkipStateDBCommitFailure(t *testing.T) {
 	require.Len(t, msgs, 1)
 	require.Same(t, successMsg, msgs[0])
 }
+
+// an unmined tx has no receipt: null right away, with or without an EVM mempool
+func TestGetTransactionReceiptUnknownTx(t *testing.T) {
+	backend := setupMockBackend(t)
+	require.Nil(t, backend.Mempool)
+
+	start := time.Now()
+	receipt, err := backend.GetTransactionReceipt(context.Background(), common.HexToHash("0xdeadbeef"))
+	require.NoError(t, err)
+	require.Nil(t, receipt)
+	require.Less(t, time.Since(start), time.Second)
+}


### PR DESCRIPTION
# Description

eth_getTransactionReceipt retried for ~51s before answering null, past json-rpc.http-timeout, so a pending or queued tx surfaced as -32002 request timed out. Answer null right away, like geth.

<!-- Please keep your PR as draft until it's ready for review -->

<!-- Pull requests that sit inactive for longer than 30 days will be closed.  -->

Closes: #1271

---

## Author Checklist

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.

I have...

- [ ] tackled an existing issue or discussed with a team member
- [ ] left instructions on how to review the changes
- [ ] targeted the `main` branch
