### PR TITLE
fix: tx evm send should never silently fall back to zeroized to-addr

### DIFF
--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -312,6 +312,70 @@ func TestAddressConversion(t *testing.T) {
 	require.Equal(t, hex, gotAddr.Hex())
 }
 
+// TestBech32StringFromHexAddressManglesNonHexInput pins the behavior
+// that non-hex addresses are parsed into garbage addresses
+func TestBech32StringFromHexAddressManglesNonHexInput(t *testing.T) {
+	config := sdk.GetConfig()
+	config.SetBech32PrefixForAccount("cosmos", "cosmospub")
+
+	const (
+		zeroAddr       = "cosmos1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqnrql8a"
+		zeroAddrPlus0C = "cosmos1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqvzax4k6"
+	)
+
+	testCases := []struct {
+		name      string
+		hexAddr   string
+		expBech32 string
+		expHex    string
+	}{
+		{
+			name:      "valid hex address is converted faithfully",
+			hexAddr:   hex,
+			expBech32: bech32,
+			expHex:    hex,
+		},
+		{
+			name:      "garbage is silently zeroed",
+			hexAddr:   "blabla",
+			expBech32: zeroAddr,
+			expHex:    "0x0000000000000000000000000000000000000000",
+		},
+		{
+			name:      "empty string is silently zeroed",
+			hexAddr:   "",
+			expBech32: zeroAddr,
+			expHex:    "0x0000000000000000000000000000000000000000",
+		},
+		{
+			// The fund-loss case: the zero address is not on the bank blocked
+			// list, so a transfer to it succeeds and the coins are gone.
+			name:      "bech32 address is silently zeroed",
+			hexAddr:   "evmos1ltzy54ms24v590zz37r2q9hrrdcc8eslndsqwv",
+			expBech32: zeroAddr,
+			expHex:    "0x0000000000000000000000000000000000000000",
+		},
+		{
+			name:      "cosmos1 bech32 address decodes to 0x..0C, not to zero",
+			hexAddr:   "cosmos18wvvwfmq77a6d8tza4h5sfuy2yj3jj88yqg82a",
+			expBech32: zeroAddrPlus0C,
+			expHex:    "0x000000000000000000000000000000000000000C",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := utils.Bech32StringFromHexAddress(tc.hexAddr)
+			require.Equal(t, tc.expBech32, got)
+
+			// No error is ever reported, which is what makes this dangerous.
+			gotAddr, err := utils.HexAddressFromBech32String(got)
+			require.NoError(t, err)
+			require.Equal(t, tc.expHex, gotAddr.Hex())
+		})
+	}
+}
+
 func TestGetIBCDenomAddress(t *testing.T) {
 	testCases := []struct {
 		name        string

--- a/x/vm/client/cli/tx.go
+++ b/x/vm/client/cli/tx.go
@@ -7,12 +7,12 @@ import (
 	"os"
 	"strings"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
-	"github.com/cosmos/evm/utils"
 	"github.com/cosmos/evm/x/vm/types"
 
 	"cosmossdk.io/core/address"
@@ -142,9 +142,18 @@ When using '--dry-run' a key name cannot be used, only an 0x or bech32 address.
 		Example: "evmd tx evm send 0x7cB61D4117AE31a12E393a1Cfa3BaC666481D02E 0xA2A8B87390F8F2D188242656BFb6852914073D06 10utoken",
 		Args:    cobra.ExactArgs(3),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			// args[0] may also be a key name, so it is only converted when it is
+			// explicitly a 0x address; anything else is passed through untouched.
 			fromAddr := args[0]
 			if strings.HasPrefix(args[0], "0x") {
-				fromAddr = utils.Bech32StringFromHexAddress(args[0])
+				fromHex, err := accountToHex(args[0])
+				if err != nil {
+					return errors.Wrap(err, "invalid from-address")
+				}
+				fromAddr, err = ac.BytesToString(common.HexToAddress(fromHex).Bytes())
+				if err != nil {
+					return err
+				}
 			}
 
 			err := cmd.Flags().Set(flags.FlagFrom, fromAddr)
@@ -156,10 +165,12 @@ When using '--dry-run' a key name cannot be used, only an 0x or bech32 address.
 				return err
 			}
 
-			toAddr, err := ac.StringToBytes(utils.Bech32StringFromHexAddress(args[1]))
+			// accountToHex accepts only 0x and bech32.
+			toHex, err := accountToHex(args[1])
 			if err != nil {
-				return err
+				return errors.Wrap(err, "invalid to-address")
 			}
+			toAddr := common.HexToAddress(toHex).Bytes()
 
 			coins, err := sdk.ParseCoinsNormalized(args[2])
 			if err != nil {

--- a/x/vm/client/cli/utils_test.go
+++ b/x/vm/client/cli/utils_test.go
@@ -41,6 +41,9 @@ func TestAddressFormats(t *testing.T) {
 		{"invalid hex ethereum address", "0x3B98C72760F7BBA69D62ED6F48278451251948E", "", true},
 		{"invalid Cosmos address", "cosmos18wvvwfmq77a6d8tza4h5sfuy2yj3jj88", "", true},
 		{"empty string", "", "", true},
+		{"Cosmos address with bad checksum", "cosmos18wvvwfmq77a6d8tza4h5sfuy2yj3jj88yqg82b", "", true},
+		{"unknown bech32 prefix", "notaprefix18wvvwfmq77a6d8tza4h5sfuy2yj3jj88wpxu9y", "", true},
+		{"hex with non-hex digits", "0xZZ98c72760f7BBa69D62ED6f48278451251948e7", "", true},
 	}
 
 	for _, tc := range testCases {
@@ -97,4 +100,54 @@ func TestAddressToCosmosAddress(t *testing.T) {
 	ethFormatted, err = cosmosAddressFromArg(ethAddr.Hex()[2:])
 	require.NoError(t, err)
 	require.Equal(t, baseAddr, ethFormatted)
+}
+
+// TestAccountToHexNeverReturnsZeroAddress pins that accountToHex does
+// never fall back to the zero address.
+func TestAccountToHexNeverReturnsZeroAddress(t *testing.T) {
+	for _, tc := range []struct {
+		inputValue  string
+		errValue    error
+		outputValue string
+	}{
+		{
+			inputValue:  "cosmos18wvvwfmq77a6d8tza4h5sfuy2yj3jj88yqg82a",
+			errValue:    nil,
+			outputValue: "0x3B98c72760f7BBa69D62ED6f48278451251948e7",
+		},
+		{
+			inputValue:  "cosmos18wvvwfmq77a6d8tza4h5sfuy2yj3jj88yqg82c",
+			errValue:    errors.New("must provide a valid Bech32 address: decoding bech32 failed: invalid checksum (expected yqg82a got yqg82c)"),
+			outputValue: "",
+		},
+		{
+			inputValue:  "notaprefix18wvvwfmq77a6d8tza4h5sfuy2yj3jj88wpxu9y",
+			errValue:    errors.New("0xnotaprefix18wvvwfmq77a6d8tza4h5sfuy2yj3jj88wpxu9y is not a valid Ethereum or Cosmos address"),
+			outputValue: "",
+		},
+		{
+			inputValue:  "not-an-address",
+			errValue:    errors.New("0xnot-an-address is not a valid Ethereum or Cosmos address"),
+			outputValue: "",
+		},
+		{
+			inputValue:  "",
+			errValue:    errors.New("0x is not a valid Ethereum or Cosmos address"),
+			outputValue: "",
+		},
+	} {
+		t.Run(tc.inputValue, func(t *testing.T) {
+			hex, err := accountToHex(tc.inputValue)
+
+			if tc.errValue != nil {
+				require.EqualError(t, err, tc.errValue.Error())
+			} else {
+				require.NoError(t, err)
+				require.NotEqual(t, common.Address{}.Hex(), hex,
+					"accountToHex(%q) resolved to the zero address", tc.inputValue)
+			}
+
+			require.Equal(t, tc.outputValue, hex)
+		})
+	}
 }


### PR DESCRIPTION
# Description

The command `tx evm send` uses `arg[0]` as from-address and `arg[1]` as to-address. The command description says: "Both 0x or bech32". However, the to-address is parsed using unguarded  `utils.Bech32StringFromHexAddress(args[1])` - which has no error return value and silently asks the to-address to be an 0x address.

And if it is not, then `Bech32StringFromHexAddress()` will create near-zero or zero garbage-addresses. That can inflict a severe fund loss case for CLI users sending their funds accidentally to those garbage addresses while inputting genuine bech32 encoded addresses -- which the CLI help text said it would be safe.

# What is the Fix:

The fix is to basically use `accountToHex()` from the cli package - which only ever accepts 0x or bech32 formatted addresses in the first place and gives `error` in any other case. Then pull it's output through HexToAddress from go-ethereum (or gracefully propagate errors).

I also added tests to pin the behavior of `Bech32StringFromHexAddress()` and `accountToHex()` - for demonstration purposes only, happy to remove them if so requested as a matter of hygiene.

# How To Review

On main, note how the provision of a completely valid bech32 address accidentially creates a _valid_ transaction sending to the garbage address:

```
$ build/evmd tx evm send 0xD74A2f4Ef6f7F2D00EBE039F68829458C91871b6 cosmos1wv4xjvjvm8tz7pd8dy8n9khlprahan7sgft3p2 1stake --generate-only --chain-id blachain-1 | jq -r
{
  "body": {
    "messages": [
      {
        "@type": "/cosmos.bank.v1beta1.MsgSend",
        "from_address": "cosmos16a9z7nhk7ledqr47qw0k3q55try3sudke7x3pk",
        "to_address": "cosmos1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqvzax4k6",
        "amount": [
          {
            "denom": "stake",
            "amount": "1"
          }
        ]
      }
    ],
    "memo": "",
    "timeout_height": "0",
    "unordered": false,
    "timeout_timestamp": null,
    "extension_options": [],
    "non_critical_extension_options": []
  },
  "auth_info": {
    "signer_infos": [],
    "fee": {
      "amount": [],
      "gas_limit": "200000",
      "payer": "",
      "granter": ""
    },
    "tip": null
  },
  "signatures": []
}
```

On my fix branch that bech32 to-address is not garbaged but taken verbatim:

```
$ build/evmd tx evm send 0xD74A2f4Ef6f7F2D00EBE039F68829458C91871b6 cosmos1wv4xjvjvm8tz7pd8dy8n9khlprahan7sgft3p2 1stake --generate-only --chain-id blachain-1 | jq -r
{
  "body": {
    "messages": [
      {
        "@type": "/cosmos.bank.v1beta1.MsgSend",
        "from_address": "cosmos16a9z7nhk7ledqr47qw0k3q55try3sudke7x3pk",
        "to_address": "cosmos1wv4xjvjvm8tz7pd8dy8n9khlprahan7sgft3p2",
        "amount": [
          {
            "denom": "stake",
            "amount": "1"
          }
        ]
      }
    ],
    "memo": "",
    "timeout_height": "0",
    "unordered": false,
    "timeout_timestamp": null,
    "extension_options": [],
    "non_critical_extension_options": []
  },
  "auth_info": {
    "signer_infos": [],
    "fee": {
      "amount": [],
      "gas_limit": "200000",
      "payer": "",
      "granter": ""
    },
    "tip": null
  },
  "signatures": []
}
```
---

## Author Checklist

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.

I have...

- [x] tackled an existing issue or discussed with a team member 
- [x] left instructions on how to review the changes -
- [x] targeted the `main` branch
